### PR TITLE
create_packet methods now des-escapes the byte array passed to it

### DIFF
--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -529,7 +529,7 @@ class GenericXBeePacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=GenericXBeePacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -529,7 +529,7 @@ class GenericXBeePacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeeAPIPacket.unescape_data(raw)
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=GenericXBeePacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -528,6 +528,9 @@ class GenericXBeePacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeeAPIPacket.unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=GenericXBeePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.GENERIC.code:
@@ -612,6 +615,9 @@ class UnknownXBeePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeeAPIPacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=UnknownXBeePacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -90,6 +90,9 @@ class ATCommPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommPacket.__MIN_PACKET_LENGTH)
 
@@ -247,6 +250,9 @@ class ATCommQueuePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommQueuePacket.__MIN_PACKET_LENGTH)
 
@@ -408,6 +414,9 @@ class ATCommResponsePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommResponsePacket.__MIN_PACKET_LENGTH)
 
@@ -594,6 +603,9 @@ class ReceivePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ReceivePacket.__MIN_PACKET_LENGTH)
 
@@ -829,6 +841,9 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandPacket.__MIN_PACKET_LENGTH)
 
@@ -1086,6 +1101,9 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH)
 
@@ -1358,6 +1376,9 @@ class TransmitPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitPacket.__MIN_PACKET_LENGTH)
 
@@ -1608,6 +1629,9 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitStatusPacket.__MIN_PACKET_LENGTH)
 
@@ -1806,6 +1830,9 @@ class ModemStatusPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ModemStatusPacket.__MIN_PACKET_LENGTH)
 
@@ -1940,6 +1967,9 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorPacket.__MIN_PACKET_LENGTH)
 
@@ -2289,6 +2319,9 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitAddressingPacket.__MIN_PACKET_LENGTH)
 
@@ -2649,6 +2682,9 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitRXIndicatorPacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -92,7 +92,7 @@ class ATCommPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommPacket.__MIN_PACKET_LENGTH)
 
@@ -252,7 +252,7 @@ class ATCommQueuePacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommQueuePacket.__MIN_PACKET_LENGTH)
 
@@ -416,7 +416,7 @@ class ATCommResponsePacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommResponsePacket.__MIN_PACKET_LENGTH)
 
@@ -605,7 +605,7 @@ class ReceivePacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ReceivePacket.__MIN_PACKET_LENGTH)
 
@@ -843,7 +843,7 @@ class RemoteATCommandPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandPacket.__MIN_PACKET_LENGTH)
 
@@ -1103,7 +1103,7 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH)
 
@@ -1378,7 +1378,7 @@ class TransmitPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitPacket.__MIN_PACKET_LENGTH)
 
@@ -1631,7 +1631,7 @@ class TransmitStatusPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitStatusPacket.__MIN_PACKET_LENGTH)
 
@@ -1832,7 +1832,7 @@ class ModemStatusPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ModemStatusPacket.__MIN_PACKET_LENGTH)
 
@@ -1969,7 +1969,7 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorPacket.__MIN_PACKET_LENGTH)
 
@@ -2321,7 +2321,7 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitAddressingPacket.__MIN_PACKET_LENGTH)
 
@@ -2684,7 +2684,7 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitRXIndicatorPacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -16,7 +16,7 @@ from digi.xbee.models.mode import OperatingMode
 from digi.xbee.models.address import XBee16BitAddress, XBee64BitAddress
 from digi.xbee.models.status import ATCommandStatus, DiscoveryStatus, TransmitStatus, ModemStatus
 from digi.xbee.packets.aft import ApiFrameType
-from digi.xbee.packets.base import XBeeAPIPacket, DictKeys
+from digi.xbee.packets.base import XBeeAPIPacket, XBeePacket, DictKeys
 from digi.xbee.util import utils
 from digi.xbee.exception import InvalidOperatingModeException, InvalidPacketException
 from digi.xbee.io import IOSample, IOLine

--- a/digi/xbee/packets/devicecloud.py
+++ b/digi/xbee/packets/devicecloud.py
@@ -90,6 +90,9 @@ class DeviceRequestPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceRequestPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_REQUEST.code:
@@ -311,6 +314,9 @@ class DeviceResponsePacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_RESPONSE.code:
@@ -467,6 +473,9 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponseStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_RESPONSE_STATUS.code:
@@ -581,6 +590,9 @@ class FrameErrorPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=FrameErrorPacket.__MIN_PACKET_LENGTH)
 
@@ -714,6 +726,9 @@ class SendDataRequestPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataRequestPacket.__MIN_PACKET_LENGTH)
 
@@ -933,6 +948,9 @@ class SendDataResponsePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataResponsePacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/devicecloud.py
+++ b/digi/xbee/packets/devicecloud.py
@@ -12,7 +12,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from digi.xbee.packets.base import XBeeAPIPacket, DictKeys
+from digi.xbee.packets.base import XBeeAPIPacket, XBeePacket, DictKeys
 from digi.xbee.util import utils
 from digi.xbee.exception import InvalidOperatingModeException, InvalidPacketException
 from digi.xbee.packets.aft import ApiFrameType

--- a/digi/xbee/packets/devicecloud.py
+++ b/digi/xbee/packets/devicecloud.py
@@ -91,7 +91,7 @@ class DeviceRequestPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceRequestPacket.__MIN_PACKET_LENGTH)
 
@@ -315,7 +315,7 @@ class DeviceResponsePacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponsePacket.__MIN_PACKET_LENGTH)
 
@@ -474,7 +474,7 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponseStatusPacket.__MIN_PACKET_LENGTH)
 
@@ -592,7 +592,7 @@ class FrameErrorPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=FrameErrorPacket.__MIN_PACKET_LENGTH)
 
@@ -728,7 +728,7 @@ class SendDataRequestPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataRequestPacket.__MIN_PACKET_LENGTH)
 
@@ -950,7 +950,7 @@ class SendDataResponsePacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataResponsePacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/network.py
+++ b/digi/xbee/packets/network.py
@@ -90,7 +90,7 @@ class RXIPv4Packet(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RXIPv4Packet.__MIN_PACKET_LENGTH)
 
@@ -344,7 +344,7 @@ class TXIPv4Packet(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TXIPv4Packet.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/network.py
+++ b/digi/xbee/packets/network.py
@@ -89,6 +89,9 @@ class RXIPv4Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=RXIPv4Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RX_IPV4.code:
@@ -339,6 +342,9 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TXIPv4Packet.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/network.py
+++ b/digi/xbee/packets/network.py
@@ -16,7 +16,7 @@ from ipaddress import IPv4Address
 from digi.xbee.models.mode import OperatingMode
 from digi.xbee.models.protocol import IPProtocol
 from digi.xbee.packets.aft import ApiFrameType
-from digi.xbee.packets.base import XBeeAPIPacket, DictKeys
+from digi.xbee.packets.base import XBeeAPIPacket, XBeePacket, DictKeys
 from digi.xbee.util import utils
 from digi.xbee.exception import InvalidOperatingModeException, InvalidPacketException
 

--- a/digi/xbee/packets/raw.py
+++ b/digi/xbee/packets/raw.py
@@ -12,7 +12,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from digi.xbee.packets.base import XBeeAPIPacket, DictKeys
+from digi.xbee.packets.base import XBeeAPIPacket, XBeePacket, DictKeys
 from digi.xbee.models.address import XBee64BitAddress, XBee16BitAddress
 from digi.xbee.models.status import TransmitStatus
 from digi.xbee.exception import InvalidOperatingModeException, InvalidPacketException

--- a/digi/xbee/packets/raw.py
+++ b/digi/xbee/packets/raw.py
@@ -89,7 +89,7 @@ class TX64Packet(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TX64Packet.__MIN_PACKET_LENGTH)
 
@@ -279,7 +279,7 @@ class TX16Packet(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TX16Packet.__MIN_PACKET_LENGTH)
 
@@ -467,7 +467,7 @@ class TXStatusPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TXStatusPacket.__MIN_PACKET_LENGTH)
 
@@ -598,7 +598,7 @@ class RX64Packet(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64Packet.__MIN_PACKET_LENGTH)
 
@@ -811,7 +811,7 @@ class RX16Packet(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16Packet.__MIN_PACKET_LENGTH)
 
@@ -1019,7 +1019,7 @@ class RX64IOPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64IOPacket.__MIN_PACKET_LENGTH)
 
@@ -1285,7 +1285,7 @@ class RX16IOPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16IOPacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/raw.py
+++ b/digi/xbee/packets/raw.py
@@ -88,6 +88,9 @@ class TX64Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=TX64Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TX_64.code:
@@ -275,6 +278,9 @@ class TX16Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=TX16Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TX_16.code:
@@ -460,6 +466,9 @@ class TXStatusPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=TXStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TX_STATUS.code:
@@ -587,6 +596,9 @@ class RX64Packet(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64Packet.__MIN_PACKET_LENGTH)
 
@@ -798,6 +810,9 @@ class RX16Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RX_16.code:
@@ -1002,6 +1017,9 @@ class RX64IOPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64IOPacket.__MIN_PACKET_LENGTH)
 
@@ -1265,6 +1283,9 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16IOPacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/wifi.py
+++ b/digi/xbee/packets/wifi.py
@@ -93,6 +93,9 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR_WIFI.code:
@@ -376,6 +379,9 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
+
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_REQUEST_WIFI.code:
@@ -602,6 +608,9 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+
+        if operating_mode == OperatingMode.ESCAPED_API_MODE:
+            raw = XBeePacket._unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponseWifiPacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/wifi.py
+++ b/digi/xbee/packets/wifi.py
@@ -94,7 +94,7 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorWifiPacket.__MIN_PACKET_LENGTH)
 
@@ -380,7 +380,7 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandWifiPacket.__MIN_PACKET_LENGTH)
 
@@ -610,7 +610,7 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
         if operating_mode == OperatingMode.ESCAPED_API_MODE:
-            raw = XBeePacket._unescape_data(raw)
+            raw = XBeePacket.unescape_data(raw)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponseWifiPacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/wifi.py
+++ b/digi/xbee/packets/wifi.py
@@ -12,7 +12,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from digi.xbee.packets.base import XBeeAPIPacket, DictKeys
+from digi.xbee.packets.base import XBeeAPIPacket, XBeePacket, DictKeys
 from digi.xbee.util import utils
 from digi.xbee.exception import InvalidOperatingModeException, InvalidPacketException
 from digi.xbee.packets.aft import ApiFrameType


### PR DESCRIPTION
This resolves issue #15 , which was closed with a workaround, rather than a fix.