### PR TITLE
Tleon/fixes

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -3032,24 +3032,33 @@ class Raw802Device(XBeeDevice):
     This class represents a local 802.15.4 XBee device.
     """
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`Raw802Device` with the provided parameters.
+        Class constructor. Instantiates a new :class:`.Raw802Device` with the provided parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
             All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
-        
+
         .. seealso::
            | :class:`.XBeeDevice`
            | :meth:`.XBeeDevice.__init__`
         """
-        super().__init__(port, baud_rate)
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
 
     def open(self):
         """
@@ -3137,15 +3146,23 @@ class DigiMeshDevice(XBeeDevice):
     This class represents a local DigiMesh XBee device.
     """
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`DigiMeshDevice` with the provided parameters.
+        Class constructor. Instantiates a new :class:`.DigiMeshDevice` with the provided parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
             All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
@@ -3154,7 +3171,8 @@ class DigiMeshDevice(XBeeDevice):
            | :class:`.XBeeDevice`
            | :meth:`.XBeeDevice.__init__`
         """
-        super().__init__(port, baud_rate)
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
 
     def open(self):
         """
@@ -3266,24 +3284,34 @@ class DigiPointDevice(XBeeDevice):
     This class represents a local DigiPoint XBee device.
     """
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`DigiPointDevice` with the provided parameters.
+        Class constructor. Instantiates a new :class:`.DigiPointDevice` with the provided
+        parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
-            All exceptions raised by :meth:`XBeeDevice.__init__` constructor.
+            All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
 
         .. seealso::
            | :class:`.XBeeDevice`
            | :meth:`.XBeeDevice.__init__`
         """
-        super().__init__(port, baud_rate)
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
 
     def open(self):
         """
@@ -3395,24 +3423,33 @@ class ZigBeeDevice(XBeeDevice):
     This class represents a local ZigBee XBee device.
     """
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`ZigBeeDevice` with the provided parameters.
+        Class constructor. Instantiates a new :class:`.ZigBeeDevice` with the provided parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
-            All exceptions raised by :func:`.XBeeDevice.__init__` constructor.
+            All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
 
         .. seealso::
            | :class:`.XBeeDevice`
-           | :meth:`XBeeDevice.__init__`
+           | :meth:`.XBeeDevice.__init__`
         """
-        super().__init__(port, baud_rate)
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
 
     def open(self):
         """
@@ -3757,26 +3794,33 @@ class IPDevice(XBeeDevice):
 
     __OPERATION_EXCEPTION = "Operation not supported in this module."
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`.IPDevice` with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.IPDevice` with the provided parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
-            All exceptions raised by :func:`.XBeeDevice.__init__` constructor.
+            All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
 
         .. seealso::
            | :class:`.XBeeDevice`
-           | :meth:`XBeeDevice.__init__`
+           | :meth:`.XBeeDevice.__init__`
         """
-        super().__init__(port, baud_rate)
-
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
         self._ip_addr = None
         self._source_port = self.__DEFAULT_SOURCE_PORT
 
@@ -4283,26 +4327,33 @@ class CellularDevice(IPDevice):
     This class represents a local Cellular device.
     """
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`.CellularDevice` with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.CellularDevice` with the provided parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
-            All exceptions raised by :func:`.XBeeDevice.__init__` constructor.
+            All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
 
         .. seealso::
            | :class:`.XBeeDevice`
-           | :meth:`XBeeDevice.__init__`
+           | :meth:`.XBeeDevice.__init__`
         """
-        super().__init__(port, baud_rate)
-
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
         self._imei_addr = None
 
     def open(self):
@@ -4570,25 +4621,33 @@ class LPWANDevice(CellularDevice):
     devices.
     """
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`.LPWANDevice` with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.LPWANDevice` with the provided parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
-            All exceptions raised by :func:`.XBeeDevice.__init__` constructor.
+            All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
 
         .. seealso::
-           | :class:`.XBeeDevice`
-           | :meth:`XBeeDevice.__init__`
+           | :class:`.CellularDevice`
+           | :meth:`.CellularDevice.__init__`
         """
-        super().__init__(port, baud_rate)
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
 
     def send_ip_data(self, ip_addr, dest_port, protocol, data, close_socket=False):
         """
@@ -4678,26 +4737,33 @@ class NBIoTDevice(LPWANDevice):
     This class represents a local NB-IoT device.
     """
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`.CellularDevice` with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.NBIoTDevice` with the provided parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
-            All exceptions raised by :func:`.XBeeDevice.__init__` constructor.
+            All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
 
         .. seealso::
-           | :class:`.XBeeDevice`
-           | :meth:`XBeeDevice.__init__`
+           | :class:`.LPWANDevice`
+           | :meth:`.LPWANDevice.__init__`
         """
-        super().__init__(port, baud_rate)
-
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
         self._imei_addr = None
 
     def open(self):
@@ -4733,24 +4799,33 @@ class WiFiDevice(IPDevice):
     __DEFAULT_ACCESS_POINT_TIMEOUT = 15  # 15 seconds of timeout to connect, disconnect and scan access points.
     __DISCOVER_TIMEOUT = 30  # 30 seconds of access points discovery timeout.
 
-    def __init__(self, port, baud_rate):
+    def __init__(self, port, baud_rate, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
+                 parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS):
         """
-        Class constructor. Instantiates a new :class:`WiFiDevice` with the provided parameters.
+        Class constructor. Instantiates a new :class:`.WiFiDevice` with the provided parameters.
 
         Args:
             port (Integer or String): serial port identifier.
                 Integer: number of XBee device, numbering starts at zero.
-                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on GNU/Linux or 'COM3' on Windows.
+                Device name: depending on operating system. e.g. '/dev/ttyUSB0' on 'GNU/Linux' or
+                'COM3' on Windows.
             baud_rate (Integer): the serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): comm port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): comm port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): comm port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): comm port flow control.
+            _sync_ops_timeout (Integer, default: 3): comm port read timeout.
 
         Raises:
-            All exceptions raised by :func:`.XBeeDevice.__init__` constructor.
+            All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
 
         .. seealso::
-           | :class:`.XBeeDevice`
-           | :meth:`XBeeDevice.__init__`
+           | :class:`.IPDevice`
+           | :meth:`.v.__init__`
         """
-        super().__init__(port, baud_rate)
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits, parity=parity,
+                         flow_control=flow_control, _sync_ops_timeout=_sync_ops_timeout)
         self.__ap_timeout = self.__DEFAULT_ACCESS_POINT_TIMEOUT
         self.__scanning_aps = False
         self.__scanning_aps_error = False

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -769,8 +769,9 @@ class AbstractXBeeDevice(object):
             ATCommandException: if the response is not as expected.
             OperationNotSupportedException: if the received data is not an IO mode.
         """
+        value = self.get_parameter(io_line.at_command)
         try:
-            mode = IOMode.get(self.get_parameter(io_line.at_command)[0])
+            mode = IOMode(value[0])
         except ValueError:
             raise OperationNotSupportedException("The received value is not an IO mode.")
         return mode

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -1343,190 +1343,28 @@ class AbstractXBeeDevice(object):
 
     def _add_packet_received_callback(self, callback):
         """
-        Adds a callback for the event :class:`.PacketReceived`.
+        Adds a callback for the event :class:`digi.xbee.reader.PacketReceived`.
 
         Args:
             callback (Function): the callback. Receives two arguments.
 
-                * The received packet as a :class:`.XBeeAPIPacket`
+                * The received packet as a :class:`digi.xbee.packets.base.XBeeAPIPacket`
                 * The sender as a :class:`.RemoteXBeeDevice`
         """
         self._packet_listener.add_packet_received_callback(callback)
 
-    def _add_data_received_callback(self, callback):
-        """
-        Adds a callback for the event :class:`.DataReceived`.
-
-        Args:
-            callback (Function): the callback. Receives one argument.
-
-                * The data received as an :class:`.XBeeMessage`
-        """
-        self._packet_listener.add_data_received_callback(callback)
-
-    def _add_modem_status_received_callback(self, callback):
-        """
-        Adds a callback for the event :class:`.ModemStatusReceived`.
-
-        Args:
-            callback (Function): the callback. Receives one argument.
-
-                * The modem status as a :class:`.ModemStatus`
-        """
-        self._packet_listener.add_modem_status_received_callback(callback)
-
-    def _add_io_sample_received_callback(self, callback):
-        """
-        Adds a callback for the event :class:`.IOSampleReceived`.
-
-        Args:
-            callback (Function): the callback. Receives three arguments.
-
-                * The received IO sample as an :class:`.IOSample`
-                * The remote XBee device who has sent the packet as a :class:`.RemoteXBeeDevice`
-                * The time in which the packet was received as an Integer
-        """
-        self._packet_listener.add_io_sample_received_callback(callback)
-
-    def _add_expl_data_received_callback(self, callback):
-        """
-        Adds a callback for the event :class:`.ExplicitDataReceived`.
-
-        Args:
-            callback (Function): the callback. Receives one argument.
-
-                * The explicit data received as an :class:`.ExplicitXBeeMessage`
-        """
-        self._packet_listener.add_explicit_data_received_callback(callback)
-
-    def _add_user_data_relay_received_callback(self, callback):
-        """
-        Adds a callback for the event :class:`.RelayDataReceived`.
-
-        Args:
-            callback (Function): the callback. Receives one argument.
-
-                * The relay data as a :class:`.UserDataRelayMessage`
-        """
-        self._packet_listener.add_user_data_relay_received_callback(callback)
-
-    def _add_bluetooth_data_received_callback(self, callback):
-        """
-        Adds a callback for the event :class:`.BluetoothDataReceived`.
-
-        Args:
-            callback (Function): the callback. Receives one argument.
-
-                * The Bluetooth data as a Bytearray
-        """
-        self._packet_listener.add_bluetooth_data_received_callback(callback)
-
-    def _add_micropython_data_received_callback(self, callback):
-        """
-        Adds a callback for the event :class:`.MicroPythonDataReceived`.
-
-        Args:
-            callback (Function): the callback. Receives one argument.
-
-                * The MicroPython data as a Bytearray
-        """
-        self._packet_listener.add_micropython_data_received_callback(callback)
-
     def _del_packet_received_callback(self, callback):
         """
-        Deletes a callback for the callback list of :class:`.PacketReceived` event.
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.PacketReceived` event.
 
         Args:
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.PacketReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.PacketReceived` event.
         """
         self._packet_listener.del_packet_received_callback(callback)
-
-    def _del_data_received_callback(self, callback):
-        """
-        Deletes a callback for the callback list of :class:`.DataReceived` event.
-
-        Args:
-            callback (Function): the callback to delete.
-
-        Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.DataReceived` event.
-        """
-        self._packet_listener.del_data_received_callback(callback)
-
-    def _del_modem_status_received_callback(self, callback):
-        """
-        Deletes a callback for the callback list of :class:`.ModemStatusReceived` event.
-
-        Args:
-            callback (Function): the callback to delete.
-
-        Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.ModemStatusReceived` event.
-        """
-        self._packet_listener.del_modem_status_received_callback(callback)
-
-    def _del_io_sample_received_callback(self, callback):
-        """
-        Deletes a callback for the callback list of :class:`.IOSampleReceived` event.
-
-        Args:
-            callback (Function): the callback to delete.
-
-        Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.IOSampleReceived` event.
-        """
-        self._packet_listener.del_io_sample_received_callback(callback)
-
-    def _del_expl_data_received_callback(self, callback):
-        """
-        Deletes a callback for the callback list of :class:`.ExplicitDataReceived` event.
-
-        Args:
-            callback (Function): the callback to delete.
-
-        Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.ExplicitDataReceived` event.
-        """
-        self._packet_listener.del_explicit_data_received_callback(callback)
-
-    def _del_user_data_relay_received_callback(self, callback):
-        """
-        Deletes a callback for the callback list of :class:`.RelayDataReceived` event.
-
-        Args:
-            callback (Function): the callback to delete.
-
-        Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.RelayDataReceived` event.
-        """
-        self._packet_listener.del_user_data_relay_received_callback(callback)
-
-    def _del_bluetooth_data_received_callback(self, callback):
-        """
-        Deletes a callback for the callback list of :class:`.BluetoothDataReceived` event.
-
-        Args:
-            callback (Function): the callback to delete.
-
-        Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.BluetoothDataReceived` event.
-        """
-        self._packet_listener.del_bluetooth_data_received_callback(callback)
-
-    def _del_micropython_data_received_callback(self, callback):
-        """
-        Deletes a callback for the callback list of :class:`.MicroPythonDataReceived` event.
-
-        Args:
-            callback (Function): the callback to delete.
-
-        Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.MicroPythonDataReceived` event.
-        """
-        self._packet_listener.del_micropython_data_received_callback(callback)
 
     def _send_packet_sync_and_get_response(self, packet_to_send):
         """
@@ -1809,15 +1647,51 @@ class XBeeDevice(AbstractXBeeDevice):
         if self._is_open:
             raise XBeeException("XBee device already open.")
 
+        # Store already registered callbacks
+        packet_cbs = self._packet_listener.get_packet_received_callbacks() \
+            if self._packet_listener else None
+        data_cbs = self._packet_listener.get_data_received_callbacks() \
+            if self._packet_listener else None
+        modem_status_cbs = self._packet_listener.get_modem_status_received_callbacks() \
+            if self._packet_listener else None
+        io_cbs = self._packet_listener.get_io_sample_received_callbacks() \
+            if self._packet_listener else None
+        expl_data_cbs = self._packet_listener.get_explicit_data_received_callbacks() \
+            if self._packet_listener else None
+        ip_data_cbs = self._packet_listener.get_ip_data_received_callbacks() \
+            if self._packet_listener else None
+        sms_cbs = self._packet_listener.get_sms_received_callbacks() \
+            if self._packet_listener else None
+        user_data_relay_cbs = self._packet_listener.get_user_data_relay_received_callbacks() \
+            if self._packet_listener else None
+        bt_data_cbs = self._packet_listener.get_bluetooth_data_received_callbacks() \
+            if self._packet_listener else None
+        mp_data_cbs = self._packet_listener.get_micropython_data_received_callbacks() \
+            if self._packet_listener else None
+
         self._serial_port.port = self.__port
         self._serial_port.open()
         self._log.info("%s port opened" % self.__port)
 
         # Initialize the packet listener.
+        self._packet_listener = None
         self._packet_listener = PacketListener(self._serial_port, self)
         self.__packet_queue = self._packet_listener.get_queue()
         self.__data_queue = self._packet_listener.get_data_queue()
         self.__explicit_queue = self._packet_listener.get_explicit_queue()
+
+        # Restore callbacks if any
+        self._packet_listener.add_packet_received_callback(packet_cbs)
+        self._packet_listener.add_data_received_callback(data_cbs)
+        self._packet_listener.add_modem_status_received_callback(modem_status_cbs)
+        self._packet_listener.add_io_sample_received_callback(io_cbs)
+        self._packet_listener.add_explicit_data_received_callback(expl_data_cbs)
+        self._packet_listener.add_ip_data_received_callback(ip_data_cbs)
+        self._packet_listener.add_sms_received_callback(sms_cbs)
+        self._packet_listener.add_user_data_relay_received_callback(user_data_relay_cbs)
+        self._packet_listener.add_bluetooth_data_received_callback(bt_data_cbs)
+        self._packet_listener.add_micropython_data_received_callback(mp_data_cbs)
+
         self._packet_listener.start()
 
         # Determine the operating mode of the XBee device.
@@ -2505,107 +2379,213 @@ class XBeeDevice(AbstractXBeeDevice):
 
     def add_packet_received_callback(self, callback):
         """
-        Override.
+        Adds a callback for the event :class:`digi.xbee.reader.PacketReceived`.
+
+        Args:
+            callback (Function): the callback. Receives two arguments.
+
+                * The received packet as a :class:`digi.xbee.packets.base.XBeeAPIPacket`
+                * The sender as a :class:`.RemoteXBeeDevice`
         """
         super()._add_packet_received_callback(callback)
 
     def add_data_received_callback(self, callback):
         """
-        Override.
+        Adds a callback for the event :class:`digi.xbee.reader.DataReceived`.
+
+        Args:
+            callback (Function): the callback. Receives one argument.
+
+                * The data received as an :class:`digi.xbee.models.message.XBeeMessage`
         """
-        super()._add_data_received_callback(callback)
+        self._packet_listener.add_data_received_callback(callback)
 
     def add_modem_status_received_callback(self, callback):
         """
-        Override.
+        Adds a callback for the event :class:`digi.xbee.reader.ModemStatusReceived`.
+
+        Args:
+            callback (Function): the callback. Receives one argument.
+
+                * The modem status as a :class:`digi.xbee.models.status.ModemStatus`
         """
-        super()._add_modem_status_received_callback(callback)
+        self._packet_listener.add_modem_status_received_callback(callback)
 
     def add_io_sample_received_callback(self, callback):
         """
-        Override.
+        Adds a callback for the event :class:`digi.xbee.reader.IOSampleReceived`.
+
+        Args:
+            callback (Function): the callback. Receives three arguments.
+
+                * The received IO sample as an :class:`digi.xbee.io.IOSample`
+                * The remote XBee device who has sent the packet as a :class:`.RemoteXBeeDevice`
+                * The time in which the packet was received as an Integer
         """
-        super()._add_io_sample_received_callback(callback)
+        self._packet_listener.add_io_sample_received_callback(callback)
 
     def add_expl_data_received_callback(self, callback):
         """
-        Override.
+        Adds a callback for the event :class:`digi.xbee.reader.ExplicitDataReceived`.
+
+        Args:
+            callback (Function): the callback. Receives one argument.
+
+                * The explicit data received as a
+                  :class:`digi.xbee.models.message.ExplicitXBeeMessage`.
         """
-        super()._add_expl_data_received_callback(callback)
+        self._packet_listener.add_explicit_data_received_callback(callback)
 
     def add_user_data_relay_received_callback(self, callback):
         """
-        Override.
+        Adds a callback for the event :class:`digi.xbee.reader.RelayDataReceived`.
+
+        Args:
+            callback (Function): the callback. Receives one argument.
+
+                * The relay data as a :class:`digi.xbee.models.message.UserDataRelayMessage`
         """
-        super()._add_user_data_relay_received_callback(callback)
+        self._packet_listener.add_user_data_relay_received_callback(callback)
 
     def add_bluetooth_data_received_callback(self, callback):
         """
-        Override.
+        Adds a callback for the event :class:`digi.xbee.reader.BluetoothDataReceived`.
+
+        Args:
+            callback (Function): the callback. Receives one argument.
+
+                * The Bluetooth data as a Bytearray
         """
-        super()._add_bluetooth_data_received_callback(callback)
+        self._packet_listener.add_bluetooth_data_received_callback(callback)
 
     def add_micropython_data_received_callback(self, callback):
         """
-        Override.
+        Adds a callback for the event :class:`digi.xbee.reader.MicroPythonDataReceived`.
+
+        Args:
+            callback (Function): the callback. Receives one argument.
+
+                * The MicroPython data as a Bytearray
         """
-        super()._add_micropython_data_received_callback(callback)
+        self._packet_listener.add_micropython_data_received_callback(callback)
 
     def del_packet_received_callback(self, callback):
         """
-        Override.
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.PacketReceived` event.
+
+        Args:
+            callback (Function): the callback to delete.
+
+        Raises:
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.PacketReceived` event.
         """
         super()._del_packet_received_callback(callback)
 
     def del_data_received_callback(self, callback):
         """
-        Override.
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.DataReceived` event.
+
+        Args:
+            callback (Function): the callback to delete.
+
+        Raises:
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.DataReceived` event.
         """
-        super()._del_data_received_callback(callback)
+        self._packet_listener.del_data_received_callback(callback)
 
     def del_modem_status_received_callback(self, callback):
         """
-        Override.
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.ModemStatusReceived`
+        event.
+
+        Args:
+            callback (Function): the callback to delete.
+
+        Raises:
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.ModemStatusReceived` event.
         """
-        super()._del_modem_status_received_callback(callback)
+        self._packet_listener.del_modem_status_received_callback(callback)
 
     def del_io_sample_received_callback(self, callback):
         """
-        Override.
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.IOSampleReceived`
+        event.
+
+        Args:
+            callback (Function): the callback to delete.
+
+        Raises:
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.IOSampleReceived` event.
         """
-        super()._del_io_sample_received_callback(callback)
+        self._packet_listener.del_io_sample_received_callback(callback)
 
     def del_expl_data_received_callback(self, callback):
         """
-        Override.
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.ExplicitDataReceived`
+        event.
+
+        Args:
+            callback (Function): the callback to delete.
+
+        Raises:
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.ExplicitDataReceived` event.
         """
-        super()._del_expl_data_received_callback(callback)
+        self._packet_listener.del_explicit_data_received_callback(callback)
 
     def del_user_data_relay_received_callback(self, callback):
         """
-        Override.
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.RelayDataReceived`
+        event.
+
+        Args:
+            callback (Function): the callback to delete.
+
+        Raises:
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.RelayDataReceived` event.
         """
-        super()._del_user_data_relay_received_callback(callback)
+        self._packet_listener.del_user_data_relay_received_callback(callback)
 
     def del_bluetooth_data_received_callback(self, callback):
         """
-        Override.
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.BluetoothDataReceived`
+        event.
+
+        Args:
+            callback (Function): the callback to delete.
+
+        Raises:
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.BluetoothDataReceived` event.
         """
-        super()._del_bluetooth_data_received_callback(callback)
+        self._packet_listener.del_bluetooth_data_received_callback(callback)
 
     def del_micropython_data_received_callback(self, callback):
         """
-        Override.
+        Deletes a callback for the callback list of
+        :class:`digi.xbee.reader.MicroPythonDataReceived` event.
+
+        Args:
+            callback (Function): the callback to delete.
+
+        Raises:
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.MicroPythonDataReceived` event.
         """
-        super()._del_micropython_data_received_callback(callback)
+        self._packet_listener.del_micropython_data_received_callback(callback)
 
     def get_xbee_device_callbacks(self):
         """
         Returns this XBee internal callbacks for process received packets.
-        
+
         This method is called by the PacketListener associated with this XBee to get its callbacks. These
         callbacks will be executed before user callbacks.
-        
+
         Returns:
             :class:`.PacketReceived`
         """
@@ -3874,25 +3854,26 @@ class IPDevice(XBeeDevice):
 
     def add_ip_data_received_callback(self, callback):
         """
-        Adds a callback for the event :class:`.IPDataReceived`.
+        Adds a callback for the event :class:`digi.xbee.reader.IPDataReceived`.
 
         Args:
             callback (Function): the callback. Receives one argument.
 
-                * The data received as an :class:`.IPMessage`
+                * The data received as an :class:`digi.xbee.models.message.IPMessage`
         """
         self._packet_listener.add_ip_data_received_callback(callback)
 
     def del_ip_data_received_callback(self, callback):
         """
-        Deletes a callback for the callback list of :class:`.IPDataReceived`
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.IPDataReceived`
         event.
 
         Args:
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.IPDataReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.IPDataReceived` event.
         """
         self._packet_listener.del_ip_data_received_callback(callback)
 
@@ -4392,25 +4373,26 @@ class CellularDevice(IPDevice):
 
     def add_sms_callback(self, callback):
         """
-        Adds a callback for the event :class:`.SMSReceived`.
+        Adds a callback for the event :class:`digi.xbee.reader.SMSReceived`.
 
         Args:
             callback (Function): the callback. Receives one argument.
 
-                * The data received as an :class:`.SMSMessage`
+                * The data received as an :class:`digi.xbee.models.message.SMSMessage`
         """
         self._packet_listener.add_sms_received_callback(callback)
 
     def del_sms_callback(self, callback):
         """
-        Deletes a callback for the callback list of :class:`.SMSReceived`
+        Deletes a callback for the callback list of :class:`digi.xbee.reader.SMSReceived`
         event.
 
         Args:
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.SMSReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`digi.xbee.reader.SMSReceived` event.
         """
         self._packet_listener.del_sms_received_callback(callback)
 

--- a/digi/xbee/exception.py
+++ b/digi/xbee/exception.py
@@ -42,7 +42,11 @@ class ATCommandException(CommunicationException):
     All functionality of this class is the inherited of `Exception
     <https://docs.python.org/2/library/exceptions.html?highlight=exceptions.exception#exceptions.Exception>`_.
     """
-    pass
+    __DEFAULT_MESSAGE = "There was a problem sending the AT command packet."
+
+    def __init__(self, message=__DEFAULT_MESSAGE, cmd_status=None):
+        super().__init__(message)
+        self.status = cmd_status
 
 
 class ConnectionException(XBeeException):
@@ -69,7 +73,7 @@ class XBeeDeviceException(XBeeException):
 
 class InvalidConfigurationException(ConnectionException):
     """
-    This exception will be thrown when trying to open an interface with an 
+    This exception will be thrown when trying to open an interface with an
     invalid configuration.
 
     All functionality of this class is the inherited of `Exception
@@ -78,7 +82,7 @@ class InvalidConfigurationException(ConnectionException):
     __DEFAULT_MESSAGE = "The configuration used to open the interface is invalid."
 
     def __init__(self, message=__DEFAULT_MESSAGE):
-        ConnectionException.__init__(self, message)
+        super().__init__(message)
 
 
 class InvalidOperatingModeException(ConnectionException):
@@ -90,19 +94,17 @@ class InvalidOperatingModeException(ConnectionException):
     <https://docs.python.org/2/library/exceptions.html?highlight=exceptions.exception#exceptions.Exception>`_.
     """
     __DEFAULT_MESSAGE = "The operating mode of the XBee device is not supported by the library."
+    __DEFAULT_MSG_FORMAT = "Unsupported operating mode: %s (%d)"
 
-    def __init__(self, message=__DEFAULT_MESSAGE):
-        ConnectionException.__init__(self, message)
+    def __init__(self, message=__DEFAULT_MESSAGE, op_mode=None):
+        if op_mode and not message:
+            message = InvalidOperatingModeException.__DEFAULT_MSG_FORMAT \
+                      % (op_mode.description, op_mode.code)
+        elif not message:
+            message = InvalidOperatingModeException.__DEFAULT_MESSAGE
 
-    @classmethod
-    def from_operating_mode(cls, operating_mode):
-        """
-        Class constructor.
-
-        Args:
-            operating_mode (:class:`.OperatingMode`): the operating mode that generates the exceptions.
-        """
-        return cls("Unsupported operating mode: " + operating_mode.description)
+        super().__init__(message)
+        self.__op_mode = op_mode
 
 
 class InvalidPacketException(CommunicationException):
@@ -116,7 +118,7 @@ class InvalidPacketException(CommunicationException):
     __DEFAULT_MESSAGE = "The XBee API packet is not properly formed."
 
     def __init__(self, message=__DEFAULT_MESSAGE):
-        CommunicationException.__init__(self, message)
+        super().__init__(message)
 
 
 class OperationNotSupportedException(XBeeDeviceException):
@@ -127,11 +129,11 @@ class OperationNotSupportedException(XBeeDeviceException):
     All functionality of this class is the inherited of `Exception
     <https://docs.python.org/2/library/exceptions.html?highlight=exceptions.exception#exceptions.Exception>`_.
     """
-    __DEFAULT_MESSAGE = "The requested operation is not supported by either the connection interface or " \
-                        "the XBee device."
+    __DEFAULT_MESSAGE = "The requested operation is not supported by either " \
+                        "the connection interface or the XBee device."
 
     def __init__(self, message=__DEFAULT_MESSAGE):
-        XBeeDeviceException.__init__(self, message)
+        super().__init__(message)
 
 
 class TimeoutException(CommunicationException):
@@ -144,8 +146,8 @@ class TimeoutException(CommunicationException):
     """
     __DEFAULT_MESSAGE = "There was a timeout while executing the requested operation."
 
-    def __init__(self, _message=__DEFAULT_MESSAGE):
-        CommunicationException.__init__(self)
+    def __init__(self, message=__DEFAULT_MESSAGE):
+        super().__init__(message)
 
 
 class TransmitException(CommunicationException):
@@ -158,5 +160,6 @@ class TransmitException(CommunicationException):
     """
     __DEFAULT_MESSAGE = "There was a problem with a transmitted packet response (status not ok)"
 
-    def __init__(self, _message=__DEFAULT_MESSAGE):
-        CommunicationException.__init__(self, _message)
+    def __init__(self, message=__DEFAULT_MESSAGE, transmit_status=None):
+        super().__init__(message)
+        self.status = transmit_status

--- a/digi/xbee/io.py
+++ b/digi/xbee/io.py
@@ -621,7 +621,7 @@ class IOSample(object):
 
 class IOMode(Enum):
     """
-    Enumerates the different Input/Output modes that an IO line can be 
+    Enumerates the different Input/Output modes that an IO line can be
     configured with.
     """
 
@@ -645,3 +645,6 @@ class IOMode(Enum):
 
     DIGITAL_OUT_HIGH = 5
     """Digital output, High"""
+
+    I2C_FUNCTIONALITY = 6
+    """I2C functionality"""

--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -434,22 +434,22 @@ class XBeeAPIPacket(XBeePacket):
            | :mod:`.factory`
         """
         if len(raw) < min_length:
-                raise InvalidPacketException("Bytearray must have, at least, 5 of complete length (header, length, "
-                                             "frameType, checksum)")
+            raise InvalidPacketException(message="Bytearray must have, at least, 5 of complete length (header, length, "
+                                         "frameType, checksum)")
 
         if raw[0] & 0xFF != SpecialByte.HEADER_BYTE.code:
-            raise InvalidPacketException("Bytearray must start with the header byte (SpecialByte.HEADER_BYTE.code)")
+            raise InvalidPacketException(message="Bytearray must start with the header byte (SpecialByte.HEADER_BYTE.code)")
 
         # real frame specific data length
         real_length = len(raw[3:-1])
         # length is specified in the length field.
         length_field = utils.length_to_int(raw[1:3])
         if real_length != length_field:
-            raise InvalidPacketException("The real length of this frame is distinct than the specified by length "
+            raise InvalidPacketException(message="The real length of this frame is distinct than the specified by length "
                                          "field (bytes 2 and 3)")
 
         if 0xFF - (sum(raw[3:-1]) & 0xFF) != raw[-1]:
-            raise InvalidPacketException("Wrong checksum")
+            raise InvalidPacketException(message="Wrong checksum")
 
     @abstractmethod
     def _get_api_packet_spec_data(self):
@@ -531,12 +531,12 @@ class GenericXBeePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=GenericXBeePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.GENERIC.code:
-            raise InvalidPacketException("Wrong frame type, expected: " + ApiFrameType.GENERIC.description +
+            raise InvalidPacketException(message="Wrong frame type, expected: " + ApiFrameType.GENERIC.description +
                                          ". Value: " + ApiFrameType.GENERIC.code)
 
         return GenericXBeePacket(raw[4:-1])
@@ -616,7 +616,7 @@ class UnknownXBeePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=UnknownXBeePacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/cellular.py
+++ b/digi/xbee/packets/cellular.py
@@ -81,12 +81,12 @@ class RXSMSPacket(XBeeAPIPacket):
            | :meth:`.XBeePacket.create_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
         
         XBeeAPIPacket._check_api_packet(raw, min_length=RXSMSPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RX_SMS.code:
-            raise InvalidPacketException("This packet is not an RXSMSPacket")
+            raise InvalidPacketException(message="This packet is not an RXSMSPacket")
 
         return RXSMSPacket(raw[4:23].decode("utf8").replace("\0", ""), raw[24:-1].decode("utf8"))
 
@@ -249,12 +249,12 @@ class TXSMSPacket(XBeeAPIPacket):
            | :meth:`.XBeePacket.create_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
         
         XBeeAPIPacket._check_api_packet(raw, min_length=TXSMSPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TX_SMS.code:
-            raise InvalidPacketException("This packet is not a TXSMSPacket")
+            raise InvalidPacketException(message="This packet is not a TXSMSPacket")
 
         return TXSMSPacket(raw[4], raw[6:25].decode("utf8").replace("\0", ""), raw[26:-1].decode("utf8"))
 

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -89,12 +89,12 @@ class ATCommPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.AT_COMMAND.code:
-            raise InvalidPacketException("This packet is not an AT command packet.")
+            raise InvalidPacketException(message="This packet is not an AT command packet.")
 
         return ATCommPacket(raw[4], raw[5:7].decode("utf8"), raw[7:-1])
 
@@ -246,12 +246,12 @@ class ATCommQueuePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommQueuePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.AT_COMMAND_QUEUE.code:
-            raise InvalidPacketException("This packet is not an AT command Queue packet.")
+            raise InvalidPacketException(message="This packet is not an AT command Queue packet.")
 
         return ATCommQueuePacket(raw[4], raw[5:7].decode("utf8"), raw[7:-1])
 
@@ -407,14 +407,14 @@ class ATCommResponsePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.AT_COMMAND_RESPONSE.code:
-            raise InvalidPacketException("This packet is not an AT command response packet.")
+            raise InvalidPacketException(message="This packet is not an AT command response packet.")
         if ATCommandStatus.get(raw[7]) is None:
-            raise InvalidPacketException("Invalid command status.")
+            raise InvalidPacketException(message="Invalid command status.")
 
         return ATCommResponsePacket(raw[4], raw[5:7].decode("utf8"), ATCommandStatus.get(raw[7]), raw[8:-1])
 
@@ -593,12 +593,12 @@ class ReceivePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ReceivePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RECEIVE_PACKET.code:
-            raise InvalidPacketException("This packet is not a receive packet.")
+            raise InvalidPacketException(message="This packet is not a receive packet.")
         return ReceivePacket(XBee64BitAddress(raw[4:12]),
                              XBee16BitAddress(raw[12:14]),
                              raw[14],
@@ -837,12 +837,12 @@ class RemoteATCommandPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_REQUEST.code:
-            raise InvalidPacketException("This packet is not a remote AT command request packet.")
+            raise InvalidPacketException(message="This packet is not a remote AT command request packet.")
 
         return RemoteATCommandPacket(
                 raw[4],
@@ -1094,12 +1094,12 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_RESPONSE.code:
-            raise InvalidPacketException("This packet is not a remote AT command response packet.")
+            raise InvalidPacketException(message="This packet is not a remote AT command response packet.")
 
         return RemoteATCommandResponsePacket(raw[4], XBee64BitAddress(raw[5:13]),
                                              XBee16BitAddress(raw[13:15]), raw[15:17].decode("utf8"),
@@ -1366,12 +1366,12 @@ class TransmitPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TRANSMIT_REQUEST.code:
-            raise InvalidPacketException("This packet is not a transmit request packet.")
+            raise InvalidPacketException(message="This packet is not a transmit request packet.")
 
         return TransmitPacket(raw[4], XBee64BitAddress(raw[5:13]),
                               XBee16BitAddress(raw[13:15]), raw[15],
@@ -1616,12 +1616,12 @@ class TransmitStatusPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TRANSMIT_STATUS.code:
-            raise InvalidPacketException("This packet is not a transmit status packet.")
+            raise InvalidPacketException(message="This packet is not a transmit status packet.")
 
         return TransmitStatusPacket(raw[4], XBee16BitAddress(raw[5:7]), raw[7],
                                     TransmitStatus.get(raw[8]), DiscoveryStatus.get(raw[9]))
@@ -1814,12 +1814,12 @@ class ModemStatusPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ModemStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.MODEM_STATUS.code:
-            raise InvalidPacketException("This packet is not a modem status packet.")
+            raise InvalidPacketException(message="This packet is not a modem status packet.")
 
         return ModemStatusPacket(ModemStatus.get(raw[4]))
 
@@ -1948,12 +1948,12 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR.code:
-            raise InvalidPacketException("This packet is not an IO data sample RX indicator packet.")
+            raise InvalidPacketException(message="This packet is not an IO data sample RX indicator packet.")
 
         return IODataSampleRxIndicatorPacket(XBee64BitAddress(raw[4:12]), XBee16BitAddress(raw[12:14]),
                                              raw[14], raw[15:-1])
@@ -2297,12 +2297,12 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitAddressingPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.EXPLICIT_ADDRESSING.code:
-            raise InvalidPacketException("This packet is not an explicit addressing packet")
+            raise InvalidPacketException(message="This packet is not an explicit addressing packet")
 
         return ExplicitAddressingPacket(raw[4], XBee64BitAddress(raw[5:13]), XBee16BitAddress(raw[13:15]),
                                         raw[15], raw[16], utils.bytes_to_int(raw[17:19]),
@@ -2657,12 +2657,12 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitRXIndicatorPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.EXPLICIT_RX_INDICATOR.code:
-            raise InvalidPacketException("This packet is not an explicit RX indicator packet.")
+            raise InvalidPacketException(message="This packet is not an explicit RX indicator packet.")
 
         return ExplicitRXIndicatorPacket(XBee64BitAddress(raw[4:12]), XBee16BitAddress(raw[12:14]), raw[14], raw[15],
                                          utils.bytes_to_int(raw[16:18]), utils.bytes_to_int(raw[18:20]),

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -613,6 +613,15 @@ class ReceivePacket(XBeeAPIPacket):
         """
         return False
 
+    def is_broadcast(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`XBeeAPIPacket.is_broadcast`
+        """
+        return utils.is_bit_enabled(self.__receive_options, 1)
+
     def _get_api_packet_spec_data(self):
         """
         Override method.
@@ -2667,6 +2676,15 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket.needs_id`
         """
         return False
+
+    def is_broadcast(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`XBeeAPIPacket.is_broadcast`
+        """
+        return utils.is_bit_enabled(self.__receive_options, 1)
 
     def _get_api_packet_spec_data(self):
         """

--- a/digi/xbee/packets/devicecloud.py
+++ b/digi/xbee/packets/devicecloud.py
@@ -88,12 +88,12 @@ class DeviceRequestPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceRequestPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_REQUEST.code:
-            raise InvalidPacketException("This packet is not a device request packet.")
+            raise InvalidPacketException(message="This packet is not a device request packet.")
 
         target_length = raw[7]
         return DeviceRequestPacket(raw[4], raw[8:8 + target_length].decode("utf8"), raw[8 + target_length:-1])
@@ -309,12 +309,12 @@ class DeviceResponsePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_RESPONSE.code:
-            raise InvalidPacketException("This packet is not a device response packet.")
+            raise InvalidPacketException(message="This packet is not a device response packet.")
 
         return DeviceResponsePacket(raw[4], raw[5], raw[7:-1])
 
@@ -465,12 +465,12 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponseStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_RESPONSE_STATUS.code:
-            raise InvalidPacketException("This packet is not a device response status packet.")
+            raise InvalidPacketException(message="This packet is not a device response status packet.")
 
         return DeviceResponseStatusPacket(raw[4], DeviceCloudStatus.get(raw[5]))
 
@@ -580,12 +580,12 @@ class FrameErrorPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=FrameErrorPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.FRAME_ERROR.code:
-            raise InvalidPacketException("This packet is not a frame error packet.")
+            raise InvalidPacketException(message="This packet is not a frame error packet.")
 
         return FrameErrorPacket(FrameError.get(raw[4]))
 
@@ -713,12 +713,12 @@ class SendDataRequestPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataRequestPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SEND_DATA_REQUEST.code:
-            raise InvalidPacketException("This packet is not a send data request packet.")
+            raise InvalidPacketException(message="This packet is not a send data request packet.")
 
         path_length = raw[5]
         content_type_length = raw[6 + path_length]
@@ -932,12 +932,12 @@ class SendDataResponsePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SEND_DATA_RESPONSE.code:
-            raise InvalidPacketException("This packet is not a send data response packet.")
+            raise InvalidPacketException(message="This packet is not a send data response packet.")
 
         return SendDataResponsePacket(raw[4], DeviceCloudStatus.get(raw[5]))
 

--- a/digi/xbee/packets/network.py
+++ b/digi/xbee/packets/network.py
@@ -87,12 +87,12 @@ class RXIPv4Packet(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RXIPv4Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RX_IPV4.code:
-            raise InvalidPacketException("This packet is not an RXIPv4Packet.")
+            raise InvalidPacketException(message="This packet is not an RXIPv4Packet.")
 
         return RXIPv4Packet(IPv4Address(bytes(raw[4:8])), utils.bytes_to_int(raw[8:10]),
                             utils.bytes_to_int(raw[10:12]), IPProtocol.get(raw[12]),
@@ -338,12 +338,12 @@ class TXIPv4Packet(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode =operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TXIPv4Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TX_IPV4.code:
-            raise InvalidPacketException("This packet is not an TXIPv4Packet.")
+            raise InvalidPacketException(message="This packet is not an TXIPv4Packet.")
 
         return TXIPv4Packet(raw[4], IPv4Address(bytes(raw[5:9])), utils.bytes_to_int(raw[9:11]),
                             utils.bytes_to_int(raw[11:13]), IPProtocol.get(raw[13]),

--- a/digi/xbee/packets/raw.py
+++ b/digi/xbee/packets/raw.py
@@ -86,12 +86,12 @@ class TX64Packet(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TX64Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TX_64.code:
-            raise InvalidPacketException("This packet is not a TX 64 packet.")
+            raise InvalidPacketException(message="This packet is not a TX 64 packet.")
 
         return TX64Packet(raw[4], XBee64BitAddress(raw[5:13]), raw[13], raw[14:-1])
 
@@ -273,12 +273,12 @@ class TX16Packet(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TX16Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TX_16.code:
-            raise InvalidPacketException("This packet is not a TX 16 packet.")
+            raise InvalidPacketException(message="This packet is not a TX 16 packet.")
 
         return TX16Packet(raw[4], XBee16BitAddress(raw[5:7]), raw[7], raw[8:-1])
 
@@ -458,12 +458,12 @@ class TXStatusPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TXStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TX_STATUS.code:
-            raise InvalidPacketException("This packet is not a TX status packet.")
+            raise InvalidPacketException(message="This packet is not a TX status packet.")
 
         return TXStatusPacket(raw[4], TransmitStatus.get(raw[5]))
 
@@ -586,12 +586,12 @@ class RX64Packet(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RX_64.code:
-            raise InvalidPacketException("This packet is not an RX 64 packet.")
+            raise InvalidPacketException(message="This packet is not an RX 64 packet.")
 
         return RX64Packet(XBee64BitAddress(raw[4:12]), raw[12], raw[13], raw[14:-1])
 
@@ -806,12 +806,12 @@ class RX16Packet(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16Packet.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RX_16.code:
-            raise InvalidPacketException("This packet is not an RX 16 Packet")
+            raise InvalidPacketException(message="This packet is not an RX 16 Packet")
 
         return RX16Packet(XBee16BitAddress(raw[4:6]), raw[6], raw[7], raw[8:-1])
 
@@ -1021,12 +1021,12 @@ class RX64IOPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64IOPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RX_IO_64.code:
-            raise InvalidPacketException("This packet is not an RX 64 IO packet.")
+            raise InvalidPacketException(message="This packet is not an RX 64 IO packet.")
 
         return RX64IOPacket(XBee64BitAddress(raw[4:12]), raw[12], raw[13], raw[14:-1])
 
@@ -1294,12 +1294,12 @@ class RX16IOPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16IOPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.RX_IO_16.code:
-            raise InvalidPacketException("This packet is not an RX 16 IO packet.")
+            raise InvalidPacketException(message="This packet is not an RX 16 IO packet.")
 
         return RX16IOPacket(XBee16BitAddress(raw[4:6]), raw[6], raw[7], raw[8:-1])
 

--- a/digi/xbee/packets/raw.py
+++ b/digi/xbee/packets/raw.py
@@ -604,6 +604,16 @@ class RX64Packet(XBeeAPIPacket):
         """
         return False
 
+    def is_broadcast(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`XBeeAPIPacket.is_broadcast`
+        """
+        return (utils.is_bit_enabled(self.__receive_options, 1)
+                or utils.is_bit_enabled(self.__receive_options, 2))
+
     def _get_api_packet_spec_data(self):
         """
         Override method.
@@ -814,6 +824,16 @@ class RX16Packet(XBeeAPIPacket):
         """
         return False
 
+    def is_broadcast(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`XBeeAPIPacket.is_broadcast`
+        """
+        return (utils.is_bit_enabled(self.__receive_options, 1)
+                or utils.is_bit_enabled(self.__receive_options, 2))
+
     def _get_api_packet_spec_data(self):
         """
         Override method.
@@ -1018,6 +1038,16 @@ class RX64IOPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket.needs_id`
         """
         return False
+
+    def is_broadcast(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`XBeeAPIPacket.is_broadcast`
+        """
+        return (utils.is_bit_enabled(self.__receive_options, 1)
+                or utils.is_bit_enabled(self.__receive_options, 2))
 
     def _get_api_packet_spec_data(self):
         """
@@ -1281,6 +1311,16 @@ class RX16IOPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket.needs_id`
         """
         return False
+
+    def is_broadcast(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`XBeeAPIPacket.is_broadcast`
+        """
+        return (utils.is_bit_enabled(self.__receive_options, 1)
+                or utils.is_bit_enabled(self.__receive_options, 2))
 
     def _get_api_packet_spec_data(self):
         """

--- a/digi/xbee/packets/relay.py
+++ b/digi/xbee/packets/relay.py
@@ -88,12 +88,12 @@ class UserDataRelayPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=UserDataRelayPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.USER_DATA_RELAY_REQUEST.code:
-            raise InvalidPacketException("This packet is not a user data relay packet.")
+            raise InvalidPacketException(message="This packet is not a user data relay packet.")
 
         return UserDataRelayPacket(raw[4], XBeeLocalInterface.get([5]), raw[6:-1])
 
@@ -248,12 +248,12 @@ class UserDataRelayOutputPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=UserDataRelayOutputPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.USER_DATA_RELAY_OUTPUT.code:
-            raise InvalidPacketException("This packet is not a user data relay output packet.")
+            raise InvalidPacketException(message="This packet is not a user data relay output packet.")
 
         return UserDataRelayOutputPacket(XBeeLocalInterface.get(raw[4]), raw[5:-1])
 

--- a/digi/xbee/packets/wifi.py
+++ b/digi/xbee/packets/wifi.py
@@ -91,12 +91,12 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR_WIFI.code:
-            raise InvalidPacketException("This packet is not an IO data sample RX indicator Wi-Fi packet.")
+            raise InvalidPacketException(message="This packet is not an IO data sample RX indicator Wi-Fi packet.")
 
         return IODataSampleRxIndicatorWifiPacket(IPv4Address(bytes(raw[4:8])), raw[7], raw[8], raw[9:-1])
 
@@ -374,12 +374,12 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_REQUEST_WIFI.code:
-            raise InvalidPacketException("This packet is not a remote AT command request Wi-Fi packet.")
+            raise InvalidPacketException(message="This packet is not a remote AT command request Wi-Fi packet.")
 
         return RemoteATCommandWifiPacket(
             raw[4],
@@ -601,12 +601,12 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponseWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_RESPONSE_WIFI.code:
-            raise InvalidPacketException("This packet is not a remote AT command response Wi-Fi packet.")
+            raise InvalidPacketException(message="This packet is not a remote AT command response Wi-Fi packet.")
 
         return RemoteATCommandResponseWifiPacket(raw[4],
                                                  IPv4Address(bytes(raw[9:13])),

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -324,6 +324,8 @@ class PacketListener(threading.Thread):
         """
         threading.Thread.__init__(self)
 
+        self.daemon = True
+
         # User callbacks:
         self.__packet_received = PacketReceived()
         self.__data_received = DataReceived()

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -462,113 +462,143 @@ class PacketListener(threading.Thread):
         Adds a callback for the event :class:`.PacketReceived`.
 
         Args:
-            callback (Function): the callback. Receives two arguments.
+            callback (Function or List of functions): the callback. Receives two arguments.
 
                 * The received packet as a :class:`.XBeeAPIPacket`
                 * The sender as a :class:`.RemoteXBeeDevice`
         """
-        self.__packet_received += callback
+        if isinstance(callback, list):
+            self.__packet_received.extend(callback)
+        elif callback:
+            self.__packet_received += callback
 
     def add_data_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.DataReceived`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function or List of functions): the callback. Receives one argument.
 
                 * The data received as an :class:`.XBeeMessage`
         """
-        self.__data_received += callback
+        if isinstance(callback, list):
+            self.__data_received.extend(callback)
+        elif callback:
+            self.__data_received += callback
 
     def add_modem_status_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.ModemStatusReceived`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function or List of functions): the callback. Receives one argument.
 
                 * The modem status as a :class:`.ModemStatus`
         """
-        self.__modem_status_received += callback
+        if isinstance(callback, list):
+            self.__modem_status_received.extend(callback)
+        elif callback:
+            self.__modem_status_received += callback
 
     def add_io_sample_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.IOSampleReceived`.
 
         Args:
-            callback (Function): the callback. Receives three arguments.
+            callback (Function or List of functions): the callback. Receives three arguments.
 
                 * The received IO sample as an :class:`.IOSample`
                 * The remote XBee device who has sent the packet as a :class:`.RemoteXBeeDevice`
                 * The time in which the packet was received as an Integer
         """
-        self.__io_sample_received += callback
+        if isinstance(callback, list):
+            self.__io_sample_received.extend(callback)
+        elif callback:
+            self.__io_sample_received += callback
 
     def add_explicit_data_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.ExplicitDataReceived`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function or List of functions): the callback. Receives one argument.
 
                 * The explicit data received as an :class:`.ExplicitXBeeMessage`
         """
-        self.__explicit_packet_received += callback
+        if isinstance(callback, list):
+            self.__explicit_packet_received.extend(callback)
+        elif callback:
+            self.__explicit_packet_received += callback
 
     def add_ip_data_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.IPDataReceived`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function or List of functions): the callback. Receives one argument.
 
                 * The data received as an :class:`.IPMessage`
         """
-        self.__ip_data_received += callback
+        if isinstance(callback, list):
+            self.__ip_data_received.extend(callback)
+        elif callback:
+            self.__ip_data_received += callback
 
     def add_sms_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.SMSReceived`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function or List of functions): the callback. Receives one argument.
 
                 * The data received as an :class:`.SMSMessage`
         """
-        self.__sms_received += callback
+        if isinstance(callback, list):
+            self.__sms_received.extend(callback)
+        elif callback:
+            self.__sms_received += callback
 
     def add_user_data_relay_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.RelayDataReceived`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function or List of functions): the callback. Receives one argument.
 
                 * The data received as a :class:`.UserDataRelayMessage`
         """
-        self.__relay_data_received += callback
+        if isinstance(callback, list):
+            self.__relay_data_received.extend(callback)
+        elif callback:
+            self.__relay_data_received += callback
 
     def add_bluetooth_data_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.BluetoothDataReceived`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function or List of functions): the callback. Receives one argument.
 
                 * The data received as a Bytearray
         """
-        self.__bluetooth_data_received += callback
+        if isinstance(callback, list):
+            self.__bluetooth_data_received.extend(callback)
+        elif callback:
+            self.__bluetooth_data_received += callback
 
     def add_micropython_data_received_callback(self, callback):
         """
         Adds a callback for the event :class:`.MicroPythonDataReceived`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function or List of functions): the callback. Receives one argument.
 
                 * The data received as a Bytearray
         """
-        self.__micropython_data_received += callback
+        if isinstance(callback, list):
+            self.__micropython_data_received.extend(callback)
+        elif callback:
+            self.__micropython_data_received += callback
 
     def del_packet_received_callback(self, callback):
         """
@@ -578,7 +608,8 @@ class PacketListener(threading.Thread):
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.PacketReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`.PacketReceived` event.
         """
         self.__packet_received -= callback
 
@@ -602,7 +633,8 @@ class PacketListener(threading.Thread):
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.ModemStatusReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`.ModemStatusReceived` event.
         """
         self.__modem_status_received -= callback
 
@@ -614,7 +646,8 @@ class PacketListener(threading.Thread):
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.IOSampleReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`.IOSampleReceived` event.
         """
         self.__io_sample_received -= callback
 
@@ -626,7 +659,8 @@ class PacketListener(threading.Thread):
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.ExplicitDataReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`.ExplicitDataReceived` event.
         """
         self.__explicit_packet_received -= callback
 
@@ -638,7 +672,8 @@ class PacketListener(threading.Thread):
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.IPDataReceived` event.
+            ValueError: if ``callback`` is not in the callback list of :class:`.IPDataReceived`
+                event.
         """
         self.__ip_data_received -= callback
 
@@ -662,7 +697,8 @@ class PacketListener(threading.Thread):
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.RelayDataReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`.RelayDataReceived` event.
         """
         self.__relay_data_received -= callback
 
@@ -674,7 +710,8 @@ class PacketListener(threading.Thread):
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.BluetoothDataReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`.BluetoothDataReceived` event.
         """
         self.__bluetooth_data_received -= callback
 
@@ -686,9 +723,100 @@ class PacketListener(threading.Thread):
             callback (Function): the callback to delete.
 
         Raises:
-            ValueError: if ``callback`` is not in the callback list of :class:`.MicroPythonDataReceived` event.
+            ValueError: if ``callback`` is not in the callback list of
+                :class:`.MicroPythonDataReceived` event.
         """
         self.__micropython_data_received -= callback
+
+    def get_packet_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received packets.
+
+        Returns:
+            List: List of :class:`.PacketReceived` events.
+        """
+        return self.__packet_received
+
+    def get_data_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received data.
+
+        Returns:
+            List: List of :class:`.DataReceived` events.
+        """
+        return self.__data_received
+
+    def get_modem_status_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received modem status.
+
+        Returns:
+            List: List of :class:`.ModemStatusReceived` events.
+        """
+        return self.__modem_status_received
+
+    def get_io_sample_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received IO samples.
+
+        Returns:
+            List: List of :class:`.IOSampleReceived` events.
+        """
+        return self.__io_sample_received
+
+    def get_explicit_data_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received explicit data.
+
+        Returns:
+            List: List of :class:`.ExplicitDataReceived` events.
+        """
+        return self.__explicit_packet_received
+
+    def get_ip_data_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received IP data.
+
+        Returns:
+            List: List of :class:`.IPDataReceived` events.
+        """
+        return self.__ip_data_received
+
+    def get_sms_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received SMS.
+
+        Returns:
+            List: List of :class:`.SMSReceived` events.
+        """
+        return self.__sms_received
+
+    def get_user_data_relay_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received user data relay.
+
+        Returns:
+            List: List of :class:`.RelayDataReceived` events.
+        """
+        return self.__relay_data_received
+
+    def get_bluetooth_data_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received Bluetooth data.
+
+        Returns:
+            List: List of :class:`.BluetoothDataReceived` events.
+        """
+        return self.__bluetooth_data_received
+
+    def get_micropython_data_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received micropython data.
+
+        Returns:
+            List: List of :class:`.MicroPythonDataReceived` events.
+        """
+        return self.__micropython_data_received
 
     def __execute_user_callbacks(self, xbee_packet, remote=None):
         """


### PR DESCRIPTION
Several fixes:
* Register existing custom callbacks when opening an XBee device
* Fix check of received broadcast packets
* Override the method `is_broadcast()` for the required packets
* Fix `get_io_configuration()` method
* Implement dual notification for explicit frames with IO samples
* Add all serial parameters to protocol specific device constructors
* Rework exceptions to add details about the error
* Daemonize the serial port packet listener thread
