### PR TITLE
reader: fix the reader stop method to avoid accessing the port when it is closed

### DIFF
--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -413,6 +413,8 @@ class PacketListener(threading.Thread):
         Stops listening.
         """
         self.__stop = True
+        # Wait until thread fully stops.
+        self.join()
 
     def is_running(self):
         """
@@ -964,6 +966,8 @@ class PacketListener(threading.Thread):
             # Add packet delimiter.
             xbee_packet[0] = self.__serial_port.read_byte()
             while xbee_packet[0] != SpecialByte.HEADER_BYTE.value:
+                if self.__stop:
+                    return None
                 xbee_packet[0] = self.__serial_port.read_byte()
 
             # Add packet length.


### PR DESCRIPTION
- The stop method of the reader class now waits until the thread is fully shut-down.
  In some scenarios, when the port was closed and open very quickly, a read exception
  was thrown by the reader thread.
- Check thread stop variable in the read packet method to avoid accessing the port
  if the thread has been already stopped.

Signed-off-by: David Escalona <david.escalona@digi.com>