### PR TITLE
packet received callback: fix code documentation to remove non existi…

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -1354,7 +1354,6 @@ class AbstractXBeeDevice(object):
             callback (Function): the callback. Receives two arguments.
 
                 * The received packet as a :class:`digi.xbee.packets.base.XBeeAPIPacket`
-                * The sender as a :class:`.RemoteXBeeDevice`
         """
         self._packet_listener.add_packet_received_callback(callback)
 
@@ -2390,7 +2389,6 @@ class XBeeDevice(AbstractXBeeDevice):
             callback (Function): the callback. Receives two arguments.
 
                 * The received packet as a :class:`digi.xbee.packets.base.XBeeAPIPacket`
-                * The sender as a :class:`.RemoteXBeeDevice`
         """
         super()._add_packet_received_callback(callback)
 

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -291,7 +291,6 @@ class PacketListener(threading.Thread):
 
     1. PacketReceived:
         1.1 received_packet (:class:`.XBeeAPIPacket`): the received packet.
-        1.2 sender (:class:`.RemoteXBeeDevice`): the remote XBee device who has sent the packet.
     2. DataReceived
         2.1 message (:class:`.XBeeMessage`): message containing the data received, the sender and the time.
     3. ModemStatusReceived
@@ -469,7 +468,6 @@ class PacketListener(threading.Thread):
             callback (Function or List of functions): the callback. Receives two arguments.
 
                 * The received packet as a :class:`.XBeeAPIPacket`
-                * The sender as a :class:`.RemoteXBeeDevice`
         """
         if isinstance(callback, list):
             self.__packet_received.extend(callback)


### PR DESCRIPTION
…ng argument

- The 'sender' argument was never used in the packet received callbacks, so remove
  it from the code documentation headers.

Signed-off-by: David Escalona <david.escalona@digi.com>