### PR TITLE
devices: read the actual operating mode when the device is in AT mode

### DIFF
--- a/digi/xbee/exception.py
+++ b/digi/xbee/exception.py
@@ -96,7 +96,7 @@ class InvalidOperatingModeException(ConnectionException):
     __DEFAULT_MESSAGE = "The operating mode of the XBee device is not supported by the library."
     __DEFAULT_MSG_FORMAT = "Unsupported operating mode: %s (%d)"
 
-    def __init__(self, message=__DEFAULT_MESSAGE, op_mode=None):
+    def __init__(self, message=None, op_mode=None):
         if op_mode and not message:
             message = InvalidOperatingModeException.__DEFAULT_MSG_FORMAT \
                       % (op_mode.description, op_mode.code)

--- a/digi/xbee/models/mode.py
+++ b/digi/xbee/models/mode.py
@@ -29,6 +29,8 @@ class OperatingMode(Enum):
     AT_MODE = (0, "AT mode")
     API_MODE = (1, "API mode")
     ESCAPED_API_MODE = (2, "API mode with escaped characters")
+    MICROPYTHON_MODE = (4, "MicroPython REPL")
+    BYPASS_MODE = (5, "Bypass mode")
     UNKNOWN = (99, "Unknown")
 
     def __init__(self, code, description):


### PR DESCRIPTION
- If the device cannot be discovered in API mode, the library checks if it is
  in AT mode by entering command mode. In some scenarios like a hardware reset
  or recovery mode, the module could be in API mode, but the library cannot
  find it and determines that it is in AT mode raising an exception. To avoid
  that, the library now asks for the actual operating mode after entering
  command mode.

Signed-off-by: Diego Escalona <diego.escalona@digi.com>