### PR TITLE
Several fixes

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -1718,7 +1718,13 @@ class AbstractXBeeDevice(object):
                 # response and the command matches in both packets.
                 if packet_to_send.get_frame_type() == ApiFrameType.REMOTE_AT_COMMAND_REQUEST \
                         and (received_packet.get_frame_type() != ApiFrameType.REMOTE_AT_COMMAND_RESPONSE
-                             or packet_to_send.command != received_packet.command):
+                             or packet_to_send.command != received_packet.command
+                             or (packet_to_send.x64bit_dest_addr != XBee64BitAddress.BROADCAST_ADDRESS
+                                 and packet_to_send.x64bit_dest_addr != XBee64BitAddress.UNKNOWN_ADDRESS
+                                 and packet_to_send.x64bit_dest_addr != received_packet.x64bit_source_addr)
+                             or (packet_to_send.x16bit_dest_addr != XBee16BitAddress.BROADCAST_ADDRESS
+                                 and packet_to_send.x16bit_dest_addr != XBee16BitAddress.UNKNOWN_ADDRESS
+                                 and packet_to_send.x16bit_dest_addr != received_packet.x16bit_source_addr)):
                     return
                 # If the packet sent is a Socket Create, verify that the received one is a Socket Create Response.
                 if packet_to_send.get_frame_type() == ApiFrameType.SOCKET_CREATE \

--- a/digi/xbee/firmware.py
+++ b/digi/xbee/firmware.py
@@ -289,7 +289,7 @@ class _OTAFile(object):
                 self._file = open(self._file_path, "rb")
                 self._file.read(self._discard_size)
 
-            return self._file.read(_OTA_DEFAULT_BLOCK_SIZE)
+            return self._file.read(self._chunk_size)
         except IOError as e:
             self.close_file()
             raise _ParsingOTAException(str(e))

--- a/digi/xbee/models/zdo.py
+++ b/digi/xbee/models/zdo.py
@@ -328,6 +328,20 @@ class __ZDOCommand(metaclass=ABCMeta):
             return
 
         if frame.get_frame_type() == ApiFrameType.EXPLICIT_RX_INDICATOR:
+            # Check address
+            x64 = self._xbee.get_64bit_addr()
+            x16 = self._xbee.get_16bit_addr()
+            if (not self._is_broadcast()
+                    and x64 != XBee64BitAddress.UNKNOWN_ADDRESS
+                    and x64 != frame.x64bit_source_addr
+                    and x16 != XBee16BitAddress.UNKNOWN_ADDRESS
+                    and x16 != frame.x16bit_source_addr):
+                return
+            # Check profile and endpoints
+            if frame.profile_id != self.__class__._PROFILE_ID \
+                    or frame.source_endpoint != self.__class__._SOURCE_ENDPOINT \
+                    or frame.dest_endpoint != self.__class__._DESTINATION_ENDPOINT:
+                return
             # Check if the cluster ID is correct.
             if frame.cluster_id != self.__receive_cluster_id:
                 return


### PR DESCRIPTION
* remote at: check the origin of 'Remote AT command response' frames
* zdo: check the origin of 'Explicit RX indicator' frames
* firmware: use the calculated size when reading the next chunk of an ota file
* firmware: workaround for 'No ack' error on XBee 3 DigiMesh remote firmware updates