### PR TITLE
XBee 3 DigiMesh/802.15.4 remote profile update fix

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -3052,6 +3052,9 @@ class XBeeDevice(AbstractXBeeDevice):
         """
         api_callbacks = PacketReceived()
 
+        if not self._network:
+            return api_callbacks
+
         for i in self._network.get_discovery_callbacks():
             api_callbacks.append(i)
         return api_callbacks


### PR DESCRIPTION
* Retry the application of a profile settings also when receiving an at command error status
* Define different reset timeouts for local and remote XBee firmware updates (remote also depends on the protocol running on the XBee)