### PR TITLE
role: catch a possible exception while determining the XBee role

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -525,7 +525,13 @@ class AbstractXBeeDevice(object):
         if self._protocol in [XBeeProtocol.DIGI_MESH, XBeeProtocol.SX, XBeeProtocol.XTEND_DM]:
             ce = utils.bytes_to_int(self.get_parameter(ATStringCommand.CE.command))
             if ce == 0:
-                ss = self.get_parameter(ATStringCommand.SS.command)
+                try:
+                    # Capture the possible exception because DigiMesh S2C does not have
+                    # SS command, so the read will throw an ATCommandException
+                    ss = self.get_parameter(ATStringCommand.SS.command)
+                except ATCommandException:
+                    ss = None
+
                 if not ss:
                     return Role.ROUTER
 


### PR DESCRIPTION
DigiMesh XBee S2C and XBee 3 3001 firmware versions does not support synchronous
sleep, so 'SS' command fails because it is not included.

https://github.com/digidotcom/xbee-python/issues/103

