### PR TITLE
devices: digimesh: set 16bit address as unknown

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -507,6 +507,9 @@ class AbstractXBeeDevice(object):
                      or self._16bit_addr == XBee16BitAddress.UNKNOWN_ADDRESS)):
             r = self.get_parameter(ATStringCommand.MY.command)
             self._16bit_addr = XBee16BitAddress(r)
+        else:
+            # For protocols that do not support a 16 bit address, set it to unknown
+            self._16bit_addr = XBee16BitAddress.UNKNOWN_ADDRESS
 
         # Role:
         if init or self._role is None or self._role == Role.UNKNOWN:


### PR DESCRIPTION
On DigiMesh, the 16 bit address is set to 0xFFFE on the XBee frames, which is
the value returned by get_16bit_addr() method on a RemoteXBee.

On local XBee devices, however, 'None' was being returned. This commits
makes it so that 0xFFFE is also returned when using local XBee devices,
fixing this inconsistency.

Signed-off-by: Jose Diaz de Grenu <Jose.DiazdeGrenu@digi.com>