### PR TITLE
Get Zigbee and DigiMesh routes

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -3886,6 +3886,24 @@ class DigiMeshDevice(XBeeDevice):
         """
         return XBeeProtocol.DIGI_MESH
 
+    def build_aggregate_routes(self):
+        """
+        Automatically build routes to this node. All nodes in the network will
+        build routes to this node. The receiving node establishes a route back
+        to this node.
+
+        Raises:
+            TimeoutException: If the response is not received before the read
+                timeout expires.
+            XBeeException: If the XBee device's serial port is closed.
+            InvalidOperatingModeException: If the XBee device's operating mode
+                is not API or ESCAPED API. This method only checks the cached
+                value of the operating mode.
+            ATCommandException: If the response is not as expected.
+        """
+        self.set_parameter(ATStringCommand.AG.command,
+                           XBee16BitAddress.UNKNOWN_ADDRESS.address)
+
     def send_data_64(self, x64addr, data, transmit_options=TransmitOptions.NONE.value):
         """
         Override.

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -507,7 +507,7 @@ class AbstractXBeeDevice(object):
                      or self._16bit_addr == XBee16BitAddress.UNKNOWN_ADDRESS)):
             r = self.get_parameter(ATStringCommand.MY.command)
             self._16bit_addr = XBee16BitAddress(r)
-        else:
+        elif not self._16bit_addr:
             # For protocols that do not support a 16 bit address, set it to unknown
             self._16bit_addr = XBee16BitAddress.UNKNOWN_ADDRESS
 

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2131,6 +2131,8 @@ class XBeeDevice(AbstractXBeeDevice):
             if self._packet_listener else None
         socket_data_from_cbs = self._packet_listener.get_socket_data_received_from_callbacks() \
             if self._packet_listener else None
+        route_record_cbs = self._packet_listener.get_route_record_received_callbacks() \
+            if self._packet_listener else None
 
         self._comm_iface.open()
         self._log.info("%s port opened" % self._comm_iface)
@@ -2156,6 +2158,7 @@ class XBeeDevice(AbstractXBeeDevice):
         self._packet_listener.add_socket_state_received_callback(socket_st_cbs)
         self._packet_listener.add_socket_data_received_callback(socket_data_cbs)
         self._packet_listener.add_socket_data_received_from_callback(socket_data_from_cbs)
+        self._packet_listener.add_route_record_received_callback(route_record_cbs)
 
         self._packet_listener.start()
         self._packet_listener.wait_until_started()

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2133,6 +2133,8 @@ class XBeeDevice(AbstractXBeeDevice):
             if self._packet_listener else None
         route_record_cbs = self._packet_listener.get_route_record_received_callbacks() \
             if self._packet_listener else None
+        route_info_cbs = self._packet_listener.get_route_info_callbacks() \
+            if self._packet_listener else None
 
         self._comm_iface.open()
         self._log.info("%s port opened" % self._comm_iface)
@@ -2159,6 +2161,7 @@ class XBeeDevice(AbstractXBeeDevice):
         self._packet_listener.add_socket_data_received_callback(socket_data_cbs)
         self._packet_listener.add_socket_data_received_from_callback(socket_data_from_cbs)
         self._packet_listener.add_route_record_received_callback(route_record_cbs)
+        self._packet_listener.add_route_info_received_callback(route_info_cbs)
 
         self._packet_listener.start()
         self._packet_listener.wait_until_started()

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -7664,9 +7664,16 @@ class XBeeNetwork(object):
                     self._log.debug("Error while trying to get 64-bit address of XBee (%s): %s"
                                     % (remote_xbee.get_16bit_addr(), str(e)))
 
-            with self.__lock:
-                if remote_xbee in self.__devices_list:
-                    found = self.__devices_list[self.__devices_list.index(remote_xbee)]
+                    # Look for the device by its 16-bit address.
+                    x16 = remote_xbee.get_16bit_addr()
+                    if x16 and x16 != XBee16BitAddress.UNKNOWN_ADDRESS \
+                            and x16 != XBee16BitAddress.BROADCAST_ADDRESS:
+                        found = self.get_device_by_16(x16)
+
+            if not found:
+                with self.__lock:
+                    if remote_xbee in self.__devices_list:
+                        found = self.__devices_list[self.__devices_list.index(remote_xbee)]
 
         if found:
             already_in_scan = False

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2125,6 +2125,12 @@ class XBeeDevice(AbstractXBeeDevice):
             if self._packet_listener else None
         mp_data_cbs = self._packet_listener.get_micropython_data_received_callbacks() \
             if self._packet_listener else None
+        socket_st_cbs = self._packet_listener.get_socket_state_received_callbacks() \
+            if self._packet_listener else None
+        socket_data_cbs = self._packet_listener.get_socket_data_received_callbacks() \
+            if self._packet_listener else None
+        socket_data_from_cbs = self._packet_listener.get_socket_data_received_from_callbacks() \
+            if self._packet_listener else None
 
         self._comm_iface.open()
         self._log.info("%s port opened" % self._comm_iface)
@@ -2147,6 +2153,9 @@ class XBeeDevice(AbstractXBeeDevice):
         self._packet_listener.add_user_data_relay_received_callback(user_data_relay_cbs)
         self._packet_listener.add_bluetooth_data_received_callback(bt_data_cbs)
         self._packet_listener.add_micropython_data_received_callback(mp_data_cbs)
+        self._packet_listener.add_socket_state_received_callback(socket_st_cbs)
+        self._packet_listener.add_socket_data_received_callback(socket_data_cbs)
+        self._packet_listener.add_socket_data_received_from_callback(socket_data_from_cbs)
 
         self._packet_listener.start()
         self._packet_listener.wait_until_started()

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -4219,6 +4219,59 @@ class ZigBeeDevice(XBeeDevice):
         """
         super()._force_disassociate()
 
+    def get_many_to_one_broadcasting_time(self):
+        """
+        Returns the time between aggregation route broadcast in seconds.
+
+        Returns:
+            Integer: The number of seconds between aggregation route broadcasts.
+                -1 if it is disabled.
+
+        Raises:
+            TimeoutException: If the response is not received before the read
+                timeout expires.
+            XBeeException: If the XBee device's serial port is closed.
+            InvalidOperatingModeException: If the XBee device's operating mode
+                is not API or ESCAPED API. This method only checks the cached
+                value of the operating mode.
+            ATCommandException: If the response is not as expected.
+        """
+        seconds = utils.bytes_to_int(self.get_parameter(ATStringCommand.AR.command))
+        # 0xFF disables aggregation route broadcasting
+        if seconds == 0xFF:
+            return -1
+
+        return seconds
+
+    def set_many_to_one_broadcasting_time(self, seconds):
+        """
+        Configures the time between aggregation route broadcast in seconds.
+
+        Args:
+            seconds (Integer): The number of seconds between aggregation route
+                broadcasts. -1 to disable. 0 to only send one broadcast.
+
+        Raises:
+            TimeoutException: If the response is not received before the read
+                timeout expires.
+            XBeeException: If the XBee device's serial port is closed.
+            InvalidOperatingModeException: If the XBee device's operating mode
+                is not API or ESCAPED API. This method only checks the cached
+                value of the operating mode.
+            ATCommandException: If the response is not as expected.
+            ValueError: If ``seconds`` is ``None`` or is lower than -1, or
+                bigger than 254.
+        """
+        if seconds is None:
+            raise ValueError("The number of seconds cannot be None")
+        if seconds < -1 or seconds > 0xFE:
+            raise ValueError("The number of seconds must be between -1 and 254")
+
+        if seconds == -1:
+            seconds = 0xFF
+
+        self.set_parameter(ATStringCommand.AR.command, bytearray([seconds]))
+
     def send_data_64_16(self, x64addr, x16addr, data, transmit_options=TransmitOptions.NONE.value):
         """
         Override.

--- a/digi/xbee/models/atcomm.py
+++ b/digi/xbee/models/atcomm.py
@@ -28,6 +28,7 @@ class ATStringCommand(Enum):
     """
 
     AC = ("AC", "Apply changes")
+    AG = ("AG", "Aggregator support")
     AI = ("AI", "Association indication")
     AO = ("AO", "API options")
     AP = ("AP", "API enable")

--- a/digi/xbee/models/atcomm.py
+++ b/digi/xbee/models/atcomm.py
@@ -31,6 +31,7 @@ class ATStringCommand(Enum):
     AI = ("AI", "Association indication")
     AO = ("AO", "API options")
     AP = ("AP", "API enable")
+    AR = ("AR", "Many-to-one route broadcast time")
     AS = ("AS", "Active scan")
     BD = ("BD", "UART baudrate")
     BL = ("BL", "Bluetooth address")

--- a/digi/xbee/packets/aft.py
+++ b/digi/xbee/packets/aft.py
@@ -56,6 +56,7 @@ class ApiFrameType(Enum):
     TX_STATUS = (0x89, "TX (Transmit) Status")
     MODEM_STATUS = (0x8A, "Modem Status")
     TRANSMIT_STATUS = (0x8B, "Transmit Status")
+    DIGIMESH_ROUTE_INFORMATION = (0x8D, "Route Information")
     IO_DATA_SAMPLE_RX_INDICATOR_WIFI = (0x8F, "IO Data Sample RX Indicator (Wi-Fi)")
     RECEIVE_PACKET = (0x90, "Receive Packet")
     EXPLICIT_RX_INDICATOR = (0x91, "Explicit RX Indicator")

--- a/digi/xbee/packets/aft.py
+++ b/digi/xbee/packets/aft.py
@@ -62,6 +62,7 @@ class ApiFrameType(Enum):
     IO_DATA_SAMPLE_RX_INDICATOR = (0x92, "IO Data Sample RX Indicator")
     REMOTE_AT_COMMAND_RESPONSE = (0x97, "Remote Command Response")
     RX_SMS = (0x9F, "RX SMS")
+    ROUTE_RECORD_INDICATOR = (0xA1, "Route Record Indicator")
     REGISTER_JOINING_DEVICE_STATUS = (0xA4, "Register Joining Device Status")
     USER_DATA_RELAY_OUTPUT = (0xAD, "User Data Relay Output")
     RX_IPV4 = (0xB0, "RX IPv4")

--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -88,6 +88,8 @@ class DictKeys(Enum):
     CLIENT_SOCKET_ID = "client_socket_id"
     REMOTE_ADDR = "remote_address"
     REMOTE_PORT = "remote_port"
+    NUM_OF_HOPS = "number_hops"
+    HOPS = "hops"
 
 
 class XBeePacket:

--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -90,6 +90,14 @@ class DictKeys(Enum):
     REMOTE_PORT = "remote_port"
     NUM_OF_HOPS = "number_hops"
     HOPS = "hops"
+    SRC_EVENT = "src_event"
+    TIMESTAMP = "timestamp"
+    ACK_TIMEOUT_COUNT = "ack_timeout_count"
+    TX_BLOCKED_COUNT = "tx_blocked_count"
+    SRC_ADDR = "src_address"
+    RESPONDER_ADDR = "responder_address"
+    SUCCESSOR_ADDR = "successor_address"
+    ADDITIONAL_DATA = "additional_data"
 
 
 class XBeePacket:

--- a/digi/xbee/packets/digimesh.py
+++ b/digi/xbee/packets/digimesh.py
@@ -1,0 +1,449 @@
+# Copyright 2019, Digi International Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+
+from digi.xbee.exception import InvalidOperatingModeException, InvalidPacketException
+from digi.xbee.models.address import XBee64BitAddress
+from digi.xbee.models.mode import OperatingMode
+from digi.xbee.packets.aft import ApiFrameType
+from digi.xbee.packets.base import XBeeAPIPacket, DictKeys
+from digi.xbee.util import utils
+
+
+class RouteInformationPacket(XBeeAPIPacket):
+    """
+    This class represents a DigiMesh Route Information packet. Packet is built
+    using the parameters of the constructor or providing a valid API
+    payload.
+
+    A Route Information Packet can be output for DigiMesh unicast transmissions
+    on which the NACK enable or the Trace Route enable TX option is enabled.
+
+    .. seealso::
+       | :class:`.XBeeAPIPacket`
+    """
+
+    __MIN_PACKET_LENGTH = 46
+
+    def __init__(self, src_event, timestamp, ack_timeout_count, tx_block_count,
+                 dst_addr, src_addr, responder_addr, successor_addr,
+                 additional_data=None):
+        """
+        Class constructor. Instantiates a new
+        :class:`.RouteInformationPacket` object with the provided
+        parameters.
+
+        Args:
+            src_event (Integer): Source event identifier.
+                0x11=NACK, 0x12=Trace route
+            timestamp (Integer): System timer value on the node generating the
+                this packet. The timestamp is in microseconds.
+            ack_timeout_count (Integer): The number of MAC ACK timeouts.
+            tx_block_count (Integer): The number of times the transmission was
+                blocked due to reception in progress.
+            dst_addr (:class:`.XBee64BitAddress`): The 64-bit address of the
+                final destination node of this network-level transmission.
+            src_addr (:class:`.XBee64BitAddress`): The 64-bit address of the
+                source node of this network-level transmission.
+            responder_addr (:class:`.XBee64BitAddress`): The 64-bit address of
+                the node that generates this packet after it sends
+                (or attempts to send) the packet to the next hop (successor node).
+            successor_addr (:class:`.XBee64BitAddress`): The 64-bit address of
+                the next node after the responder in the route towards the
+                destination, whether or not the packet arrived successfully at
+                the successor node.
+            additional_data (Bytearray, optional, default=`None`): Additional
+                data of the packet.
+
+        Raises:
+            ValueError: if ``src_event`` is not 0x11 or 0x12.
+            ValueError: if ``timestamp`` is not between 0 and 0xFFFFFFFF.
+            ValueError: if ``ack_timeout_count`` or ``tx_block_count`` are not
+                between 0 and 255.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+           | :class:`.XBeeAPIPacket`
+        """
+        if src_event not in [0x11, 0x12]:
+            raise ValueError("Source event must be 0x11 or 0x12.")
+        if timestamp < 0 or timestamp > 0xFFFFFFFF:  # 4 bytes
+            raise ValueError("Timestamp must be between 0 and %d." % 0xFFFFFFFF)
+        if ack_timeout_count < 0 or ack_timeout_count > 0xFF:  # 1 byte
+            raise ValueError("ACK timeout count must be between 0 and 255")
+        if tx_block_count < 0 or tx_block_count > 0xFF:  # 1 byte
+            raise ValueError("TX blocked count must be between 0 and 255")
+
+        super().__init__(ApiFrameType.DIGIMESH_ROUTE_INFORMATION)
+
+        self.__src_event = src_event
+        self.__timestamp = timestamp
+        self.__ack_timeout_count = ack_timeout_count
+        self.__tx_block_count = tx_block_count
+        self.__reserved = 0
+        self.__dst_addr = dst_addr
+        self.__src_addr = src_addr
+        self.__responder_addr = responder_addr
+        self.__successor_addr = successor_addr
+        self.__additional_data = additional_data
+
+    @staticmethod
+    def create_packet(raw, operating_mode):
+        """
+        Override method.
+
+        Returns:
+            :class:`.RouteInformationPacket`.
+
+        Raises:
+            InvalidPacketException: If the bytearray length is less than 46.
+                (start delim. + length (2 bytes) + frame type + src_event
+                 + length + timestamp (4 bytes) + ack timeout count
+                 + tx blocked count + reserved + dest addr (8 bytes)
+                 + src addr (8 bytes) + responder addr (8 bytes)
+                 + succesor addr (8 bytes) + checksum = 46 bytes).
+            InvalidPacketException: If the length field of `raw` is different
+                from its real length. (length field: bytes 1 and 3)
+            InvalidPacketException: If the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: If the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: If the frame type is not
+                :attr:`.ApiFrameType.DIGIMESH_ROUTE_INFORMATION`.
+            InvalidPacketException: If the internal length byte of the rest
+                of the frame (without the checksum) is different from its real
+                length.
+            InvalidOperatingModeException: If ``operating_mode`` is not
+                supported.
+
+        .. seealso::
+           | :meth:`.XBeePacket.create_packet`
+           | :meth:`.XBeeAPIPacket._check_api_packet`
+        """
+        if operating_mode not in [OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE]:
+            raise InvalidOperatingModeException(
+                operating_mode.name + " is not supported.")
+
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=RouteInformationPacket.__MIN_PACKET_LENGTH)
+
+        if raw[3] != ApiFrameType.DIGIMESH_ROUTE_INFORMATION.code:
+            raise InvalidPacketException(
+                "This packet is not a Route Information packet.")
+
+        # 7: frame len starting from this byte (index 5) and without the checksum
+        if raw[5] != len(raw) - 7:
+            raise InvalidPacketException("Length does not match with the data length")
+
+        additional_data = []
+        if len(raw) > RouteInformationPacket.__MIN_PACKET_LENGTH:
+            additional_data = raw[45:]
+        packet = RouteInformationPacket(raw[4], utils.bytes_to_int(raw[6:10]),
+                                        raw[10], raw[11],
+                                        XBee64BitAddress(raw[13:21]),
+                                        XBee64BitAddress(raw[21:29]),
+                                        XBee64BitAddress(raw[29:37]),
+                                        XBee64BitAddress(raw[37:45]),
+                                        additional_data)
+        packet.__reserved = raw[12]
+
+        return packet
+
+    def needs_id(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.needs_id`
+        """
+        return False
+
+    def _get_api_packet_spec_data(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
+        """
+        ret = bytearray([self.__src_event])
+        ret.append(self.length)
+        ret += utils.int_to_bytes(self.__timestamp, num_bytes=4)
+        ret.append(self.__ack_timeout_count)
+        ret.append(self.__tx_block_count)
+        ret.append(self.__reserved)
+        ret += self.__dst_addr.address
+        ret += self.__src_addr.address
+        ret += self.__responder_addr.address
+        ret += self.__successor_addr.address
+        if self.__additional_data:
+            ret += self.__additional_data
+
+        return ret
+
+    def _get_api_packet_spec_data_dict(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_api_packet_spec_data_dict`
+        """
+        return {DictKeys.SRC_EVENT:         self.__src_event,
+                DictKeys.LENGTH:            self.length,
+                DictKeys.TIMESTAMP:         self.__timestamp,
+                DictKeys.ACK_TIMEOUT_COUNT: self.__ack_timeout_count,
+                DictKeys.TX_BLOCKED_COUNT:  self.__tx_block_count,
+                DictKeys.DEST_ADDR:         self.__dst_addr,
+                DictKeys.SRC_ADDR:          self.__src_addr,
+                DictKeys.RESPONDER_ADDR:    self.__responder_addr,
+                DictKeys.SUCCESSOR_ADDR:    self.__successor_addr,
+                DictKeys.ADDITIONAL_DATA:   self.__additional_data}
+
+    @property
+    def src_event(self):
+        """
+        Returns the source event.
+
+        Returns:
+            Integer: The source event.
+        """
+        return self.__src_event
+
+    @src_event.setter
+    def src_event(self, src_event):
+        """
+        Sets the source event identifier. 0x11=NACK, 0x12=Trace route
+
+        Args:
+            src_event (Integer): The new source event.
+
+        Raises:
+            ValueError: if ``src_event`` is not 0x11 or 0x12.
+        """
+        if src_event not in [0x11, 0x12]:
+            raise ValueError("Source event must be 0x11 or 0x12.")
+
+        self.__src_event = src_event
+
+    @property
+    def length(self):
+        """
+        Returns the number of bytes that follow, excluding the checksum.
+
+        Returns:
+            Integer: Data length.
+
+        """
+        # len: len(additional_data) + 4 MACS + timestamp (4 bytes) + 3 bytes
+        return len(self.__additional_data) + 8 * 4 + 4 + 3
+
+    @property
+    def timestamp(self):
+        """
+        Returns the system timer value on the node generating this package.
+        The timestamp is in microseconds.
+
+        Returns:
+            Integer: The system timer value in microseconds.
+        """
+        return self.__timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """
+        Sets the system timer value on the node generating this package.
+        The timestamp is in microseconds.
+
+        Args:
+            timestamp (Integer): The number of microseconds.
+
+        Raises:
+            ValueError: if ``timestamp`` is not between 0 and 0xFFFFFFFF.
+        """
+        if timestamp < 0 or timestamp > 0xFFFFFFFF:  # 4 bytes
+            raise ValueError("Timestamp must be between 0 and %d." % 0xFFFFFFFF)
+
+        self.__timestamp = timestamp
+
+    @property
+    def ack_timeout_count(self):
+        """
+        Returns the number of MAC ACK timeouts that occur.
+
+        Returns:
+            Integer: The number of MAC ACK timeouts that occur.
+        """
+        return self.__ack_timeout_count
+
+    @ack_timeout_count.setter
+    def ack_timeout_count(self, ack_timeout_count):
+        """
+        Sets the number of MAC ACK timeouts that occur.
+
+        Args:
+            ack_timeout_count (Integer): The number of MAC ACK timeouts that occur.
+
+        Raises:
+            ValueError: if ``ack_timeout_count`` is not between 0 and 255.
+        """
+        if ack_timeout_count < 0 or ack_timeout_count > 0xFF:  # 1 byte
+            raise ValueError("ACK timeout count must be between 0 and 255")
+
+        self.__ack_timeout_count = ack_timeout_count
+
+    @property
+    def tx_block_count(self):
+        """
+        Returns the number of times the transmission was blocked due to reception
+        in progress.
+
+        Returns:
+            Integer: The number of times the transmission was blocked due to
+                reception in progress.
+        """
+        return self.__tx_block_count
+
+    @tx_block_count.setter
+    def tx_block_count(self, tx_block_count):
+        """
+        Sets the number of times the transmission was blocked due to reception
+        in progress.
+
+        Args:
+            tx_block_count (Integer): The number of times the transmission was
+                blocked due to reception in progress.
+
+        Raises:
+            ValueError: if ``tx_block_count`` is not between 0 and 255.
+        """
+        if tx_block_count < 0 or tx_block_count > 0xFF:  # 1 byte
+            raise ValueError("TX blocked count must be between 0 and 255")
+
+        self.__tx_block_count = tx_block_count
+
+    @property
+    def dst_addr(self):
+        """
+        Returns the 64-bit source address.
+
+        Returns:
+            :class:`.XBee64BitAddress`: The 64-bit address of the final
+                destination node.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+        """
+        return self.__dst_addr
+
+    @dst_addr.setter
+    def dst_addr(self, dst_addr):
+        """
+        Sets the 64-bit address of the final destination node of this
+        network-level transmission.
+
+        Args:
+            dst_addr (:class:`.XBee64BitAddress`): The new 64-bit address of the
+                final destination node.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+        """
+        self.__dst_addr = dst_addr
+
+    @property
+    def src_addr(self):
+        """
+        Returns the 64-bit address of the source node of this network-level
+        transmission.
+
+        Returns:
+            :class:`.XBee64BitAddress`: The 64-bit address of the source node.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+        """
+        return self.__src_addr
+
+    @src_addr.setter
+    def src_addr(self, src_addr):
+        """
+        Sets the 64-bit address of the source node of this network-level
+        transmission.
+
+        Args:
+            src_addr (:class:`.XBee64BitAddress`): The new 64-bit address of the
+                source node.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+        """
+        self.__src_addr = src_addr
+
+    @property
+    def responder_addr(self):
+        """
+        Returns the 64-bit address of the node that generates this packet after
+        it sends (or attempts to send) the packet to the next hop (successor node).
+
+        Returns:
+            :class:`.XBee64BitAddress`: The 64-bit address of the responder node.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+        """
+        return self.__responder_addr
+
+    @responder_addr.setter
+    def responder_addr(self, responder_addr):
+        """
+        Sets the 64-bit address of the node that generates this packet after it
+        sends (or attempts to send) the packet to the next hop (successor node).
+
+        Args:
+            responder_addr (:class:`.XBee64BitAddress`): The new 64-bit address
+                of the responder node.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+        """
+        self.__responder_addr = responder_addr
+
+    @property
+    def successor_addr(self):
+        """
+        Returns the 64-bit address of the next node after the responder in the
+        route towards the destination, whether or not the packet arrived
+        successfully at the successor node.
+
+        Returns:
+            :class:`.XBee64BitAddress`: The 64-bit address of the successor node.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+        """
+        return self.__successor_addr
+
+    @successor_addr.setter
+    def successor_addr(self, successor_addr):
+        """
+        Sets the 64-bit address of the next node after the responder in the
+        route towards the destination, whether or not the packet arrived
+        successfully at the successor node.
+
+        Args:
+            successor_addr (:class:`.XBee64BitAddress`): The new 64-bit address
+                of the successor node.
+
+        .. seealso::
+           | :class:`.XBee64BitAddress`
+        """
+        self.__successor_addr = successor_addr

--- a/digi/xbee/packets/factory.py
+++ b/digi/xbee/packets/factory.py
@@ -16,6 +16,7 @@ from digi.xbee.packets.base import *
 from digi.xbee.packets.cellular import *
 from digi.xbee.packets.common import *
 from digi.xbee.packets.devicecloud import *
+from digi.xbee.packets.digimesh import RouteInformationPacket
 from digi.xbee.packets.network import *
 from digi.xbee.packets.raw import *
 from digi.xbee.packets.relay import *
@@ -272,6 +273,9 @@ def build_frame(packet_bytearray, operating_mode=OperatingMode.API_MODE):
 
     elif frame_type == ApiFrameType.SOCKET_STATE:
         return SocketStatePacket.create_packet(packet_bytearray, operating_mode)
+
+    elif frame_type == ApiFrameType.DIGIMESH_ROUTE_INFORMATION:
+        return RouteInformationPacket.create_packet(packet_bytearray, operating_mode)
 
     else:
         return UnknownXBeePacket.create_packet(packet_bytearray, operating_mode=operating_mode)

--- a/digi/xbee/packets/factory.py
+++ b/digi/xbee/packets/factory.py
@@ -23,7 +23,8 @@ from digi.xbee.packets.socket import *
 from digi.xbee.packets.wifi import *
 from digi.xbee.packets.aft import ApiFrameType
 from digi.xbee.models.mode import OperatingMode
-from digi.xbee.packets.zigbee import RegisterJoiningDevicePacket, RegisterDeviceStatusPacket
+from digi.xbee.packets.zigbee import RegisterJoiningDevicePacket,\
+    RegisterDeviceStatusPacket, RouteRecordIndicatorPacket
 
 """
 This module provides functionality to build XBee packets from
@@ -220,6 +221,9 @@ def build_frame(packet_bytearray, operating_mode=OperatingMode.API_MODE):
 
     elif frame_type == ApiFrameType.REGISTER_JOINING_DEVICE_STATUS:
         return RegisterDeviceStatusPacket.create_packet(packet_bytearray, operating_mode)
+
+    elif frame_type == ApiFrameType.ROUTE_RECORD_INDICATOR:
+        return RouteRecordIndicatorPacket.create_packet(packet_bytearray, operating_mode)
 
     elif frame_type == ApiFrameType.SOCKET_CREATE:
         return SocketCreatePacket.create_packet(packet_bytearray, operating_mode)

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -380,6 +380,22 @@ class RouteInformationReceived(XBeeEvent):
     pass
 
 
+class RouteReceived(XBeeEvent):
+    """
+    This event is fired when a route is received.
+
+    The callbacks to handle these events will receive the following arguments:
+        1. source (:class:`.XBeeDevice`): The local node.
+        2. destination (:class:`.RemoteXBeeDevice`): The remote node.
+        3. hops (List): List of intermediate hops from source node to
+            closest to destination (:class:`.RemoteXBeeDevice`).
+
+    .. seealso::
+       | :class:`.XBeeEvent`
+    """
+    pass
+
+
 class InitDiscoveryScan(XBeeEvent):
     """
     This event is fired when a new network discovery scan is about to start.

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -335,6 +335,34 @@ class SocketDataReceivedFrom(XBeeEvent):
     pass
 
 
+class InitDiscoveryScan(XBeeEvent):
+    """
+    This event is fired when a new network discovery scan is about to start.
+
+    The callbacks to handle these events will receive the following arguments:
+        1. Number of scan to start (starting with 1).
+        2. Total number of scans.
+
+    .. seealso::
+       | :class:`.XBeeEvent`
+    """
+    pass
+
+
+class EndDiscoveryScan(XBeeEvent):
+    """
+    This event is fired when a network discovery scan has just finished.
+
+    The callbacks to handle these events will receive the following arguments:
+        1. Number of scan that has finished (starting with 1).
+        2. Total number of scans.
+
+    .. seealso::
+       | :class:`.XBeeEvent`
+    """
+    pass
+
+
 class PacketListener(threading.Thread):
     """
     This class represents a packet listener, which is a thread that's always

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -982,6 +982,33 @@ class PacketListener(threading.Thread):
         """
         return self.__micropython_data_received
 
+    def get_socket_state_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received socket state.
+
+        Returns:
+            List: List of :class:`.SocketStateReceived` events.
+        """
+        return self.__socket_state_received
+
+    def get_socket_data_received_callbacks(self):
+        """
+        Returns the list of registered callbacks for received socket data.
+
+        Returns:
+            List: List of :class:`.SocketDataReceived` events.
+        """
+        return self.__socket_data_received
+
+    def get_socket_data_received_from_callbacks(self):
+        """
+        Returns the list of registered callbacks for received socket data from.
+
+        Returns:
+            List: List of :class:`.SocketDataReceivedFrom` events.
+        """
+        return self.__socket_data_received_from
+
     def __execute_user_callbacks(self, xbee_packet, remote=None):
         """
         Executes callbacks corresponding to the received packet.

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -1110,17 +1110,6 @@ class PacketListener(threading.Thread):
                                                     more_data="%s - %s" % (address,
                                                                            utils.hex_to_string(xbee_packet.payload))))
 
-    def __create_remote_device_from_packet(self, xbee_packet):
-        """
-        Creates a :class:`.RemoteXBeeDevice` that represents the device that
-        has sent the ``xbee_packet``.
-
-        Returns:
-            :class:`.RemoteXBeeDevice`
-        """
-        x64bit_addr, x16bit_addr = self.__get_remote_device_data_from_packet(xbee_packet)
-        return digi.xbee.devices.RemoteXBeeDevice(self.__xbee_device, x64bit_addr=x64bit_addr,
-                                                  x16bit_addr=x16bit_addr)
 
     @staticmethod
     def __get_remote_device_data_from_packet(xbee_packet):

--- a/doc/api/digi.xbee.packets.digimesh.rst
+++ b/doc/api/digi.xbee.packets.digimesh.rst
@@ -1,0 +1,7 @@
+digi\.xbee\.packets\.digimesh module
+===================================
+
+.. automodule:: digi.xbee.packets.digimesh
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/doc/api/digi.xbee.packets.rst
+++ b/doc/api/digi.xbee.packets.rst
@@ -16,6 +16,7 @@ Submodules
    digi.xbee.packets.cellular
    digi.xbee.packets.common
    digi.xbee.packets.devicecloud
+   digi.xbee.packets.digimesh
    digi.xbee.packets.network
    digi.xbee.packets.raw
    digi.xbee.packets.relay


### PR DESCRIPTION
Added a method and a callback to get the Zigbee source routes and DigiMesh trace routes from local to a remote node.