### PR TITLE
Bugfix/ATMode with s2c pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /doc/_build
 .idea
 venv/
+.venv/

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2120,6 +2120,11 @@ class XBeeDevice(AbstractXBeeDevice):
     Command to change Operating Mode to Escaped API Mode
     """
 
+    __COMMAND_CLOSE_COMMAND_MODE = "ATCN\r"
+    """
+    Command to leave COMMAND MODE
+    """
+
     def __init__(self, port=None, baud_rate=None, data_bits=serial.EIGHTBITS, stop_bits=serial.STOPBITS_ONE,
                  parity=serial.PARITY_NONE, flow_control=FlowControl.NONE,
                  _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS, comm_iface=None):

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2331,16 +2331,19 @@ class XBeeDevice(AbstractXBeeDevice):
         """
         try:
             if self._serial_port is not None:
+                self._log.warning(f"Changing Operating Mode to {OperatingMode.ESCAPED_API_MODE}")
                 command_mode_ok_bytes = bytes(self.__COMMAND_MODE_OK, "utf-8")
                 self._serial_port.reset_output_buffer()
                 size = self._serial_port.write(bytes(self.__COMMAND_MODE_CHAR * 3, "utf-8"))
-                response_cmd_mode = self._serial_port.read(size=size+1)
+                response_cmd_mode = self._serial_port.read(size=size+1)  # + 1 to size otherwise communication freezes
                 if command_mode_ok_bytes in response_cmd_mode:
                     response_size = self._serial_port.write(bytes(self.__COMMAND_ESCAPED_API_MODE, "utf-8"))
-                    response_at_command = self.serial_port.read(size=response_size + 1)
+                    response_at_command = self.serial_port.read(size=response_size + 1)  # + 1 to size otherwise communication freezes
                     if command_mode_ok_bytes in response_at_command:
                         self._operating_mode = OperatingMode.ESCAPED_API_MODE
                         self._log.warning(f"Changed mode to {OperatingMode.ESCAPED_API_MODE}")
+                        self._serial_port.write(bytes(self.__COMMAND_CLOSE_COMMAND_MODE, "utf-8"))
+                        self._serial_port.reset_output_buffer()
                     else:
                         raise TimeoutException
                 else:

--- a/digi/xbee/serial.py
+++ b/digi/xbee/serial.py
@@ -12,9 +12,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import abc
 import time
-from abc import abstractmethod, ABCMeta
 
 from digi.xbee.comm_interface import XBeeCommunicationInterface
 from digi.xbee.models.atcomm import SpecialByte


### PR DESCRIPTION
I decided to change the behavior of the library when it comes to opening the port with a radio that is not in Escaped API mode or API mode.

I have made a few tests on a Xbee S2C TH which seems to work fine. I only get a TimeoutException when the change to Escaped API Mode is made.

If you have any better implementation to propose I am all ears! 

 