### PR TITLE
firmware: wait for target reset before restoring updater

### DIFF
--- a/digi/xbee/firmware.py
+++ b/digi/xbee/firmware.py
@@ -1046,14 +1046,14 @@ class _XBeeFirmwareUpdater(ABC):
         # Finish the firmware update process.
         self._finish_firmware_update()
 
+        # Wait for target to reset.
+        self._wait_for_target_reset()
+
         # Leave updater in its original state.
         try:
             self._restore_updater()
         except Exception as e:
             raise FirmwareUpdateException(_ERROR_RESTORE_TARGET_CONNECTION % str(e))
-
-        # Wait for target to reset.
-        self._wait_for_target_reset()
 
         _log.info("Update process finished successfully")
 


### PR DESCRIPTION
When the XBee was open before starting the firmware update, the code will
try to open it again when the firmware update is done.
In order for his open operation to be successful, we need to wait for the
target to reset first.

Signed-off-by: Isaac Hermida <isaac.hermida@digi.com>