### PR TITLE
firmware: ota: set 'upgrade time' with the same value as 'current time'

### DIFF
--- a/digi/xbee/firmware.py
+++ b/digi/xbee/firmware.py
@@ -2084,12 +2084,14 @@ class _RemoteFirmwareUpdater(_XBeeFirmwareUpdater):
         Returns:
             Bytearray: the upgrade end response frame.
         """
+        current_time = utils.int_to_bytes(int(time.time()) - _TIME_SECONDS_1970_TO_2000, 4)
+
         payload = bytearray()
         payload.extend(_reverse_bytearray(utils.int_to_bytes(self._ota_file.manufacturer_code, 2)))
         payload.extend(_reverse_bytearray(utils.int_to_bytes(self._ota_file.image_type, 2)))
         payload.extend(_reverse_bytearray(utils.int_to_bytes(self._ota_file.file_version, 4)))
-        payload.extend(_reverse_bytearray(utils.int_to_bytes(int(time.time()) - _TIME_SECONDS_1970_TO_2000, 4)))
-        payload.extend(_reverse_bytearray(utils.int_to_bytes(0, 4)))
+        payload.extend(_reverse_bytearray(current_time))
+        payload.extend(_reverse_bytearray(current_time))
 
         return self._create_zdo_frame(_ZDO_FRAME_CONTROL_SERVER_TO_CLIENT, self._seq_number,
                                       _ZDO_COMMAND_ID_UPGRADE_END_RESP, payload)


### PR DESCRIPTION
This commit configures the 'current time' and 'upgrade time' fields of the
'Upgrade End Response' explicit packet with the same value for an immediate
update after transferring the OTA file.

Starting from Zigbee 100A firmware versions (I guess next versions of DigiMesh
and 802.15.4 too), the OTA firmware update process supports scheduled updates.
This means the 'Upgrade End Response' explicit packet must set the
'upgrade time' to:

   * the same value as 'current time' (immediate update)
   * a bigger value than 'current time' (scheduled updates)
   * or 0xFFFFFFFF (update delayed until another 'Upgrade End Response' is
     received by the client)

https://jira.digi.com/browse/XBPL-350