### PR TITLE
profile: pass integer to progress callback

### DIFF
--- a/digi/xbee/profile.py
+++ b/digi/xbee/profile.py
@@ -1097,7 +1097,7 @@ class _ProfileUpdater(object):
         """
         _log.debug("Reading device parameters:")
         if self._progress_callback is not None:
-            self._progress_callback(_TASK_READING_DEVICE_PARAMETERS, None)
+            self._progress_callback(_TASK_READING_DEVICE_PARAMETERS, 0)
         if self._is_local:
             # Connect the device.
             if not self._xbee_device.is_open():


### PR DESCRIPTION
The update status callback expects an integer percentage, so pass a 0
instead of None.

This prevents the XNM creating a status JSON with a null percentage:

{
  "client-id" : "myMQTTClientID",
  "request" : "profile-update",
  "timeout" : 13,
  "max-sleep-time" : 120,
  "status" : [ {
    "xpro-file" : "/etc/config/xbee-profiles/profile_1009_NI.xpro",
    "node" : {
      "64bit" : "0013A2004195C889",
      "16bit" : "FFFE"
    },
    "pct" : null,
    "code" : 2,
    "desc" : "In progress: Reading device parameters"
  } ]
}

Signed-off-by: Javier Viguera <javier.viguera@digi.com>