### PR TITLE
serial: save timeout parameter in the constructor

### DIFF
--- a/digi/xbee/serial.py
+++ b/digi/xbee/serial.py
@@ -87,6 +87,7 @@ class XBeeSerialPort(Serial, XBeeCommunicationInterface):
             Serial.__init__(self, port=None, baudrate=baud_rate,
                             bytesize=data_bits, stopbits=stop_bits, parity=parity, timeout=timeout)
         self.__port_to_open = port
+        self.timeout = timeout
         self._isReading = False
 
     def __str__(self):


### PR DESCRIPTION
'quit_reading' function uses this variable, so it needs to be saved.

Otherwise there are code paths (seen once using XNM) that allows to
reach that point causing an exception:

> File "/usr/bin/xnm", line 175, in <module> main()
> File "/usr/bin/xnm", line 171, in main event.wait()
> File "/usr/bin/xnm", line 158, in terminate_gracefully xbeemqtt.stop()
> File "/usr/lib/python3.6/site-packages/digi/xnm/bridge.py", line 3256, in stop self.__xbc.disconnect()
> File "/usr/lib/python3.6/site-packages/digi/xnm/bridge.py", line 2564, in disconnect self.__xbee.close()
> File "/usr/lib/python3.6/site-packages/digi/xbee/devices.py", line 2375, in close self._packet_listener.stop()
> File "/usr/lib/python3.6/site-packages/digi/xbee/reader.py", line 603, in stop self.__comm_iface.quit_reading()
> File "/usr/lib/python3.6/site-packages/digi/xbee/serial.py", line 196, in quit_reading time.sleep(self.timeout)
> TypeError: an integer is required (got type NoneType)
> 
