### PR TITLE
at commands: use upper case commands before comparing

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -338,7 +338,7 @@ class AbstractXBeeDevice(object):
         # Check if the parameter matches the apply changes or write settings command
         # and we have the operation mode pending to update.
         if not self.is_remote() \
-                and (parameter in (ATStringCommand.AC.command, ATStringCommand.WR.command)) \
+                and (parameter.upper() in (ATStringCommand.AC.command, ATStringCommand.WR.command)) \
                 and self._future_operating_mode is not None:
             self._operating_mode = self._future_operating_mode
             self._future_operating_mode = None
@@ -1657,17 +1657,17 @@ class AbstractXBeeDevice(object):
         updated = False
 
         # Node identifier
-        if parameter == ATStringCommand.NI.command:
+        if parameter.upper() == ATStringCommand.NI.command:
             node_id = value.decode()
             updated = self._node_id != node_id
             self._node_id = node_id
         # 16-bit address
-        elif parameter == ATStringCommand.MY.command:
+        elif parameter.upper() == ATStringCommand.MY.command:
             x16bit_addr = XBee16BitAddress(value)
             updated = self._16bit_addr != x16bit_addr
             self._16bit_addr = x16bit_addr
         # Operating mode
-        elif parameter == ATStringCommand.AP.command:
+        elif parameter.upper() == ATStringCommand.AP.command:
             # Only update the cached operating mode if the setting has been written. If not,
             # just store the new value and update it after applying or writing settings.
             if self.is_apply_changes_enabled():
@@ -1859,13 +1859,13 @@ class AbstractXBeeDevice(object):
                 # the command matches in both packets.
                 if packet_to_send.get_frame_type() == ApiFrameType.AT_COMMAND \
                         and (received_packet.get_frame_type() != ApiFrameType.AT_COMMAND_RESPONSE
-                             or packet_to_send.command != received_packet.command):
+                             or packet_to_send.command.upper() != received_packet.command.upper()):
                     return
                 # If the packet sent is a remote AT command, verify that the received one is a remote AT command
                 # response and the command matches in both packets.
                 if packet_to_send.get_frame_type() == ApiFrameType.REMOTE_AT_COMMAND_REQUEST \
                         and (received_packet.get_frame_type() != ApiFrameType.REMOTE_AT_COMMAND_RESPONSE
-                             or packet_to_send.command != received_packet.command
+                             or packet_to_send.command.upper() != received_packet.command.upper()
                              or (packet_to_send.x64bit_dest_addr != XBee64BitAddress.BROADCAST_ADDRESS
                                  and packet_to_send.x64bit_dest_addr != XBee64BitAddress.UNKNOWN_ADDRESS
                                  and packet_to_send.x64bit_dest_addr != received_packet.x64bit_source_addr)
@@ -6394,7 +6394,7 @@ class WiFiDevice(IPDevice):
                 return
             if xbee_packet.get_frame_type() != ApiFrameType.AT_COMMAND_RESPONSE:
                 return
-            if xbee_packet.command != ATStringCommand.AS.command:
+            if xbee_packet.command.upper() != ATStringCommand.AS.command:
                 return
 
             # Check for error.
@@ -8648,7 +8648,7 @@ class XBeeNetwork(object):
                  * :attr:`.XBeeNetwork.ND_PACKET_REMOTE`: if ``xbee_packet`` has info about a remote XBee device.
         """
         if (xbee_packet.get_frame_type() == ApiFrameType.AT_COMMAND_RESPONSE and
-           xbee_packet.command == ATStringCommand.ND.command):
+           xbee_packet.command.upper() == ATStringCommand.ND.command):
             if xbee_packet.command_value is None or len(xbee_packet.command_value) == 0:
                 return XBeeNetwork.ND_PACKET_FINISH
             else:

--- a/digi/xbee/filesystem.py
+++ b/digi/xbee/filesystem.py
@@ -401,7 +401,7 @@ class LocalXBeeFileSystemManager(object):
         try:
             self._serial_port.write(str.encode(_COMMAND_FILE_SYSTEM, encoding='utf-8'))
             answer = self._read_data()
-            if answer and _ANSWER_ATFS in answer:
+            if answer and _ANSWER_ATFS in answer.upper():
                 self._parse_filesystem_functions(answer.replace("\r", ""))
                 return True
 

--- a/digi/xbee/profile.py
+++ b/digi/xbee/profile.py
@@ -1205,17 +1205,17 @@ class _ProfileUpdater(object):
         stop_bits_changed = False
         cts_flow_control_changed = False
         for setting in self._xbee_profile.profile_settings:
-            if setting.name in _PARAMETERS_SERIAL_PORT:
-                if setting.name == ATStringCommand.BD.command:
+            if setting.name.upper() in _PARAMETERS_SERIAL_PORT:
+                if setting.name.upper() == ATStringCommand.BD.command:
                     baudrate_changed = True
                     port_parameters["baudrate"] = FirmwareBaudrate.get(int(setting.value, 16)).baudrate
-                elif setting.name == ATStringCommand.NB.command:
+                elif setting.name.upper() == ATStringCommand.NB.command:
                     parity_changed = True
                     port_parameters["parity"] = FirmwareParity.get(int(setting.value, 16)).parity
-                elif setting.name == ATStringCommand.SB.command:
+                elif setting.name.upper() == ATStringCommand.SB.command:
                     stop_bits_changed = True
                     port_parameters["stopbits"] = FirmwareStopbits.get(int(setting.value, 16)).stop_bits
-                elif setting.name == ATStringCommand.D7.command:
+                elif setting.name.upper() == ATStringCommand.D7.command:
                     cts_flow_control_changed = True
                     if setting.value == _VALUE_CTS_ON:
                         port_parameters["rtscts"] = True
@@ -1314,9 +1314,9 @@ class _ProfileUpdater(object):
                 self._set_parameter_with_retries(setting.name, setting.bytearray_value, _PARAMETER_WRITE_RETRIES)
                 setting_index += 1
                 # Check if the setting was sensitive for network or cache information
-                if setting.name in _PARAMETERS_NETWORK:
+                if setting.name.upper() in _PARAMETERS_NETWORK:
                     network_settings_changed = True
-                if setting.name in _PARAMETERS_CACHE:
+                if setting.name.upper() in _PARAMETERS_CACHE:
                     cache_settings_changed = True
             # Write settings.
             percent = setting_index * 100 // num_settings

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -1452,11 +1452,11 @@ class PacketListener(threading.Thread):
         if (xbee_packet.get_frame_type() in
                 [ApiFrameType.AT_COMMAND_RESPONSE, ApiFrameType.REMOTE_AT_COMMAND_RESPONSE]
                 and xbee_packet.status == ATCommandStatus.OK):
-            if xbee_packet.command == ATStringCommand.NI.command:
+            if xbee_packet.command.upper() == ATStringCommand.NI.command:
                 node_id = xbee_packet.command_value.decode()
-            elif xbee_packet.command == ATStringCommand.HV.command:
+            elif xbee_packet.command.upper() == ATStringCommand.HV.command:
                 hw_version = HardwareVersion.get(xbee_packet.command_value[0])
-            elif xbee_packet.command == ATStringCommand.VR.command:
+            elif xbee_packet.command.upper() == ATStringCommand.VR.command:
                 fw_version = xbee_packet.command_value
 
         return x64bit_addr, x16bit_addr, node_id, hw_version, fw_version


### PR DESCRIPTION
Python is case sensitive but XBees are not. This commit uses upper cases
to compare AT commands.