### PR TITLE
discovery: add description as optional param to net discovery finished callbacks

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -7851,9 +7851,10 @@ class XBeeNetwork(object):
         Adds a callback for the event :class:`.DiscoveryProcessFinished`.
 
         Args:
-            callback (Function): the callback. Receives one argument.
+            callback (Function): the callback. Receives two argument.
 
-                * The event code as an :class:`.Integer`
+                * The event code as an :class:`.NetworkDiscoveryStatus`
+                * (Optional) A description of the discovery process as a String
 
         .. seealso::
            | :meth:`.XBeeNetwork.del_discovery_process_finished_callback`

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -216,6 +216,7 @@ class DiscoveryProcessFinished(XBeeEvent):
 
     The callbacks that handle this event will receive the following arguments:
         1. status (:class:`.NetworkDiscoveryStatus`): the network discovery status.
+        2. description (String, optional): A description of the discovery status.
 
     .. seealso::
        | :class:`.NetworkDiscoveryStatus`


### PR DESCRIPTION
This optional parameter may give a description of the result of the network
discovery.