### PR TITLE
relay_frames: fix an issue when creating a User Data Relay packet

### DIFF
--- a/digi/xbee/packets/relay.py
+++ b/digi/xbee/packets/relay.py
@@ -95,7 +95,7 @@ class UserDataRelayPacket(XBeeAPIPacket):
         if raw[3] != ApiFrameType.USER_DATA_RELAY_REQUEST.code:
             raise InvalidPacketException(message="This packet is not a user data relay packet.")
 
-        return UserDataRelayPacket(raw[4], XBeeLocalInterface.get([5]), data=raw[6:-1])
+        return UserDataRelayPacket(raw[4], XBeeLocalInterface.get(raw[5]), data=raw[6:-1])
 
     def needs_id(self):
         """


### PR DESCRIPTION
The local interface was not being obtained from the raw data.

Signed-off-by: Andres Saenz <andres.saenz@digi.com>
Signed-off-by: Ruben Moral <ruben.moral@digi.com>