### PR TITLE
Optionally specify operating_mode during open.

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2231,7 +2231,8 @@ class XBeeDevice(AbstractXBeeDevice):
                           flow_control=comm_port_data["flowControl"],
                           _sync_ops_timeout=comm_port_data["timeout"])
 
-    def open(self, force_settings=False):
+    def open(self, force_settings=False, initial_operating_mode=OperatingMode.API_MODE):
+
         """
         Opens the communication with the XBee device and loads some information about it.
         
@@ -2239,6 +2240,10 @@ class XBeeDevice(AbstractXBeeDevice):
             force_settings (Boolean, optional): ``True`` to open the device ensuring/forcing that the specified
                 serial settings are applied even if the current configuration is different,
                 ``False`` to open the device with the current configuration. Default to False.
+            initial_operating_mode (OperatingMode, optional): If the operating mode is known ahead of time (e.g.
+                when re-opening for serial setting updates) it can be explicitly specified. Useful if
+                operating in ESCAPED_API_MODE when the next frame may contain escaped characters. Default to
+                API_MODE.
 
         Raises:
             TimeoutException: if there is any problem with the communication.
@@ -2311,7 +2316,7 @@ class XBeeDevice(AbstractXBeeDevice):
         self._packet_listener.add_route_record_received_callback(route_record_cbs)
         self._packet_listener.add_route_info_received_callback(route_info_cbs)
 
-        self._operating_mode = OperatingMode.API_MODE
+        self._operating_mode = initial_operating_mode
         self._packet_listener.start()
         self._packet_listener.wait_until_started()
 


### PR DESCRIPTION
#162 

Explicitly set the operating_mode during re-opening so that we aren't briefly running in the wrong mode. Perhaps a more robust solution is needed, but handles the immediate issue.