### PR TITLE
pylint: fix several pylint issues

### DIFF
--- a/digi/xbee/models/accesspoint.py
+++ b/digi/xbee/models/accesspoint.py
@@ -1,4 +1,4 @@
-# Copyright 2017, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,12 +16,12 @@ from enum import Enum, unique
 from digi.xbee.util import utils
 
 
-class AccessPoint(object):
+class AccessPoint:
     """
-    This class represents an Access Point for the Wi-Fi protocol. It contains 
-    SSID, the encryption type and the link quality between the Wi-Fi module and 
+    This class represents an Access Point for the Wi-Fi protocol. It contains
+    SSID, the encryption type and the link quality between the Wi-Fi module and
     the access point.
-    
+
     This class is used within the library to list the access points
     and connect to a specific one in the Wi-Fi protocol.
 
@@ -43,9 +43,9 @@ class AccessPoint(object):
             signal_quality (Integer, optional): signal quality with the access point in %. Optional.
 
         Raises:
-            ValueError: if length of ``ssid`` is 0.
-            ValueError: if ``channel`` is less than 0.
-            ValueError: if ``signal_quality`` is less than 0 or greater than 100.
+            ValueError: if length of `ssid` is 0.
+            ValueError: if `channel` is less than 0.
+            ValueError: if `signal_quality` is less than 0 or greater than 100.
 
         .. seealso::
            | :class:`.WiFiEncryptionType`
@@ -72,7 +72,8 @@ class AccessPoint(object):
         return "%s (%s) - CH: %s - Signal: %s%%" % (self.__ssid, self.__encryption_type.description,
                                                     self.__channel, self.__signal_quality)
 
-    def __get_ssid(self):
+    @property
+    def ssid(self):
         """
         Returns the SSID of the access point.
 
@@ -81,7 +82,8 @@ class AccessPoint(object):
         """
         return self.__ssid
 
-    def __get_encryption_type(self):
+    @property
+    def encryption_type(self):
         """
         Returns the encryption type of the access point.
 
@@ -93,7 +95,8 @@ class AccessPoint(object):
         """
         return self.__encryption_type
 
-    def __get_channel(self):
+    @property
+    def channel(self):
         """
         Returns the channel of the access point.
 
@@ -105,7 +108,8 @@ class AccessPoint(object):
         """
         return self.__channel
 
-    def __set_channel(self, channel):
+    @channel.setter
+    def channel(self, channel):
         """
         Sets the channel of the access point.
 
@@ -113,7 +117,7 @@ class AccessPoint(object):
             channel (Integer): the new channel of the access point
 
         Raises:
-            ValueError: if ``channel`` is less than 0.
+            ValueError: if `channel` is less than 0.
 
         .. seealso::
            | :func:`.AccessPoint.get_channel`
@@ -122,7 +126,8 @@ class AccessPoint(object):
             raise ValueError(self.__ERROR_CHANNEL)
         self.__channel = channel
 
-    def __get_signal_quality(self):
+    @property
+    def signal_quality(self):
         """
         Returns the signal quality with the access point in %.
 
@@ -134,15 +139,16 @@ class AccessPoint(object):
         """
         return self.__signal_quality
 
-    def __set_signal_quality(self, signal_quality):
+    @signal_quality.setter
+    def signal_quality(self, signal_quality):
         """
-        Sets the channel of the access point.
+        Sets the signal quality with the access point (percentage).
 
         Args:
             signal_quality (Integer): the new signal quality with the access point.
 
         Raises:
-            ValueError: if ``signal_quality`` is less than 0 or greater than 100.
+            ValueError: if `signal_quality` is less than 0 or greater than 100.
 
         .. seealso::
            | :func:`.AccessPoint.__get_signal_quality`
@@ -150,18 +156,6 @@ class AccessPoint(object):
         if signal_quality < 0 or signal_quality > 100:
             raise ValueError(self.__ERROR_SIGNAL_QUALITY)
         self.__signal_quality = signal_quality
-
-    ssid = property(__get_ssid)
-    """String. SSID of the access point."""
-
-    encryption_type = property(__get_encryption_type)
-    """:class:`.WiFiEncryptionType`. Encryption type of the access point."""
-
-    channel = property(__get_channel, __set_channel)
-    """String. Channel of the access point."""
-
-    signal_quality = property(__get_signal_quality, __set_signal_quality)
-    """String. The signal quality with the access point in %."""
 
 
 @unique
@@ -178,7 +172,8 @@ class WiFiEncryptionType(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the WiFiEncryptionType element.
 
@@ -187,7 +182,8 @@ class WiFiEncryptionType(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the WiFiEncryptionType element.
 
@@ -205,20 +201,13 @@ class WiFiEncryptionType(Enum):
             code (Integer): the code of the Wi-Fi encryption type to get.
 
         Returns:
-            :class:`.WiFiEncryptionType`: the WiFiEncryptionType with the given code, ``None`` if there is
-                not any Wi-Fi encryption type with the provided code.
+            :class:`.WiFiEncryptionType`: the WiFiEncryptionType with the given
+                code, `None` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The Wi-Fi encryption type code."""
-
-    description = property(__get_description)
-    """String. The Wi-Fi encryption type description."""
+        for enc_type in cls:
+            if enc_type.code == code:
+                return enc_type
+        return None
 
 
-WiFiEncryptionType.lookupTable = {x.code: x for x in WiFiEncryptionType}
 WiFiEncryptionType.__doc__ += utils.doc_enum(WiFiEncryptionType)

--- a/digi/xbee/models/address.py
+++ b/digi/xbee/models/address.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,7 +16,7 @@ import re
 from digi.xbee.util import utils
 
 
-class XBee16BitAddress(object):
+class XBee16BitAddress:
     """
     This class represent a 16-bit network address.
 
@@ -29,15 +29,15 @@ class XBee16BitAddress(object):
 
     DigiMesh and Point-to-multipoint does not support 16-bit addressing.
 
-    Each device has its own 16-bit address which is unique in the network. 
-    It is automatically assigned when the radio joins the network for ZigBee 
+    Each device has its own 16-bit address which is unique in the network.
+    It is automatically assigned when the radio joins the network for ZigBee
     and Znet 2.5, and manually configured in 802.15.4 radios.
 
     | Attributes:
     |     **COORDINATOR_ADDRESS** (XBee16BitAddress): 16-bit address reserved for the coordinator.
     |     **BROADCAST_ADDRESS** (XBee16BitAddress): 16-bit broadcast address.
     |     **UNKNOWN_ADDRESS** (XBee16BitAddress): 16-bit unknown address.
-    |     **PATTERN** (String): Pattern for the 16-bit address string: ``(0[xX])?[0-9a-fA-F]{1,4}``
+    |     **PATTERN** (String): Pattern for the 16-bit address string: `(0[xX])?[0-9a-fA-F]{1,4}`
 
     """
 
@@ -71,8 +71,8 @@ class XBee16BitAddress(object):
             address (Bytearray): address as byte array. Must be 1-2 digits.
 
         Raises:
-            TypeError: if ``address`` is ``None``.
-            ValueError: if ``address`` is ``None`` or  has less than 1 byte or more than 2.
+            TypeError: if `address` is `None`.
+            ValueError: if `address` is `None` or  has less than 1 byte or more than 2.
         """
         if not address:
             raise ValueError("Address must contain at least 1 byte")
@@ -93,8 +93,8 @@ class XBee16BitAddress(object):
                 hex. digits without blanks. Minimum 1 character, maximum 4 (16-bit).
 
         Raises:
-            ValueError: if ``address`` has less than 1 character.
-            ValueError: if ``address`` contains non-hexadecimal characters.
+            ValueError: if `address` has less than 1 character.
+            ValueError: if `address` contains non-hexadecimal characters.
         """
         if not address:
             raise ValueError("Address must contain at least 1 digit")
@@ -114,8 +114,8 @@ class XBee16BitAddress(object):
             lsb (Integer): low significant byte of the address.
 
         Raises:
-            ValueError: if ``lsb`` is less than 0 or greater than 255.
-            ValueError: if ``hsb`` is less than 0 or greater than 255.
+            ValueError: if `lsb` is less than 0 or greater than 255.
+            ValueError: if `hsb` is less than 0 or greater than 255.
         """
         if hsb > 255 or hsb < 0:
             raise ValueError("HSB must be between 0 and 255.")
@@ -135,14 +135,15 @@ class XBee16BitAddress(object):
                 Bytearray: Address as byte array. Must be 1-2 digits.
 
         Returns:
-            Boolean: ``True`` for a valid 16-bit address, ``False`` otherwise.
+            Boolean: `True` for a valid 16-bit address, `False` otherwise.
         """
-        if isinstance(address, bytearray) and 2 < len(address) < 1:
-            return False
-        elif isinstance(address, str) and not cls.__REGEXP.match(address):
-            return False
+        if isinstance(address, bytearray):
+            return 1 <= len(address) <= 2
 
-        return True
+        if isinstance(address, str):
+            return cls.__REGEXP.match(address)
+
+        return False
 
     def __get_item__(self, index):
         """
@@ -175,8 +176,8 @@ class XBee16BitAddress(object):
             Integer: hash code value for the object.
         """
         res = 23
-        for b in self.__address:
-            res = 31 * (res + b)
+        for byte in self.__address:
+            res = 31 * (res + byte)
         return res
 
     def __eq__(self, other):
@@ -187,12 +188,12 @@ class XBee16BitAddress(object):
             other (:class`.XBee16BitAddress`): another XBee16BitAddress object.
 
         Returns:
-            Boolean: ``True`` if self and other have the same value and type, ``False`` in other case.
+            Boolean: `True` if self and other have the same value and type, `False` in other case.
         """
         if not isinstance(other, XBee16BitAddress):
             return False
 
-        return self.__address.__eq__(other.__address)
+        return self.address == other.address
 
     def __iter__(self):
         """
@@ -221,7 +222,8 @@ class XBee16BitAddress(object):
         """
         return self.__address[1]
 
-    def __get_value(self):
+    @property
+    def address(self):
         """
         Returns a bytearray representation of this XBee16BitAddress.
 
@@ -230,16 +232,13 @@ class XBee16BitAddress(object):
         """
         return bytearray(self.__address)
 
-    address = property(__get_value)
-    """Bytearray. Bytearray representation of this XBee16BitAddress."""
-
 
 XBee16BitAddress.COORDINATOR_ADDRESS = XBee16BitAddress.from_hex_string("0000")
 XBee16BitAddress.BROADCAST_ADDRESS = XBee16BitAddress.from_hex_string("FFFF")
 XBee16BitAddress.UNKNOWN_ADDRESS = XBee16BitAddress.from_hex_string("FFFE")
 
 
-class XBee64BitAddress(object):
+class XBee64BitAddress:
     """
     This class represents a 64-bit address (also known as MAC address).
 
@@ -279,7 +278,7 @@ class XBee64BitAddress(object):
             address (Bytearray): the XBee 64-bit address as byte array.
 
         Raise:
-            ValueError: if ``address`` is ``None`` or its length less than 1 or greater than 8.
+            ValueError: if `address` is `None` or its length less than 1 or greater than 8.
         """
         if not address:
             raise ValueError("Address must contain at least 1 byte")
@@ -303,11 +302,11 @@ class XBee64BitAddress(object):
 
         Raises:
             ValueError: if the address' length is less than 1 or does not match
-                with the pattern: ``(0[xX])?[0-9a-fA-F]{1,16}``.
+                with the pattern: `(0[xX])?[0-9a-fA-F]{1,16}`.
         """
         if not address:
             raise ValueError("Address must contain at least 1 byte")
-        if not (cls.__REGEXP.match(address)):
+        if not cls.__REGEXP.match(address):
             raise ValueError("Address must follow this pattern: " + cls.PATTERN)
 
         return cls(utils.hex_string_to_bytes(address))
@@ -325,8 +324,8 @@ class XBee64BitAddress(object):
         """
         if len(args) != 8:
             raise ValueError("Number of bytes given as arguments must be 8.")
-        for i in range(len(args)):
-            if args[i] > 255 or args[i] < 0:
+        for i, val in enumerate(args):
+            if val > 255 or val < 0:
                 raise ValueError("Byte " + str(i + 1) + " must be between 0 and 255")
 
         return cls(bytearray(args))
@@ -339,15 +338,16 @@ class XBee64BitAddress(object):
         Args:
             address (String or Bytearray): The XBee 64-bit address as a string or bytearray.
 
-        Returns:
-            Boolean: ``True`` for a valid 64-bit address, ``False`` otherwise.
+        Returns
+            Boolean: `True` for a valid 64-bit address, `False` otherwise.
         """
-        if isinstance(address, bytearray) and 8 < len(address) < 1:
-            return False
-        elif isinstance(address, str) and not cls.__REGEXP.match(address):
-            return False
+        if isinstance(address, bytearray):
+            return 1 <= len(address) <= 8
 
-        return True
+        if isinstance(address, str):
+            return cls.__REGEXP.match(address)
+
+        return False
 
     def __str__(self):
         """
@@ -368,8 +368,8 @@ class XBee64BitAddress(object):
             Integer: hash code value for the object.
         """
         res = 23
-        for b in self.__address:
-            res = 31 * (res + b)
+        for byte in self.__address:
+            res = 31 * (res + byte)
         return res
 
     def __eq__(self, other):
@@ -380,14 +380,14 @@ class XBee64BitAddress(object):
             other: another XBee64BitAddress.
 
         Returns:
-            Boolean: ``True`` if self and other have the same value and type, ``False`` in other case.
+            Boolean: `True` if self and other have the same value and type, `False` in other case.
         """
         if other is None:
             return False
         if not isinstance(other, XBee64BitAddress):
             return False
 
-        return self.__address.__eq__(other.__address)
+        return self.address == other.address
 
     def __iter__(self):
         """
@@ -398,7 +398,8 @@ class XBee64BitAddress(object):
         """
         return self.__address.__iter__()
 
-    def __get_value(self):
+    @property
+    def address(self):
         """
         Returns a bytearray representation of this XBee64BitAddress.
 
@@ -407,16 +408,13 @@ class XBee64BitAddress(object):
         """
         return bytearray(self.__address)
 
-    address = property(__get_value)
-    """Bytearray. Bytearray representation of this XBee64BitAddress."""
-
 
 XBee64BitAddress.COORDINATOR_ADDRESS = XBee64BitAddress.from_hex_string("0000")
 XBee64BitAddress.BROADCAST_ADDRESS = XBee64BitAddress.from_hex_string("FFFF")
 XBee64BitAddress.UNKNOWN_ADDRESS = XBee64BitAddress.from_hex_string("F"*16)
 
 
-class XBeeIMEIAddress(object):
+class XBeeIMEIAddress:
     """
     This class represents an IMEI address used by cellular devices.
 
@@ -438,8 +436,8 @@ class XBeeIMEIAddress(object):
             address (Bytearray): The XBee IMEI address as byte array.
 
         Raises:
-            ValueError: if ``address`` is ``None``.
-            ValueError: if length of ``address`` greater than 8.
+            ValueError: if `address` is `None`.
+            ValueError: if length of `address` greater than 8.
         """
         if address is None:
             raise ValueError("IMEI address cannot be None")
@@ -457,12 +455,12 @@ class XBeeIMEIAddress(object):
             address (String): The XBee IMEI address as a string.
 
         Raises:
-            ValueError: if ``address`` is ``None``.
-            ValueError: if ``address`` does not match the pattern: ``^\d{0,15}$``.
+            ValueError: if `address` is `None`.
+            ValueError: if `address` does not match the pattern: `^\\d{0,15}$`.
         """
         if address is None:
             raise ValueError("IMEI address cannot be None")
-        if not (cls.__REGEXP.match(address)):
+        if not cls.__REGEXP.match(address):
             raise ValueError("Address must follow this pattern: " + cls.PATTERN)
 
         return cls(utils.hex_string_to_bytes(address))
@@ -476,14 +474,15 @@ class XBeeIMEIAddress(object):
             address (String or Bytearray): The XBee IMEI address as a string or bytearray.
 
         Returns:
-            Boolean: ``True`` for a valid IMEI, ``False`` otherwise.
+            Boolean: `True` for a valid IMEI, `False` otherwise.
         """
-        if isinstance(address, bytearray) and len(address) < 8:
-            return False
-        elif isinstance(address, str) and not cls.__REGEXP.match(address):
-            return False
+        if isinstance(address, bytearray):
+            return len(address) >= 8
 
-        return True
+        if isinstance(address, str):
+            return cls.__REGEXP.match(address)
+
+        return False
 
     @staticmethod
     def __generate_byte_array(byte_address):
@@ -498,7 +497,8 @@ class XBeeIMEIAddress(object):
         """
         return bytearray(8 - len(byte_address)) + byte_address  # Pad zeros in the MSB of the address
 
-    def __get_value(self):
+    @property
+    def address(self):
         """
         Returns a string representation of this XBeeIMEIAddress.
 
@@ -516,7 +516,7 @@ class XBeeIMEIAddress(object):
         Returns:
             String: "informal" representation of this XBeeIMEIAddress.
         """
-        return self.__get_value()
+        return self.address
 
     def __hash__(self):
         """
@@ -526,8 +526,8 @@ class XBeeIMEIAddress(object):
             Integer: hash code value for the object.
         """
         res = 23
-        for b in self.__address:
-            res = 31 * (res + b)
+        for byte in self.__address:
+            res = 31 * (res + byte)
         return res
 
     def __eq__(self, other):
@@ -538,14 +538,11 @@ class XBeeIMEIAddress(object):
             other (:class:`.XBeeIMEIAddress`): another XBeeIMEIAddress.
 
         Returns:
-            Boolean: ``True`` if self and other have the same value and type, ``False`` in other case.
+            Boolean: `True` if self and other have the same value and type, `False` in other case.
         """
         if other is None:
             return False
         if not isinstance(other, XBeeIMEIAddress):
             return False
 
-        return self.__address.__eq__(other.__address)
-
-    address = property(__get_value)
-    """String. String representation of this XBeeIMEIAddress."""
+        return self.address == other.address

--- a/digi/xbee/models/hw.py
+++ b/digi/xbee/models/hw.py
@@ -98,7 +98,8 @@ class HardwareVersion(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the HardwareVersion element.
 
@@ -107,7 +108,8 @@ class HardwareVersion(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the HardwareVersion element.
 
@@ -125,22 +127,13 @@ class HardwareVersion(Enum):
             code (Integer): the code of the hardware version to get.
 
         Returns:
-            :class:`HardwareVersion`: the HardwareVersion with the given code, ``None`` if there is not a
-                HardwareVersion with that code.
+            :class:`HardwareVersion`: the HardwareVersion with the given code,
+                `None` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The hardware version code."""
-
-    description = property(__get_description)
-    """String. The hardware version description."""
+        for version in cls:
+            if version.code == code:
+                return version
+        return None
 
 
-# Class variable of HardwareVersion. Dictionary <Integer, HardwareVersion> for
-# search HardwareVersion by code.
-HardwareVersion.lookupTable = {x.code: x for x in HardwareVersion}
 HardwareVersion.__doc__ += utils.doc_enum(HardwareVersion)

--- a/digi/xbee/models/info.py
+++ b/digi/xbee/models/info.py
@@ -1,4 +1,4 @@
-# Copyright 2019, Digi International Inc.
+# Copyright 2019, 2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -32,9 +32,11 @@ class SocketInfo:
     __SEPARATOR = "\r"
     __LIST_LENGTH = 6
 
-    def __init__(self, socket_id, state, protocol, local_port, remote_port, remote_address):
+    def __init__(self, socket_id, state, protocol, local_port, remote_port,
+                 remote_address):
         """
-        Class constructor. Instantiates a ``SocketInfo`` object with the given parameters.
+        Class constructor. Instantiates a `SocketInfo` object with the given
+        parameters.
 
         Args:
             socket_id (Integer): The ID of the socket.
@@ -54,15 +56,19 @@ class SocketInfo:
     @staticmethod
     def create_socket_info(raw):
         """
-        Parses the given bytearray data and returns a ``SocketInfo`` object.
+        Parses the given bytearray data and returns a `SocketInfo` object.
 
         Args:
-            raw (Bytearray): received data from the ``SI`` command with a socket ID as argument.
+            raw (Bytearray): received data from the `SI` command with a socket
+                ID as argument.
 
         Returns:
-            :class:`.SocketInfo`: The socket information, or ``None`` if the provided data is invalid.
+            :class:`.SocketInfo`: The socket information, or `None` if the
+                provided data is invalid.
         """
-        info_array = bytearray.fromhex(utils.hex_to_string(raw)).decode("utf8").strip().split(SocketInfo.__SEPARATOR)
+        info_array = bytearray.fromhex(
+            utils.hex_to_string(raw)).decode("utf8").strip().split(
+                SocketInfo.__SEPARATOR)
         if len(info_array) != SocketInfo.__LIST_LENGTH:
             return None
         socket_id = int(info_array[0], 0)
@@ -71,27 +77,33 @@ class SocketInfo:
         local_port = int(info_array[3], 0)
         remote_port = int(info_array[4], 0)
         remote_address = info_array[5]
-        return SocketInfo(socket_id, state, protocol, local_port, remote_port, remote_address)
+        return SocketInfo(socket_id, state, protocol, local_port,
+                          remote_port, remote_address)
 
     @staticmethod
     def parse_socket_list(raw):
         """
-        Parses the given bytearray data and returns a list with the active socket IDs.
+        Parses the given bytearray data and returns a list with the active
+        socket IDs.
 
         Args:
-            raw (Bytearray): received data from the ``SI`` command.
+            raw (Bytearray): received data from the `SI` command.
 
         Returns:
-            List: list with the IDs of all active (open) sockets, or empty list if there is not any active socket.
+            List: list with the IDs of all active (open) sockets, or empty list
+                if there is not any active socket.
         """
         socket_list = list()
-        ids_array = bytearray.fromhex(utils.hex_to_string(raw)).decode("utf8").strip().split(SocketInfo.__SEPARATOR)
-        for x in ids_array:
-            if x != "":
-                socket_list.append(int(x, 0))
+        ids_array = bytearray.fromhex(
+            utils.hex_to_string(raw)).decode("utf8").strip().split(
+                SocketInfo.__SEPARATOR)
+        for soc_id in ids_array:
+            if soc_id != "":
+                socket_list.append(int(soc_id, 0))
         return socket_list
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the ID of the socket.
 
@@ -100,7 +112,8 @@ class SocketInfo:
         """
         return self.__socket_id
 
-    def __get_state(self):
+    @property
+    def state(self):
         """
         Returns the state of the socket.
 
@@ -109,7 +122,8 @@ class SocketInfo:
         """
         return self.__state
 
-    def __get_protocol(self):
+    @property
+    def protocol(self):
         """
         Returns the protocol of the socket.
 
@@ -118,16 +132,19 @@ class SocketInfo:
         """
         return self.__protocol
 
-    def __get_local_port(self):
+    @property
+    def local_port(self):
         """
         Returns the local port of the socket.
+        This is 0 unless the socket is explicitly bound to a port.
 
         Returns:
             Integer: the local port of the socket.
         """
         return self.__local_port
 
-    def __get_remote_port(self):
+    @property
+    def remote_port(self):
         """
         Returns the remote port of the socket.
 
@@ -136,9 +153,11 @@ class SocketInfo:
         """
         return self.__remote_port
 
-    def __get_remote_address(self):
+    @property
+    def remote_address(self):
         """
         Returns the remote IPv4 address of the socket.
+        This is `0.0.0.0` for an unconnected socket.
 
         Returns:
             String: the remote IPv4 address of the socket.
@@ -157,21 +176,3 @@ class SocketInfo:
                   utils.hex_to_string(utils.int_to_bytes(self.__local_port, num_bytes=2), False),
                   utils.hex_to_string(utils.int_to_bytes(self.__remote_port, num_bytes=2), False),
                   self.__remote_address)
-
-    socket_id = property(__get_socket_id)
-    """Integer. The ID of the socket."""
-
-    state = property(__get_state)
-    """:class:`.SocketInfoState`: The state of the socket."""
-
-    protocol = property(__get_protocol)
-    """:class:`.IPProtocol`: The protocol of the socket."""
-
-    local_port = property(__get_local_port)
-    """Integer: The local port of the socket. This is 0 unless the socket is explicitly bound to a port."""
-
-    remote_port = property(__get_remote_port)
-    """Integer: The remote port of the socket."""
-
-    remote_address = property(__get_remote_address)
-    """String: The remote IPv4 address of the socket. This is ``0.0.0.0`` for an unconnected socket."""

--- a/digi/xbee/models/message.py
+++ b/digi/xbee/models/message.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,7 +15,7 @@
 import re
 
 
-class XBeeMessage(object):
+class XBeeMessage:
     """
     This class represents a XBee message, which is formed by a :class:`.RemoteXBeeDevice`
     (the sender) and some data (the data sent) as a bytearray.
@@ -28,8 +28,8 @@ class XBeeMessage(object):
         Args:
             data (Bytearray): the data sent.
             remote_device (:class:`.RemoteXBeeDevice`): the sender.
-            broadcast (Boolean, optional, default=``False``): flag indicating whether the  message is
-                broadcast (``True``) or not (``False``). Optional.
+            broadcast (Boolean, optional, default=`False`): flag indicating whether the  message is
+                broadcast (`True`) or not (`False`). Optional.
             timestamp: instant of time when the message was received.
         """
         self.__data = data
@@ -37,16 +37,18 @@ class XBeeMessage(object):
         self.__is_broadcast = broadcast
         self.__timestamp = timestamp
 
-    def __get_data(self):
+    @property
+    def data(self):
         """
-        Returns the data of the message.
+        Returns a bytearray containing the data of the message.
 
         Returns:
             Bytearray: the data of the message.
         """
         return self.__data
 
-    def __get_remote_device(self):
+    @property
+    def remote_device(self):
         """
         Returns the device which has sent the message.
 
@@ -55,18 +57,20 @@ class XBeeMessage(object):
         """
         return self.__remote_device
 
-    def __is_broadcast(self):
+    @property
+    def is_broadcast(self):
         """
         Returns whether the message is broadcast or not.
 
         Returns:
-            Boolean: ``True`` if the message is broadcast, ``False`` otherwise.
+            Boolean: `True` if the message is broadcast, `False` otherwise.
         """
         return self.__is_broadcast
 
-    def __get_timestamp(self):
+    @property
+    def timestamp(self):
         """
-        Returns the moment when the message was received as a ``time.time()``
+        Returns the moment when the message was received as a `time.time()`
         function returned value.
 
         Returns:
@@ -83,23 +87,12 @@ class XBeeMessage(object):
                 "Broadcast: ":   self.__is_broadcast,
                 "Received at: ": self.__timestamp}
 
-    data = property(__get_data)
-    """Bytearray. Bytearray containing the data of the message."""
-
-    remote_device = property(__get_remote_device)
-    """:class:`.RemoteXBeeDevice`. The device that has sent the message."""
-
-    is_broadcast = property(__is_broadcast)
-    """Boolean. ``True`` to indicate that the message is broadcast, ``False`` otherwise."""
-    
-    timestamp = property(__get_timestamp)
-    """Integer. Instant of time when the message was received."""
-
 
 class ExplicitXBeeMessage(XBeeMessage):
     """
-    This class represents an Explicit XBee message, which is formed by all parameters of a common XBee message and:
-    Source endpoint, destination endpoint, cluster ID, profile ID.
+    This class represents an Explicit XBee message, which is formed by all
+    parameters of a common XBee message and: Source endpoint, destination
+    endpoint, cluster ID, profile ID.
     """
 
     def __init__(self, data, remote_device, timestamp, source_endpoint,
@@ -115,8 +108,8 @@ class ExplicitXBeeMessage(XBeeMessage):
             dest_endpoint (Integer): destination endpoint of the message. 1 byte.
             cluster_id (Integer): cluster id of the message. 2 bytes.
             profile_id (Integer): profile id of the message. 2 bytes.
-            broadcast (Boolean, optional, default=``False``): flag indicating whether the message is
-                broadcast (``True``) or not (``False``). Optional.
+            broadcast (Boolean, optional, default=`False`): flag indicating whether the message is
+                broadcast (`True`) or not (`False`). Optional.
         """
         XBeeMessage.__init__(self, data, remote_device, timestamp, broadcast)
         self.__source_endpoint = source_endpoint
@@ -124,7 +117,8 @@ class ExplicitXBeeMessage(XBeeMessage):
         self.__cluster_id = cluster_id
         self.__profile_id = profile_id
 
-    def __get_source_endpoint(self):
+    @property
+    def source_endpoint(self):
         """
         Returns the source endpoint of the message.
 
@@ -133,7 +127,8 @@ class ExplicitXBeeMessage(XBeeMessage):
         """
         return self.__source_endpoint
 
-    def __get_dest_endpoint(self):
+    @property
+    def dest_endpoint(self):
         """
         Returns the destination endpoint of the message.
 
@@ -142,7 +137,8 @@ class ExplicitXBeeMessage(XBeeMessage):
         """
         return self.__dest_endpoint
 
-    def __get_cluster_id(self):
+    @property
+    def cluster_id(self):
         """
         Returns the cluster ID of the message.
 
@@ -151,7 +147,8 @@ class ExplicitXBeeMessage(XBeeMessage):
         """
         return self.__cluster_id
 
-    def __get_profile_id(self):
+    @property
+    def profile_id(self):
         """
         Returns the profile ID of the message.
 
@@ -160,7 +157,8 @@ class ExplicitXBeeMessage(XBeeMessage):
         """
         return self.__profile_id
 
-    def __set_source_endpoint(self, source_endpoint):
+    @source_endpoint.setter
+    def source_endpoint(self, source_endpoint):
         """
         Sets the source endpoint of the message.
 
@@ -169,7 +167,8 @@ class ExplicitXBeeMessage(XBeeMessage):
         """
         self.__source_endpoint = source_endpoint
 
-    def __set_dest_endpoint(self, dest_endpoint):
+    @dest_endpoint.setter
+    def dest_endpoint(self, dest_endpoint):
         """
          Sets the destination endpoint of the message.
 
@@ -178,7 +177,8 @@ class ExplicitXBeeMessage(XBeeMessage):
          """
         self.__dest_endpoint = dest_endpoint
 
-    def __set_cluster_id(self, cluster_id):
+    @cluster_id.setter
+    def cluster_id(self, cluster_id):
         """
          Sets the cluster ID of the message.
 
@@ -187,7 +187,8 @@ class ExplicitXBeeMessage(XBeeMessage):
          """
         self.__cluster_id = cluster_id
 
-    def __set_profile_id(self, profile_id):
+    @profile_id.setter
+    def profile_id(self, profile_id):
         """
          Sets the profile ID of the message.
 
@@ -197,30 +198,19 @@ class ExplicitXBeeMessage(XBeeMessage):
         self.__profile_id = profile_id
 
     def to_dict(self):
-        dc = XBeeMessage.to_dict(self)
-        dc.update({"Src_endpoint":  self.__source_endpoint,
-                   "Dest_endpoint": self.__dest_endpoint,
-                   "Cluster_id":    self.__cluster_id,
-                   "Profile_id":    self.__profile_id})
-        return dc
-
-    source_endpoint = property(__get_source_endpoint, __set_source_endpoint)
-    """Integer. The source endpoint of the message"""
-
-    dest_endpoint = property(__get_dest_endpoint, __set_dest_endpoint)
-    """Integer. The destination endpoint of the message"""
-
-    cluster_id = property(__get_cluster_id, __set_cluster_id)
-    """Integer. The Cluster ID of the message."""
-
-    profile_id = property(__get_profile_id, __set_profile_id)
-    """Integer. The profile ID of the message."""
+        msg_dict = XBeeMessage.to_dict(self)
+        msg_dict.update({"Src_endpoint":  self.__source_endpoint,
+                         "Dest_endpoint": self.__dest_endpoint,
+                         "Cluster_id":    self.__cluster_id,
+                         "Profile_id":    self.__profile_id})
+        return msg_dict
 
 
-class IPMessage(object):
+class IPMessage:
     """
-    This class represents an IP message containing the IP address the message belongs to, the source and destination
-    ports, the IP protocol, and the content (data) of the message.
+    This class represents an IP message containing the IP address the message
+    belongs to, the source and destination ports, the IP protocol, and the
+    content (data) of the message.
     """
 
     def __init__(self, ip_addr, source_port, dest_port, protocol, data):
@@ -235,11 +225,11 @@ class IPMessage(object):
             data (Bytearray): the data sent.
 
         Raises:
-            ValueError: if ``ip_addr`` is ``None``.
-            ValueError: if ``protocol`` is ``None``.
-            ValueError: if ``data`` is ``None``.
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535.
+            ValueError: if `ip_addr` is `None`.
+            ValueError: if `protocol` is `None`.
+            ValueError: if `data` is `None`.
+            ValueError: if `source_port` is less than 0 or greater than 65535.
+            ValueError: if `dest_port` is less than 0 or greater than 65535.
         """
         if ip_addr is None:
             raise ValueError("IP address cannot be None")
@@ -259,7 +249,8 @@ class IPMessage(object):
         self.__protocol = protocol
         self.__data = data
 
-    def __get_ip_addr(self):
+    @property
+    def ip_addr(self):
         """
         Returns the IPv4 address this message is associated to.
 
@@ -268,7 +259,8 @@ class IPMessage(object):
         """
         return self.__ip_addr
 
-    def __get_source_port(self):
+    @property
+    def source_port(self):
         """
         Returns the source port of the transmission.
 
@@ -277,7 +269,8 @@ class IPMessage(object):
         """
         return self.__source_port
 
-    def __get_dest_port(self):
+    @property
+    def dest_port(self):
         """
         Returns the destination port of the transmission.
 
@@ -286,7 +279,8 @@ class IPMessage(object):
         """
         return self.__dest_port
 
-    def __get_protocol(self):
+    @property
+    def protocol(self):
         """
         Returns the protocol used in the transmission.
 
@@ -295,9 +289,10 @@ class IPMessage(object):
         """
         return self.__protocol
 
-    def __get_data(self):
+    @property
+    def data(self):
         """
-        Returns the data of the message.
+        Returns a bytearray containing the data of the message.
 
         Returns:
             Bytearray: the data of the message.
@@ -314,23 +309,8 @@ class IPMessage(object):
                 "Protocol: ":         self.__protocol,
                 "Data: ":             self.__data}
 
-    ip_addr = property(__get_ip_addr)
-    """:class:`ipaddress.IPv4Address`. The IPv4 address this message is associated to."""
 
-    source_port = property(__get_source_port)
-    """Integer. The source port of the transmission."""
-
-    dest_port = property(__get_dest_port)
-    """Integer. The destination port of the transmission."""
-
-    protocol = property(__get_protocol)
-    """:class:`.IPProtocol`. The protocol used in the transmission."""
-
-    data = property(__get_data)
-    """Bytearray. Bytearray containing the data of the message."""
-
-
-class SMSMessage(object):
+class SMSMessage:
     """
     This class represents an SMS message containing the phone number that sent
     the message and the content (data) of the message.
@@ -342,16 +322,17 @@ class SMSMessage(object):
 
     def __init__(self, phone_number, data):
         """
-        Class  constructor. Instantiates a new :class:`.SMSMessage` object with the provided parameters.
+        Class  constructor. Instantiates a new :class:`.SMSMessage` object with
+        the provided parameters.
 
         Args:
             phone_number (String): The phone number that sent the message.
             data (String): The message text.
 
         Raises:
-            ValueError: if ``phone_number`` is ``None``.
-            ValueError: if ``data`` is ``None``.
-            ValueError: if ``phone_number`` is not a valid phone number.
+            ValueError: if `phone_number` is `None`.
+            ValueError: if `data` is `None`.
+            ValueError: if `phone_number` is not a valid phone number.
         """
         if phone_number is None:
             raise ValueError("Phone number cannot be None")
@@ -363,7 +344,8 @@ class SMSMessage(object):
         self.__phone_number = phone_number
         self.__data = data
 
-    def __get_phone_number(self):
+    @property
+    def phone_number(self):
         """
         Returns the phone number that sent the message.
 
@@ -372,7 +354,8 @@ class SMSMessage(object):
         """
         return self.__phone_number
 
-    def __get_data(self):
+    @property
+    def data(self):
         """
         Returns the data of the message.
 
@@ -388,14 +371,8 @@ class SMSMessage(object):
         return {"Phone number: ": self.__phone_number,
                 "Data: ":         self.__data}
 
-    phone_number = property(__get_phone_number)
-    """String. The phone number that sent the message."""
 
-    data = property(__get_data)
-    """String. The data of the message."""
-
-
-class UserDataRelayMessage(object):
+class UserDataRelayMessage:
     """
     This class represents a user data relay message containing the source
     interface and the content (data) of the message.
@@ -406,15 +383,15 @@ class UserDataRelayMessage(object):
 
     def __init__(self, local_interface, data):
         """
-        Class constructor. Instantiates a new :class:`.UserDataRelayMessage` object with
-        the provided parameters.
+        Class constructor. Instantiates a new :class:`.UserDataRelayMessage`
+        object with the provided parameters.
 
         Args:
             local_interface (:class:`.XBeeLocalInterface`): The source XBee local interface.
             data (Bytearray): Byte array containing the data of the message.
 
         Raises:
-            ValueError: if ``relay_interface`` is ``None``.
+            ValueError: if `relay_interface` is `None`.
 
         .. seealso::
             | :class:`.XBeeLocalInterface`
@@ -425,7 +402,8 @@ class UserDataRelayMessage(object):
         self.__local_interface = local_interface
         self.__data = data
 
-    def __get_src_interface(self):
+    @property
+    def local_interface(self):
         """
         Returns the source interface that sent the message.
 
@@ -434,7 +412,8 @@ class UserDataRelayMessage(object):
         """
         return self.__local_interface
 
-    def __get_data(self):
+    @property
+    def data(self):
         """
         Returns the data of the message.
 
@@ -449,9 +428,3 @@ class UserDataRelayMessage(object):
         """
         return {"XBee local interface: ": self.__local_interface,
                 "Data: ":                 self.__data}
-
-    local_interface = property(__get_src_interface)
-    """:class:`.XBeeLocalInterface`. Source interface that sent the message."""
-
-    data = property(__get_data)
-    """Bytearray. The data of the message."""

--- a/digi/xbee/models/mode.py
+++ b/digi/xbee/models/mode.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -39,7 +39,8 @@ class OperatingMode(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the OperatingMode element.
 
@@ -48,7 +49,8 @@ class OperatingMode(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the OperatingMode element.
 
@@ -68,19 +70,12 @@ class OperatingMode(Enum):
         Returns:
             :class:`.OperatingMode`: the OperatingMode with the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return OperatingMode.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The operating mode code."""
-
-    description = property(__get_description)
-    """String: The operating mode description."""
+        for mode in cls:
+            if mode.code == code:
+                return mode
+        return OperatingMode.UNKNOWN
 
 
-OperatingMode.lookupTable = {x.code: x for x in OperatingMode}
 OperatingMode.__doc__ += utils.doc_enum(OperatingMode)
 
 
@@ -103,7 +98,8 @@ class APIOutputMode(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the APIOutputMode element.
 
@@ -112,7 +108,8 @@ class APIOutputMode(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the APIOutputMode element.
 
@@ -130,22 +127,15 @@ class APIOutputMode(Enum):
             code (Integer): the code corresponding to the API output mode to get.
 
         Returns:
-            :class:`.OperatingMode`: the APIOutputMode with the given code, ``None`` if there is not an
-                APIOutputMode with that code.
+            :class:`.APIOutputMode`: the APIOutputMode with the given code,
+                `None` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The API output mode code."""
-
-    description = property(__get_description)
-    """String: The API output mode description."""
+        for mode in cls:
+            if mode.code == code:
+                return mode
+        return None
 
 
-APIOutputMode.lookupTable = {x.code: x for x in APIOutputMode}
 APIOutputMode.__doc__ += utils.doc_enum(APIOutputMode)
 
 
@@ -169,7 +159,8 @@ class APIOutputModeBit(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the APIOutputModeBit element.
 
@@ -178,7 +169,8 @@ class APIOutputModeBit(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the APIOutputModeBit element.
 
@@ -196,46 +188,40 @@ class APIOutputModeBit(Enum):
             code (Integer): the code corresponding to the API output mode to get.
 
         Returns:
-            :class:`.OperatingMode`: the APIOutputModeBit with the given code, ``None``
-                if there is not an APIOutputModeBit with that code.
+            :class:`.OperatingMode`: the APIOutputModeBit with the given code,
+                `None` if not found.
         """
         for item in cls:
             if code == item.code:
                 return item
-
         return None
 
     @classmethod
     def calculate_api_output_mode_value(cls, protocol, options):
         """
-        Calculates the total value of a combination of several option bits for the
-        given protocol.
+        Calculates the total value of a combination of several option bits for
+        the given protocol.
 
         Args:
-            protocol (:class:`digi.xbee.models.protocol.XBeeProtocol`): The ``XBeeProtocol``
-                to calculate the value of all the given API output options.
+            protocol (:class:`digi.xbee.models.protocol.XBeeProtocol`): The
+                `XBeeProtocol` to calculate the value of all the given API
+                output options.
             options: Collection of option bits to get the final value.
 
         Returns:
-            Integer: The value to be configured in the module depending on the given
-                collection of option bits and the protocol.
+            Integer: The value to be configured in the module depending on the
+                given collection of option bits and the protocol.
         """
         if not options:
             return 0
 
         if protocol == XBeeProtocol.ZIGBEE:
             return sum(op.code for op in options)
-        elif protocol in (XBeeProtocol.DIGI_MESH, XBeeProtocol.DIGI_POINT,
-                          XBeeProtocol.XLR, XBeeProtocol.XLR_DM):
+        if protocol in (XBeeProtocol.DIGI_MESH, XBeeProtocol.DIGI_POINT,
+                        XBeeProtocol.XLR, XBeeProtocol.XLR_DM):
             return sum(op.code for op in options if lambda option: option != cls.EXPLICIT)
 
         return 0
-
-    code = property(__get_code)
-    """Integer. The API output mode bit code."""
-
-    description = property(__get_description)
-    """String: The API output mode bit description."""
 
 
 APIOutputModeBit.__doc__ += utils.doc_enum(APIOutputModeBit)
@@ -254,7 +240,8 @@ class IPAddressingMode(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the IPAddressingMode element.
 
@@ -263,7 +250,8 @@ class IPAddressingMode(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the IPAddressingMode element.
 
@@ -281,30 +269,23 @@ class IPAddressingMode(Enum):
             code (Integer): the code corresponding to the IP addressing mode to get.
 
         Returns:
-            :class:`.IPAddressingMode`: the IPAddressingMode with the given code, ``None`` if there is not an
-                IPAddressingMode with that code.
+            :class:`.IPAddressingMode`: the IPAddressingMode with the given
+                code, `None` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The IP addressing mode code."""
-
-    description = property(__get_description)
-    """String. The IP addressing mode description."""
+        for mode in cls:
+            if mode.code == code:
+                return mode
+        return None
 
 
-IPAddressingMode.lookupTable = {x.code: x for x in IPAddressingMode}
 IPAddressingMode.__doc__ += utils.doc_enum(IPAddressingMode)
 
 
 @unique
 class NeighborDiscoveryMode(Enum):
     """
-    Enumerates the different neighbor discovery modes. This mode establishes the way the
-    network discovery process is performed.
+    Enumerates the different neighbor discovery modes. This mode establishes
+    the way the network discovery process is performed.
 
     | Inherited properties:
     |     **name** (String): the name (id) of this OperatingMode.
@@ -313,17 +294,19 @@ class NeighborDiscoveryMode(Enum):
 
     CASCADE = (0, "Cascade")
     """
-    The discovery of a node neighbors is requested once the previous request finishes.
+    The discovery of a node neighbors is requested once the previous request
+    finishes.
     This means that just one discovery process is running at the same time.
 
-    This mode is recommended for large networks, it might be a slower method but it
-    generates less traffic than 'Flood'.
+    This mode is recommended for large networks, it might be a slower method
+    but it generates less traffic than 'Flood'.
     """
 
     FLOOD = (1, "Flood")
     """
-    The discovery of a node neighbors is requested when the node is found in the network.
-    This means that several discovery processes might be running at the same time.
+    The discovery of a node neighbors is requested when the node is found in
+    the network. This means that several discovery processes might be running
+    at the same time.
     """
 
     def __init__(self, code, description):
@@ -360,10 +343,12 @@ class NeighborDiscoveryMode(Enum):
 
         Returns:
             :class:`.NeighborDiscoveryMode`: the NeighborDiscoveryMode with
-                the given code. ``None`` if there is not a mode with that code.
+                the given code. `None` if not found.
         """
         for mode in cls:
             if mode.code == code:
                 return mode
-
         return None
+
+
+NeighborDiscoveryMode.__doc__ += utils.doc_enum(NeighborDiscoveryMode)

--- a/digi/xbee/models/options.py
+++ b/digi/xbee/models/options.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -35,28 +35,28 @@ class ReceiveOptions(Enum):
     PACKET_ACKNOWLEDGED = 0x01
     """
     Packet was acknowledged.
-    
+
     Not valid for WiFi protocol.
     """
 
     BROADCAST_PACKET = 0x02
     """
     Packet was a broadcast packet.
-    
+
     Not valid for WiFi protocol.
     """
 
     APS_ENCRYPTED = 0x20
     """
     Packet encrypted with APS encryption.
-    
+
     Only valid for ZigBee XBee protocol.
     """
 
     SENT_FROM_END_DEVICE = 0x40
     """
     Packet was sent from an end device (if known).
-    
+
     Only valid for ZigBee XBee protocol.
     """
 
@@ -66,14 +66,14 @@ ReceiveOptions.__doc__ += utils.doc_enum(ReceiveOptions)
 
 class TransmitOptions(Enum):
     """
-    This class lists all the possible options that can be set while 
+    This class lists all the possible options that can be set while
     transmitting an XBee packet.
 
-    The transmit options are usually set as a bitfield meaning that the options 
+    The transmit options are usually set as a bitfield meaning that the options
     can be combined using the '|' operand.
-    
-    Not all options are available for all cases, that's why there are different 
-    names with same values. In each moment, you must be sure that the option 
+
+    Not all options are available for all cases, that's why there are different
+    names with same values. In each moment, you must be sure that the option
     your are going to use, is a valid option in your context.
     """
 
@@ -84,22 +84,22 @@ class TransmitOptions(Enum):
 
     DISABLE_ACK = 0x01
     """
-    Disables acknowledgments on all unicasts .
+    Disables acknowledgments on all unicasts.
 
-    Only valid for DigiMesh, 802.15.4 and Point-to-multipoint 
+    Only valid for DigiMesh, 802.15.4 and Point-to-multipoint
     protocols.
     """
 
     DISABLE_RETRIES_AND_REPAIR = 0x01
     """
-    Disables the retries and router repair in the frame .
+    Disables the retries and router repair in the frame.
 
     Only valid for ZigBee protocol.
     """
 
     DONT_ATTEMPT_RD = 0x02
     """
-    Doesn't attempt Route Discovery .
+    Doesn't attempt Route Discovery.
 
     Disables Route Discovery on all DigiMesh unicasts.
 
@@ -108,7 +108,7 @@ class TransmitOptions(Enum):
 
     USE_BROADCAST_PAN_ID = 0x04
     """
-    Sends packet with broadcast {@code PAN ID}. Packet will be sent to all 
+    Sends packet with broadcast {@code PAN ID}. Packet will be sent to all
     devices in the same channel ignoring the {@code PAN ID}.
 
     It cannot be combined with other options.
@@ -118,7 +118,7 @@ class TransmitOptions(Enum):
 
     ENABLE_UNICAST_NACK = 0x04
     """
-    Enables unicast NACK messages .
+    Enables unicast NACK messages.
 
     NACK message is enabled on the packet.
 
@@ -127,7 +127,7 @@ class TransmitOptions(Enum):
 
     ENABLE_UNICAST_TRACE_ROUTE = 0x04
     """
-    Enables unicast trace route messages .
+    Enables unicast trace route messages.
 
     Trace route is enabled on the packets.
 
@@ -143,9 +143,9 @@ class TransmitOptions(Enum):
 
     ENABLE_APS_ENCRYPTION = 0x20
     """
-    Enables APS encryption, only if {@code EE=1} .
+    Enables APS encryption, only if {@code EE=1}.
 
-    Enabling APS encryption decreases the maximum number of RF payload 
+    Enabling APS encryption decreases the maximum number of RF payload
     bytes by 4 (below the value reported by {@code NP}).
 
     Only valid for ZigBee XBee protocol.
@@ -153,9 +153,9 @@ class TransmitOptions(Enum):
 
     USE_EXTENDED_TIMEOUT = 0x40
     """
-    Uses the extended transmission timeout .
+    Uses the extended transmission timeout.
 
-    Setting the extended timeout bit causes the stack to set the 
+    Setting the extended timeout bit causes the stack to set the
     extended transmission timeout for the destination address.
 
     Only valid for ZigBee XBee protocol.
@@ -163,25 +163,25 @@ class TransmitOptions(Enum):
 
     POINT_MULTIPOINT_MODE = 0x40
     """
-    Transmission is performed using point-to-Multipoint mode. 
+    Transmission is performed using point-to-Multipoint mode.
 
-    Only valid for DigiMesh 868/900 and Point-to-Multipoint 868/900 
+    Only valid for DigiMesh 868/900 and Point-to-Multipoint 868/900
     protocols.
     """
 
     REPEATER_MODE = 0x80
     """
-    Transmission is performed using repeater mode .
+    Transmission is performed using repeater mode.
 
-    Only valid for DigiMesh 868/900 and Point-to-Multipoint 868/900 
+    Only valid for DigiMesh 868/900 and Point-to-Multipoint 868/900
     protocols.
     """
 
     DIGIMESH_MODE = 0xC0
     """
-    Transmission is performed using DigiMesh mode .
+    Transmission is performed using DigiMesh mode.
 
-    Only valid for DigiMesh 868/900 and Point-to-Multipoint 868/900 
+    Only valid for DigiMesh 868/900 and Point-to-Multipoint 868/900
     protocols.
     """
 
@@ -191,10 +191,10 @@ TransmitOptions.__doc__ += utils.doc_enum(TransmitOptions)
 
 class RemoteATCmdOptions(Enum):
     """
-    This class lists all the possible options that can be set while transmitting
-    a remote AT Command.
+    This class lists all the possible options that can be set while
+    transmitting a remote AT Command.
 
-    These options are usually set as a bitfield meaning that the options 
+    These options are usually set as a bitfield meaning that the options
     can be combined using the '|' operand.
     """
 
@@ -212,15 +212,15 @@ class RemoteATCmdOptions(Enum):
     """
     Applies changes in the remote device.
 
-    If this option is not set, AC command must be sent before changes 
+    If this option is not set, AC command must be sent before changes
     will take effect.
     """
 
     EXTENDED_TIMEOUT = 0x40
     """
-    Uses the extended transmission timeout
+    Uses the extended transmission timeout.
 
-    Setting the extended timeout bit causes the stack to set the extended 
+    Setting the extended timeout bit causes the stack to set the extended
     transmission timeout for the destination address.
 
     Only valid for ZigBee XBee protocol.
@@ -244,7 +244,8 @@ class SendDataRequestOptions(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the SendDataRequestOptions element.
 
@@ -253,7 +254,8 @@ class SendDataRequestOptions(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the SendDataRequestOptions element.
 
@@ -271,22 +273,15 @@ class SendDataRequestOptions(Enum):
             code (Integer): the code of the send data request option to get.
 
         Returns:
-            :class:`.FrameError`: the SendDataRequestOptions with the given code, ``None`` if there is not
-                any send data request option with the provided code.
+            :class:`.FrameError`: the SendDataRequestOptions with the given
+                code, `None` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The send data request option code."""
-
-    description = property(__get_description)
-    """String. The send data request option description."""
+        for option in cls:
+            if option.code == code:
+                return option
+        return None
 
 
-SendDataRequestOptions.lookupTable = {x.code: x for x in SendDataRequestOptions}
 SendDataRequestOptions.__doc__ += utils.doc_enum(SendDataRequestOptions)
 
 
@@ -330,40 +325,42 @@ class DiscoveryOptions(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``DiscoveryOptions`` element.
+        Returns the code of the `DiscoveryOptions` element.
 
         Returns:
-            Integer: the code of the ``DiscoveryOptions`` element.
+            Integer: the code of the `DiscoveryOptions` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``DiscoveryOptions`` element.
+        Returns the description of the `DiscoveryOptions` element.
 
         Returns:
-            String: the description of the ``DiscoveryOptions`` element.
+            String: the description of the `DiscoveryOptions` element.
         """
         return self.__description
 
     @classmethod
     def get(cls, code):
         """
-        Returns the ``DiscoveryOptions`` for the given code.
+        Returns the `DiscoveryOptions` for the given code.
 
         Args:
-            code (Integer): the code of the ``DiscoveryOptions`` to get.
+            code (Integer): the code of the `DiscoveryOptions` to get.
 
         Returns:
-            :class:`.FrameError`: the ``DiscoveryOptions`` with the given code, ``None`` if there is not
-                any discovery option with the provided code.
+            :class:`.FrameError`: the `DiscoveryOptions` with the given code,
+                `None` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
+        for option in cls:
+            if option.code == code:
+                return option
+        return None
 
     @staticmethod
     def calculate_discovery_value(protocol, options):
@@ -372,36 +369,30 @@ class DiscoveryOptions(Enum):
         given protocol.
 
         Args:
-            protocol (:class:`.XBeeProtocol`): the ``XBeeProtocol`` to calculate the value of all the given
-                discovery options.
+            protocol (:class:`.XBeeProtocol`): the `XBeeProtocol` to calculate
+                the value of all the given discovery options.
             options: collection of options to get the final value.
 
         Returns:
-            Integer: The value to be configured in the module depending on the given
-                collection of options and the protocol.
+            Integer: The value to be configured in the module depending on the
+                given collection of options and the protocol.
         """
         value = 0
         if protocol in [XBeeProtocol.ZIGBEE, XBeeProtocol.ZNET]:
-            for op in options:
-                if op == DiscoveryOptions.APPEND_RSSI:
+            for opt in options:
+                if opt == DiscoveryOptions.APPEND_RSSI:
                     continue
-                value = value + op.code
-        elif protocol in [XBeeProtocol.DIGI_MESH, XBeeProtocol.DIGI_POINT, XBeeProtocol.XLR, XBeeProtocol.XLR_DM]:
-            for op in options:
-                value = value + op.code
+                value = value + opt.code
+        elif protocol in [XBeeProtocol.DIGI_MESH, XBeeProtocol.DIGI_POINT,
+                          XBeeProtocol.XLR, XBeeProtocol.XLR_DM]:
+            for opt in options:
+                value = value + opt.code
         else:
             if DiscoveryOptions.DISCOVER_MYSELF in options:
                 value = 1  # This is different for 802.15.4.
         return value
 
-    code = property(__get_code)
-    """Integer. The discovery option code."""
 
-    description = property(__get_description)
-    """String. The discovery option description."""
-
-
-DiscoveryOptions.lookupTable = {x.code: x for x in DiscoveryOptions}
 DiscoveryOptions.__doc__ += utils.doc_enum(DiscoveryOptions)
 
 
@@ -424,21 +415,23 @@ class XBeeLocalInterface(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``XBeeLocalInterface`` element.
+        Returns the code of the `XBeeLocalInterface` element.
 
         Returns:
-            Integer: the code of the ``XBeeLocalInterface`` element.
+            Integer: the code of the `XBeeLocalInterface` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``XBeeLocalInterface`` element.
+        Returns the description of the `XBeeLocalInterface` element.
 
         Returns:
-            String: the description of the ``XBeeLocalInterface`` element.
+            String: the description of the `XBeeLocalInterface` element.
         """
         return self.__description
 
@@ -451,22 +444,15 @@ class XBeeLocalInterface(Enum):
             code (Integer): the code of the XBee local interface to get.
 
         Returns:
-            :class:`.XBeeLocalInterface`: the ``XBeeLocalInterface`` with the given code,
-                ``UNKNOWN`` if there is not any ``XBeeLocalInterface`` with the provided code.
+            :class:`.XBeeLocalInterface`: the `XBeeLocalInterface` with the
+                given code, `UNKNOWN` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return XBeeLocalInterface.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The XBee local interface code."""
-
-    description = property(__get_description)
-    """String. The XBee local interface description."""
+        for interface in cls:
+            if interface.code == code:
+                return interface
+        return XBeeLocalInterface.UNKNOWN
 
 
-XBeeLocalInterface.lookupTable = {x.code: x for x in XBeeLocalInterface}
 XBeeLocalInterface.__doc__ += utils.doc_enum(XBeeLocalInterface)
 
 
@@ -480,28 +466,31 @@ class RegisterKeyOptions(Enum):
     """
 
     LINK_KEY = (0x00, "Key is a Link Key (KY on joining node)")
-    INSTALL_CODE = (0x01, "Key is an Install Code (I? on joining node, DC must be set to 1 on joiner)")
+    INSTALL_CODE = (0x01, "Key is an Install Code (I? on joining node,"
+                          "DC must be set to 1 on joiner)")
     UNKNOWN = (0xFF, "Unknown key option")
 
     def __init__(self, code, description):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``RegisterKeyOptions`` element.
+        Returns the code of the `RegisterKeyOptions` element.
 
         Returns:
-            Integer: the code of the ``RegisterKeyOptions`` element.
+            Integer: the code of the `RegisterKeyOptions` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``RegisterKeyOptions`` element.
+        Returns the description of the `RegisterKeyOptions` element.
 
         Returns:
-            String: the description of the ``RegisterKeyOptions`` element.
+            String: the description of the `RegisterKeyOptions` element.
         """
         return self.__description
 
@@ -514,22 +503,15 @@ class RegisterKeyOptions(Enum):
             code (Integer): the code of the register key option to get.
 
         Returns:
-            :class:`.RegisterKeyOptions`: the ``RegisterKeyOptions`` with the given code,
-                ``UNKNOWN`` if there is not any ``RegisterKeyOptions`` with the provided code.
+            :class:`.RegisterKeyOptions`: the `RegisterKeyOptions` with the
+                given code, `UNKNOWN` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return RegisterKeyOptions.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The register key option code."""
-
-    description = property(__get_description)
-    """String. The register key option description."""
+        for option in cls:
+            if option.code == code:
+                return option
+        return RegisterKeyOptions.UNKNOWN
 
 
-RegisterKeyOptions.lookupTable = {x.code: x for x in RegisterKeyOptions}
 RegisterKeyOptions.__doc__ += utils.doc_enum(RegisterKeyOptions)
 
 
@@ -545,21 +527,23 @@ class SocketOption(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``SocketOption`` element.
+        Returns the code of the `SocketOption` element.
 
         Returns:
-            Integer: the code of the ``SocketOption`` element.
+            Integer: the code of the `SocketOption` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``SocketOption`` element.
+        Returns the description of the `SocketOption` element.
 
         Returns:
-            String: the description of the ``SocketOption`` element.
+            String: the description of the `SocketOption` element.
         """
         return self.__description
 
@@ -572,20 +556,13 @@ class SocketOption(Enum):
             code (Integer): the code of the Socket Option to get.
 
         Returns:
-            :class:`.SocketOption`: the ``SocketOption`` with the given code,
-                ``SocketOption.UNKNOWN`` if there is not any option with the provided code.
+            :class:`.SocketOption`: the `SocketOption` with the given code,
+                `SocketOption.UNKNOWN` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return SocketOption.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The Socket Option code."""
-
-    description = property(__get_description)
-    """String. The Socket Option description."""
+        for option in cls:
+            if option.code == code:
+                return option
+        return SocketOption.UNKNOWN
 
 
-SocketOption.lookupTable = {x.code: x for x in SocketOption}
 SocketOption.__doc__ += utils.doc_enum(SocketOption)

--- a/digi/xbee/models/protocol.py
+++ b/digi/xbee/models/protocol.py
@@ -51,7 +51,8 @@ class XBeeProtocol(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the XBeeProtocol element.
 
@@ -60,7 +61,8 @@ class XBeeProtocol(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the XBeeProtocol element.
 
@@ -80,10 +82,10 @@ class XBeeProtocol(Enum):
         Returns:
             XBeeProtocol: XBeeProtocol for the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return XBeeProtocol.UNKNOWN
+        for protocol in cls:
+            if protocol.code == code:
+                return protocol
+        return XBeeProtocol.UNKNOWN
 
     @staticmethod
     def determine_protocol(hardware_version, firmware_version, br_value=None):
@@ -106,78 +108,78 @@ class XBeeProtocol(Enum):
                 HardwareVersion.get(hardware_version) is None:
             return XBeeProtocol.UNKNOWN
 
-        elif hardware_version in [HardwareVersion.XC09_009.code,
-                                  HardwareVersion.XC09_038.code]:
+        if hardware_version in [HardwareVersion.XC09_009.code,
+                                HardwareVersion.XC09_038.code]:
             return XBeeProtocol.XCITE
 
-        elif hardware_version in [HardwareVersion.XT09_XXX.code,
-                                  HardwareVersion.XT09B_XXX.code]:
+        if hardware_version in [HardwareVersion.XT09_XXX.code,
+                                HardwareVersion.XT09B_XXX.code]:
             if ((len(firmware_version) == 4 and firmware_version.startswith("8")) or
                     (len(firmware_version) == 5 and firmware_version[1] == '8')):
                 return XBeeProtocol.XTEND_DM
             return XBeeProtocol.XTEND
 
-        elif hardware_version in [HardwareVersion.XB24_AXX_XX.code,
-                                  HardwareVersion.XBP24_AXX_XX.code]:
+        if hardware_version in [HardwareVersion.XB24_AXX_XX.code,
+                                HardwareVersion.XBP24_AXX_XX.code]:
             if len(firmware_version) == 4 and firmware_version.startswith("8"):
-                    return XBeeProtocol.DIGI_MESH
+                return XBeeProtocol.DIGI_MESH
             return XBeeProtocol.RAW_802_15_4
 
-        elif hardware_version in [HardwareVersion.XB24_BXIX_XXX.code,
-                                  HardwareVersion.XBP24_BXIX_XXX.code]:
+        if hardware_version in [HardwareVersion.XB24_BXIX_XXX.code,
+                                HardwareVersion.XBP24_BXIX_XXX.code]:
             if ((len(firmware_version) == 4 and firmware_version.startswith("1") and firmware_version.endswith("20"))
                     or (len(firmware_version) == 4 and firmware_version.startswith("2"))):
                 return XBeeProtocol.ZIGBEE
-            elif len(firmware_version) == 4 and firmware_version.startswith("3"):
+            if len(firmware_version) == 4 and firmware_version.startswith("3"):
                 return XBeeProtocol.SMART_ENERGY
             return XBeeProtocol.ZNET
 
-        elif hardware_version == HardwareVersion.XBP09_DXIX_XXX.code:
+        if hardware_version == HardwareVersion.XBP09_DXIX_XXX.code:
             if ((len(firmware_version) == 4 and firmware_version.startswith("8") or
-                (len(firmware_version) == 4 and firmware_version[1] == '8')) or
+                 (len(firmware_version) == 4 and firmware_version[1] == '8')) or
                     (len(firmware_version) == 5 and firmware_version[1] == '8')):
                 return XBeeProtocol.DIGI_MESH
             return XBeeProtocol.DIGI_POINT
 
-        elif hardware_version == HardwareVersion.XBP09_XCXX_XXX.code:
+        if hardware_version == HardwareVersion.XBP09_XCXX_XXX.code:
             return XBeeProtocol.XC
 
-        elif hardware_version == HardwareVersion.XBP08_DXXX_XXX.code:
+        if hardware_version == HardwareVersion.XBP08_DXXX_XXX.code:
             return XBeeProtocol.DIGI_POINT
 
-        elif hardware_version == HardwareVersion.XBP24B.code:
+        if hardware_version == HardwareVersion.XBP24B.code:
             if len(firmware_version) == 4 and firmware_version.startswith("3"):
                 return XBeeProtocol.SMART_ENERGY
             return XBeeProtocol.ZIGBEE
 
-        elif hardware_version in [HardwareVersion.XB24_WF.code,
-                                  HardwareVersion.WIFI_ATHEROS.code,
-                                  HardwareVersion.SMT_WIFI_ATHEROS.code]:
+        if hardware_version in [HardwareVersion.XB24_WF.code,
+                                HardwareVersion.WIFI_ATHEROS.code,
+                                HardwareVersion.SMT_WIFI_ATHEROS.code]:
             return XBeeProtocol.XBEE_WIFI
 
-        elif hardware_version in [HardwareVersion.XBP24C.code,
-                                  HardwareVersion.XB24C.code]:
+        if hardware_version in [HardwareVersion.XBP24C.code,
+                                HardwareVersion.XB24C.code]:
             if (len(firmware_version) == 4 and (firmware_version.startswith("5")) or
                     (firmware_version.startswith("6"))):
                 return XBeeProtocol.SMART_ENERGY
-            elif firmware_version.startswith("2"):
+            if firmware_version.startswith("2"):
                 return XBeeProtocol.RAW_802_15_4
-            elif firmware_version.startswith("9"):
+            if firmware_version.startswith("9"):
                 return XBeeProtocol.DIGI_MESH
             return XBeeProtocol.ZIGBEE
 
-        elif hardware_version in [HardwareVersion.XSC_GEN3.code,
-                                  HardwareVersion.SRD_868_GEN3.code]:
+        if hardware_version in [HardwareVersion.XSC_GEN3.code,
+                                HardwareVersion.SRD_868_GEN3.code]:
             if len(firmware_version) == 4 and firmware_version.startswith("8"):
                 return XBeeProtocol.DIGI_MESH
-            elif len(firmware_version) == 4 and firmware_version.startswith("1"):
+            if len(firmware_version) == 4 and firmware_version.startswith("1"):
                 return XBeeProtocol.DIGI_POINT
             return XBeeProtocol.XC
 
-        elif hardware_version == HardwareVersion.XBEE_CELL_TH.code:
+        if hardware_version == HardwareVersion.XBEE_CELL_TH.code:
             return XBeeProtocol.UNKNOWN
 
-        elif hardware_version == HardwareVersion.XLR_MODULE.code:
+        if hardware_version == HardwareVersion.XLR_MODULE.code:
             # This is for the old version of the XLR we have (K60), and it is
             # reporting the firmware of the module (8001), this will change in
             # future (after K64 integration) reporting the hardware and firmware
@@ -185,10 +187,9 @@ class XBeeProtocol(Enum):
             # TODO maybe this should be removed in future, since this case will never be released.
             if firmware_version.startswith("1"):
                 return XBeeProtocol.XLR
-            else:
-                return XBeeProtocol.XLR_MODULE
+            return XBeeProtocol.XLR_MODULE
 
-        elif hardware_version == HardwareVersion.XLR_BASEBOARD.code:
+        if hardware_version == HardwareVersion.XLR_BASEBOARD.code:
             # XLR devices with K64 will report the baseboard hardware version,
             # and also firmware version (the one we have here is 1002, but this value
             # is not being reported since is an old K60 version, the module fw version
@@ -198,30 +199,29 @@ class XBeeProtocol(Enum):
             # Probably this XLR_DM and XLR will depend on the firmware version.
             if firmware_version.startswith("1"):
                 return XBeeProtocol.XLR
-            else:
-                return XBeeProtocol.XLR_MODULE
+            return XBeeProtocol.XLR_MODULE
 
-        elif hardware_version == HardwareVersion.XB900HP_NZ.code:
+        if hardware_version == HardwareVersion.XB900HP_NZ.code:
             return XBeeProtocol.DIGI_POINT
 
-        elif hardware_version in [HardwareVersion.XBP24C_TH_DIP.code,
-                                  HardwareVersion.XB24C_TH_DIP.code,
-                                  HardwareVersion.XBP24C_S2C_SMT.code]:
+        if hardware_version in [HardwareVersion.XBP24C_TH_DIP.code,
+                                HardwareVersion.XB24C_TH_DIP.code,
+                                HardwareVersion.XBP24C_S2C_SMT.code]:
             if (len(firmware_version) == 4 and
                     (firmware_version.startswith("5") or firmware_version.startswith("6"))):
                 return XBeeProtocol.SMART_ENERGY
-            elif firmware_version.startswith("2"):
+            if firmware_version.startswith("2"):
                 return XBeeProtocol.RAW_802_15_4
-            elif firmware_version.startswith("9"):
+            if firmware_version.startswith("9"):
                 return XBeeProtocol.DIGI_MESH
             return XBeeProtocol.ZIGBEE
 
-        elif hardware_version in [HardwareVersion.SX_PRO.code,
-                                  HardwareVersion.SX.code,
-                                  HardwareVersion.XTR.code]:
+        if hardware_version in [HardwareVersion.SX_PRO.code,
+                                HardwareVersion.SX.code,
+                                HardwareVersion.XTR.code]:
             if firmware_version.startswith("2"):
                 return XBeeProtocol.XTEND
-            elif firmware_version.startswith("8"):
+            if firmware_version.startswith("8"):
                 return XBeeProtocol.XTEND_DM
 
             if hardware_version in (HardwareVersion.SX.code,
@@ -231,49 +231,41 @@ class XBeeProtocol(Enum):
 
             return XBeeProtocol.DIGI_MESH
 
-        elif hardware_version in [HardwareVersion.S2D_SMT_PRO.code,
-                                  HardwareVersion.S2D_SMT_REG.code,
-                                  HardwareVersion.S2D_TH_PRO.code,
-                                  HardwareVersion.S2D_TH_REG.code]:
+        if hardware_version in [HardwareVersion.S2D_SMT_PRO.code,
+                                HardwareVersion.S2D_SMT_REG.code,
+                                HardwareVersion.S2D_TH_PRO.code,
+                                HardwareVersion.S2D_TH_REG.code]:
             return XBeeProtocol.ZIGBEE
 
-        elif hardware_version in [HardwareVersion.CELLULAR_CAT1_LTE_VERIZON.code,
-                                  HardwareVersion.CELLULAR_3G.code,
-                                  HardwareVersion.CELLULAR_LTE_ATT.code,
-                                  HardwareVersion.CELLULAR_LTE_VERIZON.code,
-                                  HardwareVersion.CELLULAR_3_CAT1_LTE_ATT.code,
-                                  HardwareVersion.CELLULAR_3_LTE_M_VERIZON.code,
-                                  HardwareVersion.CELLULAR_3_LTE_M_ATT.code,
-                                  HardwareVersion.CELLULAR_3_CAT1_LTE_VERIZON.code]:
+        if hardware_version in [HardwareVersion.CELLULAR_CAT1_LTE_VERIZON.code,
+                                HardwareVersion.CELLULAR_3G.code,
+                                HardwareVersion.CELLULAR_LTE_ATT.code,
+                                HardwareVersion.CELLULAR_LTE_VERIZON.code,
+                                HardwareVersion.CELLULAR_3_CAT1_LTE_ATT.code,
+                                HardwareVersion.CELLULAR_3_LTE_M_VERIZON.code,
+                                HardwareVersion.CELLULAR_3_LTE_M_ATT.code,
+                                HardwareVersion.CELLULAR_3_CAT1_LTE_VERIZON.code]:
             return XBeeProtocol.CELLULAR
 
-        elif hardware_version == HardwareVersion.CELLULAR_NBIOT_EUROPE.code:
+        if hardware_version == HardwareVersion.CELLULAR_NBIOT_EUROPE.code:
             return XBeeProtocol.CELLULAR_NBIOT
 
-        elif hardware_version in [HardwareVersion.XBEE3.code,
-                                  HardwareVersion.XBEE3_SMT.code,
-                                  HardwareVersion.XBEE3_TH.code]:
+        if hardware_version in [HardwareVersion.XBEE3.code,
+                                HardwareVersion.XBEE3_SMT.code,
+                                HardwareVersion.XBEE3_TH.code]:
             if firmware_version.startswith("2"):
                 return XBeeProtocol.RAW_802_15_4
-            elif firmware_version.startswith("3"):
+            if firmware_version.startswith("3"):
                 return XBeeProtocol.DIGI_MESH
-            else:
-                return XBeeProtocol.ZIGBEE
+            return XBeeProtocol.ZIGBEE
 
-        elif hardware_version == HardwareVersion.XB8X.code:
+        if hardware_version == HardwareVersion.XB8X.code:
             return XBeeProtocol.DIGI_MESH \
                 if br_value != 0 else XBeeProtocol.DIGI_POINT
 
         return XBeeProtocol.ZIGBEE
 
-    code = property(__get_code)
-    """Integer. XBee protocol code."""
 
-    description = property(__get_description)
-    """String. XBee protocol description."""
-
-
-XBeeProtocol.lookupTable = {x.code: x for x in XBeeProtocol}
 XBeeProtocol.__doc__ += utils.doc_enum(XBeeProtocol)
 
 
@@ -295,7 +287,8 @@ class IPProtocol(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the IP protocol.
 
@@ -304,7 +297,8 @@ class IPProtocol(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the IP protocol.
 
@@ -322,13 +316,13 @@ class IPProtocol(Enum):
             code (Integer): code associated to the IP protocol.
 
         Returns:
-            :class:`.IPProtocol`: IP protocol for the given code or ``None`` if there
-                is not any ``IPProtocol`` with the given code.
+            :class:`.IPProtocol`: IP protocol for the given code or `None` if
+                there is not any `IPProtocol` with the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
+        for protocol in cls:
+            if protocol.code == code:
+                return protocol
+        return None
 
     @classmethod
     def get_by_description(cls, description):
@@ -339,22 +333,16 @@ class IPProtocol(Enum):
             description (String): the description of the IP Protocol to get.
 
         Returns:
-            :class:`.IPProtocol`: IP protocol for the given description or ``None`` if there
-                is not any ``IPProtocol`` with the given description.
+            :class:`.IPProtocol`: IP protocol for the given description or
+                `None` if there is not any `IPProtocol` with the given
+                description.
         """
-        for x in IPProtocol:
-            if x.description.lower() == description.lower():
-                return x
+        for prot in IPProtocol:
+            if prot.description.lower() == description.lower():
+                return prot
         return None
 
-    code = property(__get_code)
-    """Integer: IP protocol code."""
 
-    description = property(__get_description)
-    """String: IP protocol description."""
-
-
-IPProtocol.lookupTable = {x.code: x for x in IPProtocol}
 IPProtocol.__doc__ += utils.doc_enum(IPProtocol)
 
 
@@ -403,10 +391,11 @@ class Role(Enum):
         Returns the Role for the given identifier.
 
         Args:
-            identifier (Integer): the id value corresponding to the role to get.
+            identifier (Integer): the id value of the role to get.
 
         Returns:
-            :class:`.Role`: the Role with the given identifier. ``None`` if it does not exist.
+            :class:`.Role`: the Role with the given identifier. `None` if it
+                does not exist.
         """
         for item in cls:
             if identifier == item.id:

--- a/digi/xbee/models/status.py
+++ b/digi/xbee/models/status.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -19,7 +19,7 @@ from digi.xbee.util import utils
 @unique
 class ATCommandStatus(Enum):
     """
-    This class lists all the possible states of an AT command after executing it.
+    This class lists all the possible states of an AT command after execution.
 
     | Inherited properties:
     |     **name** (String): the name (id) of the ATCommandStatus.
@@ -36,7 +36,8 @@ class ATCommandStatus(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the ATCommandStatus element.
 
@@ -45,7 +46,8 @@ class ATCommandStatus(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the ATCommandStatus element.
 
@@ -65,21 +67,14 @@ class ATCommandStatus(Enum):
         Returns:
             :class:`.ATCommandStatus`: the AT command status with the given code.
         """
-        try:
-            # For ATCommResponsePacket (0x88) and RemoteATCommandResponsePacket
-            # (x097), use least significant nibble for status
-            return cls.lookupTable[code & 0x0F]
-        except KeyError:
-            return ATCommandStatus.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The AT command status code."""
-
-    description = property(__get_description)
-    """String. The AT command status description."""
+        # For ATCommResponsePacket (0x88) and RemoteATCommandResponsePacket
+        # (0x97), use least significant nibble for status
+        for status in cls:
+            if code & 0x0F == status.code:
+                return status
+        return ATCommandStatus.UNKNOWN
 
 
-ATCommandStatus.lookupTable = {x.code: x for x in ATCommandStatus}
 ATCommandStatus.__doc__ += utils.doc_enum(ATCommandStatus)
 
 
@@ -103,7 +98,8 @@ class DiscoveryStatus(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the DiscoveryStatus element.
 
@@ -112,7 +108,8 @@ class DiscoveryStatus(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the DiscoveryStatus element.
 
@@ -133,19 +130,12 @@ class DiscoveryStatus(Enum):
         Returns:
             :class:`.DiscoveryStatus`: the discovery status with the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return DiscoveryStatus.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The discovery status code."""
-
-    description = property(__get_description)
-    """String. The discovery status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return DiscoveryStatus.UNKNOWN
 
 
-DiscoveryStatus.lookupTable = {x.code: x for x in DiscoveryStatus}
 DiscoveryStatus.__doc__ += utils.doc_enum(DiscoveryStatus)
 
 
@@ -158,56 +148,70 @@ class TransmitStatus(Enum):
     |     **name** (String): the name (id) of ths TransmitStatus.
     |     **value** (String): the value of ths TransmitStatus.
     """
-    SUCCESS = (0x00, "Success.")
-    NO_ACK = (0x01, "No acknowledgement received.")
-    CCA_FAILURE = (0x02, "CCA failure.")
-    PURGED = (0x03, "Transmission purged, it was attempted before stack was up.")
-    WIFI_PHYSICAL_ERROR = (0x04, "Physical error occurred on the interface with the WiFi transceiver.")
-    INVALID_DESTINATION = (0x15, "Invalid destination endpoint.")
-    NO_BUFFERS = (0x18, "No buffers.")
-    NETWORK_ACK_FAILURE = (0x21, "Network ACK Failure.")
-    NOT_JOINED_NETWORK = (0x22, "Not joined to network.")
-    SELF_ADDRESSED = (0x23, "Self-addressed.")
-    ADDRESS_NOT_FOUND = (0x24, "Address not found.")
-    ROUTE_NOT_FOUND = (0x25, "Route not found.")
-    BROADCAST_FAILED = (0x26, "Broadcast source failed to hear a neighbor relay the message.")
-    INVALID_BINDING_TABLE_INDEX = (0x2B, "Invalid binding table index.")
+    SUCCESS = (0x00, "Success")
+    NO_ACK = (0x01, "No acknowledgement received")
+    CCA_FAILURE = (0x02, "CCA failure")
+    PURGED = (
+        0x03, "Transmission purged, it was attempted before stack was up")
+    WIFI_PHYSICAL_ERROR = (
+        0x04, "Physical error occurred on the interface with the WiFi "
+              "transceiver")
+    INVALID_DESTINATION = (0x15, "Invalid destination endpoint")
+    NO_BUFFERS = (0x18, "No buffers")
+    NETWORK_ACK_FAILURE = (0x21, "Network ACK Failure")
+    NOT_JOINED_NETWORK = (0x22, "Not joined to network")
+    SELF_ADDRESSED = (0x23, "Self-addressed")
+    ADDRESS_NOT_FOUND = (0x24, "Address not found")
+    ROUTE_NOT_FOUND = (0x25, "Route not found")
+    BROADCAST_FAILED = (
+        0x26, "Broadcast source failed to hear a neighbor relay the message")
+    INVALID_BINDING_TABLE_INDEX = (0x2B, "Invalid binding table index")
     INVALID_ENDPOINT = (0x2C, "Invalid endpoint")
-    BROADCAST_ERROR_APS = (0x2D, "Attempted broadcast with APS transmission.")
-    BROADCAST_ERROR_APS_EE0 = (0x2E, "Attempted broadcast with APS transmission, but EE=0.")
-    SOFTWARE_ERROR = (0x31, "A software error occurred.")
-    RESOURCE_ERROR = (0x32, "Resource error lack of free buffers, timers, etc.")
-    PAYLOAD_TOO_LARGE = (0x74, "Data payload too large.")
+    BROADCAST_ERROR_APS = (0x2D, "Attempted broadcast with APS transmission")
+    BROADCAST_ERROR_APS_EE0 = (
+        0x2E, "Attempted broadcast with APS transmission, but EE=0")
+    SOFTWARE_ERROR = (0x31, "A software error occurred")
+    RESOURCE_ERROR = (
+        0x32, "Resource error lack of free buffers, timers, etc")
+    PAYLOAD_TOO_LARGE = (0x74, "Data payload too large")
     INDIRECT_MESSAGE_UNREQUESTED = (0x75, "Indirect message unrequested")
-    SOCKET_CREATION_FAILED = (0x76, "Attempt to create a client socket failed.")
-    IP_PORT_NOT_EXIST = (0x77, "TCP connection to given IP address and port doesn't exist. Source port is non-zero so "
-                               "that a new connection is not attempted.")
-    UDP_SRC_PORT_NOT_MATCH_LISTENING_PORT = (0x78, "Source port on a UDP transmission doesn't match a listening port "
-                                                   "on the transmitting module.")
-    TCP_SRC_PORT_NOT_MATCH_LISTENING_PORT = (0x79, "Source port on a TCP transmission doesn't match a listening port "
-                                                   "on the transmitting module.")
-    INVALID_IP_ADDRESS = (0x7A, "Destination IPv4 address is not valid.")
-    INVALID_IP_PROTOCOL = (0x7B, "Protocol on an IPv4 transmission is not valid.")
-    RELAY_INTERFACE_INVALID = (0x7C, "Destination interface on a User Data Relay Frame "
-                                     "doesn't exist.")
-    RELAY_INTERFACE_REJECTED = (0x7D, "Destination interface on a User Data Relay Frame "
-                                      "exists, but the interface is not accepting data.")
-    SOCKET_CONNECTION_REFUSED = (0x80, "Destination server refused the connection.")
-    SOCKET_CONNECTION_LOST = (0x81, "The existing connection was lost before the data was sent.")
-    SOCKET_ERROR_NO_SERVER = (0x82, "The attempted connection timed out.")
-    SOCKET_ERROR_CLOSED = (0x83, "The existing connection was closed.")
-    SOCKET_ERROR_UNKNOWN_SERVER = (0x84, "The server could not be found.")
-    SOCKET_ERROR_UNKNOWN_ERROR = (0x85, "An unknown error occurred.")
-    INVALID_TLS_CONFIGURATION = (0x86, "TLS Profile on a 0x23 API request doesn't exist, or "
-                                       "one or more certificates is not valid.")
-    KEY_NOT_AUTHORIZED = (0xBB, "Key not authorized.")
-    UNKNOWN = (0xFF, "Unknown.")
+    SOCKET_CREATION_FAILED = (0x76, "Attempt to create a client socket failed")
+    IP_PORT_NOT_EXIST = (
+        0x77, "TCP connection to given IP address and port does not exist. "
+              "Source port is non-zero, so a new connection is not attempted")
+    UDP_SRC_PORT_NOT_MATCH_LISTENING_PORT = (
+        0x78, "Source port on a UDP transmission does not match a listening "
+              "port on the transmitting module")
+    TCP_SRC_PORT_NOT_MATCH_LISTENING_PORT = (
+        0x79, "Source port on a TCP transmission does not match a listening "
+              "port on the transmitting module")
+    INVALID_IP_ADDRESS = (0x7A, "Destination IPv4 address is invalid")
+    INVALID_IP_PROTOCOL = (0x7B, "Protocol on an IPv4 transmission is invalid")
+    RELAY_INTERFACE_INVALID = (
+        0x7C, "Destination interface on a User Data Relay Frame does not exist")
+    RELAY_INTERFACE_REJECTED = (
+        0x7D, "Destination interface on a User Data Relay Frame exists, but "
+              "the interface is not accepting data")
+    SOCKET_CONNECTION_REFUSED = (
+        0x80, "Destination server refused the connection")
+    SOCKET_CONNECTION_LOST = (
+        0x81, "The existing connection was lost before the data was sent")
+    SOCKET_ERROR_NO_SERVER = (0x82, "The attempted connection timed out")
+    SOCKET_ERROR_CLOSED = (0x83, "The existing connection was closed")
+    SOCKET_ERROR_UNKNOWN_SERVER = (0x84, "The server could not be found")
+    SOCKET_ERROR_UNKNOWN_ERROR = (0x85, "An unknown error occurred")
+    INVALID_TLS_CONFIGURATION = (
+        0x86, "TLS Profile on a 0x23 API request does not exist, or one or "
+              "more certificates is invalid")
+    KEY_NOT_AUTHORIZED = (0xBB, "Key not authorized")
+    UNKNOWN = (0xFF, "Unknown")
 
     def __init__(self, code, description):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the TransmitStatus element.
 
@@ -216,7 +220,8 @@ class TransmitStatus(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the TransmitStatus element.
 
@@ -236,33 +241,27 @@ class TransmitStatus(Enum):
         Returns:
             :class:`.TransmitStatus`: the transmit status with the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return TransmitStatus.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The transmit status code."""
-
-    description = property(__get_description)
-    """String. The transmit status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return TransmitStatus.UNKNOWN
 
 
-TransmitStatus.lookupTable = {x.code: x for x in TransmitStatus}
 TransmitStatus.__doc__ += utils.doc_enum(TransmitStatus)
 
 
 @unique
 class ModemStatus(Enum):
     """
-    Enumerates the different modem status events. This enumeration list is 
+    Enumerates the different modem status events. This enumeration list is
     intended to be used within the :class:`.ModemStatusPacket` packet.
     """
     HARDWARE_RESET = (0x00, "Device was reset")
     WATCHDOG_TIMER_RESET = (0x01, "Watchdog timer was reset")
     JOINED_NETWORK = (0x02, "Device joined to network")
     DISASSOCIATED = (0x03, "Device disassociated")
-    ERROR_SYNCHRONIZATION_LOST = (0x04, "Configuration error/synchronization lost")
+    ERROR_SYNCHRONIZATION_LOST = (
+        0x04, "Configuration error/synchronization lost")
     COORDINATOR_REALIGNMENT = (0x05, "Coordinator realignment")
     COORDINATOR_STARTED = (0x06, "The coordinator started")
     NETWORK_SECURITY_KEY_UPDATED = (0x07, "Network security key was updated")
@@ -271,12 +270,18 @@ class ModemStatus(Enum):
     VOLTAGE_SUPPLY_LIMIT_EXCEEDED = (0x0D, "Voltage supply limit exceeded")
     REMOTE_MANAGER_CONNECTED = (0x0E, "Remote Manager connected")
     REMOTE_MANAGER_DISCONNECTED = (0x0F, "Remote Manager disconnected")
-    MODEM_CONFIG_CHANGED_WHILE_JOINING = (0x11, "Modem configuration changed while joining")
-    BLUETOOTH_CONNECTED = (0x32, "A Bluetooth connection has been made and API mode has been unlocked.")
-    BLUETOOTH_DISCONNECTED = (0x33, "An unlocked Bluetooth connection has been disconnected.")
-    BANDMASK_CONFIGURATION_ERROR = (0x34, "LTE-M/NB-IoT bandmask configuration has failed.")
+    MODEM_CONFIG_CHANGED_WHILE_JOINING = (
+        0x11, "Modem configuration changed while joining")
+    BLUETOOTH_CONNECTED = (
+        0x32, "A Bluetooth connection has been made and API mode has been "
+              "unlocked")
+    BLUETOOTH_DISCONNECTED = (
+        0x33, "An unlocked Bluetooth connection has been disconnected")
+    BANDMASK_CONFIGURATION_ERROR = (
+        0x34, "LTE-M/NB-IoT bandmask configuration has failed")
     ERROR_STACK = (0x80, "Stack error")
-    ERROR_AP_NOT_CONNECTED = (0x82, "Send/join command issued without connecting from AP")
+    ERROR_AP_NOT_CONNECTED = (
+        0x82, "Send/join command issued without connecting from AP")
     ERROR_AP_NOT_FOUND = (0x83, "Access point not found")
     ERROR_PSK_NOT_CONFIGURED = (0x84, "PSK not configured")
     ERROR_SSID_NOT_FOUND = (0x87, "SSID not found")
@@ -289,7 +294,8 @@ class ModemStatus(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the ModemStatus element.
 
@@ -298,7 +304,8 @@ class ModemStatus(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the ModemStatus element.
 
@@ -318,26 +325,19 @@ class ModemStatus(Enum):
         Returns:
             :class:`.ModemStatus`: the ModemStatus with the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return ModemStatus.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The modem status code."""
-
-    description = property(__get_description)
-    """String. The modem status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return ModemStatus.UNKNOWN
 
 
-ModemStatus.lookupTable = {x.code: x for x in ModemStatus}
 ModemStatus.__doc__ += utils.doc_enum(ModemStatus)
 
 
 @unique
 class PowerLevel(Enum):
     """
-    Enumerates the different power levels. The power level indicates the output 
+    Enumerates the different power levels. The power level indicates the output
     power value of a radio when transmitting data.
     """
     LEVEL_LOWEST = (0x00, "Lowest")
@@ -351,7 +351,8 @@ class PowerLevel(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the PowerLevel element.
 
@@ -360,7 +361,8 @@ class PowerLevel(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the PowerLevel element.
 
@@ -380,19 +382,12 @@ class PowerLevel(Enum):
         Returns:
             :class:`.PowerLevel`: the PowerLevel with the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return PowerLevel.LEVEL_UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The power level code."""
-
-    description = property(__get_description)
-    """String. The power level description."""
+        for level in cls:
+            if code == level.code:
+                return level
+        return PowerLevel.LEVEL_UNKNOWN
 
 
-PowerLevel.lookupTable = {x.code: x for x in PowerLevel}
 PowerLevel.__doc__ += utils.doc_enum(PowerLevel)
 
 
@@ -401,108 +396,135 @@ class AssociationIndicationStatus(Enum):
     """
     Enumerates the different association indication statuses.
     """
-    SUCCESSFULLY_JOINED = (0x00, "Successfully formed or joined a network.")
-    AS_TIMEOUT = (0x01, "Active Scan Timeout.")
-    AS_NO_PANS_FOUND = (0x02, "Active Scan found no PANs.")
-    AS_ASSOCIATION_NOT_ALLOWED = (0x03, "Active Scan found PAN, but the CoordinatorAllowAssociation bit is not set.")
-    AS_BEACONS_NOT_SUPPORTED = (0x04, "Active Scan found PAN, but Coordinator and End Device are not configured to "
-                                      "support beacons.")
-    AS_ID_DOESNT_MATCH = (0x05, "Active Scan found PAN, but the Coordinator ID parameter does not match the ID "
-                                "parameter of the End Device.")
-    AS_CHANNEL_DOESNT_MATCH = (0x06, "Active Scan found PAN, but the Coordinator CH parameter does not match "
-                                     "the CH parameter of the End Device.")
-    ENERGY_SCAN_TIMEOUT = (0x07, "Energy Scan Timeout.")
-    COORDINATOR_START_REQUEST_FAILED = (0x08, "Coordinator start request failed.")
-    COORDINATOR_INVALID_PARAMETER = (0x09, "Coordinator could not start due to invalid parameter.")
-    COORDINATOR_REALIGNMENT = (0x0A, "Coordinator Realignment is in progress.")
-    AR_NOT_SENT = (0x0B, "Association Request not sent.")
-    AR_TIMED_OUT = (0x0C, "Association Request timed out - no reply was received.")
-    AR_INVALID_PARAMETER = (0x0D, "Association Request had an Invalid Parameter.")
-    AR_CHANNEL_ACCESS_FAILURE = (0x0E, "Association Request Channel Access Failure. Request was not "
-                                       "transmitted - CCA failure.")
-    AR_COORDINATOR_ACK_WASNT_RECEIVED = (0x0F, "Remote Coordinator did not send an ACK after Association "
-                                               "Request was sent.")
-    AR_COORDINATOR_DIDNT_REPLY = (0x10, "Remote Coordinator did not reply to the Association Request, but an ACK "
-                                        "was received after sending the request.")
-    SYNCHRONIZATION_LOST = (0x12, "Sync-Loss - Lost synchronization with a Beaconing Coordinator.")
-    DISASSOCIATED = (0x13, " Disassociated - No longer associated to Coordinator.")
+    SUCCESSFULLY_JOINED = (0x00, "Successfully formed or joined a network")
+    AS_TIMEOUT = (0x01, "Active Scan Timeout")
+    AS_NO_PANS_FOUND = (0x02, "Active Scan found no PANs")
+    AS_ASSOCIATION_NOT_ALLOWED = (
+        0x03, "Active Scan found PAN, but the CoordinatorAllowAssociation bit "
+              "is not set")
+    AS_BEACONS_NOT_SUPPORTED = (
+        0x04, "Active Scan found PAN, but Coordinator and End Device are not "
+              "onfigured to support beacons")
+    AS_ID_DOESNT_MATCH = (
+        0x05, "Active Scan found PAN, but the Coordinator ID parameter does "
+              "not match the ID parameter of the End Device")
+    AS_CHANNEL_DOESNT_MATCH = (
+        0x06, "Active Scan found PAN, but the Coordinator CH parameter does "
+              "not match the CH parameter of the End Device")
+    ENERGY_SCAN_TIMEOUT = (0x07, "Energy Scan Timeout")
+    COORDINATOR_START_REQUEST_FAILED = (
+        0x08, "Coordinator start request failed")
+    COORDINATOR_INVALID_PARAMETER = (
+        0x09, "Coordinator could not start due to invalid parameter")
+    COORDINATOR_REALIGNMENT = (
+        0x0A, "Coordinator Realignment is in progress")
+    AR_NOT_SENT = (0x0B, "Association Request not sent")
+    AR_TIMED_OUT = (
+        0x0C, "Association Request timed out - no reply was received")
+    AR_INVALID_PARAMETER = (
+        0x0D, "Association Request had an Invalid Parameter")
+    AR_CHANNEL_ACCESS_FAILURE = (
+        0x0E, "Association Request Channel Access Failure. Request was not "
+              "transmitted - CCA failure")
+    AR_COORDINATOR_ACK_WASNT_RECEIVED = (
+        0x0F, "Remote Coordinator did not send an ACK after Association "
+              "Request was sent")
+    AR_COORDINATOR_DIDNT_REPLY = (
+        0x10, "Remote Coordinator did not reply to the Association Request, "
+              "but an ACK was received after sending the request")
+    SYNCHRONIZATION_LOST = (
+        0x12, "Sync-Loss - Lost synchronization with a Beaconing Coordinator")
+    DISASSOCIATED = (
+        0x13, " Disassociated - No longer associated to Coordinator")
     NO_PANS_FOUND = (0x21, "Scan found no PANs.")
-    NO_PANS_WITH_ID_FOUND = (0x22, "Scan found no valid PANs based on current SC and ID settings.")
-    NJ_EXPIRED = (0x23, "Valid Coordinator or Routers found, but they are not allowing joining (NJ expired).")
-    NO_JOINABLE_BEACONS_FOUND = (0x24, "No joinable beacons were found.")
-    UNEXPECTED_STATE = (0x25, "Unexpected state, node should not be attempting to join at this time.")
-    JOIN_FAILED = (0x27, "Node Joining attempt failed (typically due to incompatible security settings).")
-    COORDINATOR_START_FAILED = (0x2A, "Coordinator Start attempt failed.")
-    CHECKING_FOR_COORDINATOR = (0x2B, "Checking for an existing coordinator.")
-    NETWORK_LEAVE_FAILED = (0x2C, "Attempt to leave the network failed.")
-    DEVICE_DIDNT_RESPOND = (0xAB, "Attempted to join a device that did not respond.")
-    UNSECURED_KEY_RECEIVED = (0xAC, "Secure join error - network security key received unsecured.")
-    KEY_NOT_RECEIVED = (0xAD, "Secure join error - network security key not received.")
-    INVALID_SECURITY_KEY = (0xAF, "Secure join error - joining device does not have the right preconfigured link key.")
-    SCANNING_NETWORK = (0xFF, "Scanning for a network/Attempting to associate.")
+    NO_PANS_WITH_ID_FOUND = (
+        0x22, "Scan found no valid PANs based on current SC and ID settings")
+    NJ_EXPIRED = (
+        0x23, "Valid Coordinator or Routers found, but they are not allowing "
+              "joining (NJ expired)")
+    NO_JOINABLE_BEACONS_FOUND = (0x24, "No joinable beacons were found")
+    UNEXPECTED_STATE = (
+        0x25, "Unexpected state, node should not be attempting to join at"
+              " this time")
+    JOIN_FAILED = (
+        0x27, "Node Joining attempt failed (typically due to incompatible "
+              "security settings)")
+    COORDINATOR_START_FAILED = (0x2A, "Coordinator Start attempt failed")
+    CHECKING_FOR_COORDINATOR = (0x2B, "Checking for an existing coordinator")
+    NETWORK_LEAVE_FAILED = (0x2C, "Attempt to leave the network failed")
+    DEVICE_DIDNT_RESPOND = (
+        0xAB, "Attempted to join a device that did not respond")
+    UNSECURED_KEY_RECEIVED = (
+        0xAC, "Secure join error - network security key received unsecured")
+    KEY_NOT_RECEIVED = (
+        0xAD, "Secure join error - network security key not received")
+    INVALID_SECURITY_KEY = (
+        0xAF, "Secure join error - joining device does not have the right "
+              "preconfigured link key")
+    SCANNING_NETWORK = (0xFF, "Scanning for a network/Attempting to associate")
 
     def __init__(self, code, description):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``AssociationIndicationStatus`` element.
+        Returns the code of the `AssociationIndicationStatus` element.
 
         Returns:
-            Integer: the code of the ``AssociationIndicationStatus`` element.
+            Integer: the code of the `AssociationIndicationStatus` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``AssociationIndicationStatus`` element.
+        Returns the description of the `AssociationIndicationStatus` element.
 
         Returns:
-            String: the description of the ``AssociationIndicationStatus`` element.
+            String: the description of the `AssociationIndicationStatus`
+                element.
         """
         return self.__description
 
     @classmethod
     def get(cls, code):
         """
-        Returns the ``AssociationIndicationStatus`` for the given code.
+        Returns the `AssociationIndicationStatus` for the given code.
 
         Args:
-            code (Integer): the code of the ``AssociationIndicationStatus`` to get.
+            code (Integer): the `AssociationIndicationStatus` code to get.
 
         Returns:
-            :class:`.AssociationIndicationStatus`: the ``AssociationIndicationStatus`` with the given code.
+            :class:`.AssociationIndicationStatus`: the
+                `AssociationIndicationStatus` with the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The association indication status code."""
-
-    description = property(__get_description)
-    """String. The association indication status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return None
 
 
-AssociationIndicationStatus.lookupTable = {x.code: x for x in AssociationIndicationStatus}
 AssociationIndicationStatus.__doc__ += utils.doc_enum(AssociationIndicationStatus)
 
 
 @unique
 class CellularAssociationIndicationStatus(Enum):
     """
-    Enumerates the different association indication statuses for the Cellular protocol.
+    Enumerates the different association indication statuses for the Cellular
+    protocol.
     """
-    SUCCESSFULLY_CONNECTED = (0x00, "Connected to the Internet.")
+    SUCCESSFULLY_CONNECTED = (0x00, "Connected to the Internet")
     REGISTERING_CELLULAR_NETWORK = (0x22, "Registering to cellular network")
     CONNECTING_INTERNET = (0x23, "Connecting to the Internet")
-    MODEM_FIRMWARE_CORRUPT = (0x24, "The cellular component requires a new firmware image.")
-    REGISTRATION_DENIED = (0x25, "Cellular network registration was denied.")
-    AIRPLANE_MODE = (0x2A, "Airplane mode is active.")
-    USB_DIRECT = (0x2B, "USB Direct mode is active.")
-    PSM_LOW_POWER = (0x2C, "The cellular component is in the PSM low-power state.")
+    MODEM_FIRMWARE_CORRUPT = (
+        0x24, "The cellular component requires a new firmware image")
+    REGISTRATION_DENIED = (0x25, "Cellular network registration was denied")
+    AIRPLANE_MODE = (0x2A, "Airplane mode is active")
+    USB_DIRECT = (0x2B, "USB Direct mode is active")
+    PSM_LOW_POWER = (
+        0x2C, "The cellular component is in the PSM low-power state")
     BYPASS_MODE = (0x2F, "Bypass mode active")
     INITIALIZING = (0xFF, "Initializing")
 
@@ -510,49 +532,47 @@ class CellularAssociationIndicationStatus(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``CellularAssociationIndicationStatus`` element.
+        Returns the code of the `CellularAssociationIndicationStatus` element.
 
         Returns:
-            Integer: the code of the ``CellularAssociationIndicationStatus`` element.
+            Integer: the code of the `CellularAssociationIndicationStatus`
+                element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``CellularAssociationIndicationStatus`` element.
+        Returns the description of the `CellularAssociationIndicationStatus`
+            element.
 
         Returns:
-            String: the description of the ``CellularAssociationIndicationStatus`` element.
+            String: the description of the `CellularAssociationIndicationStatus`
+                element.
         """
         return self.__description
 
     @classmethod
     def get(cls, code):
         """
-        Returns the ``CellularAssociationIndicationStatus`` for the given code.
+        Returns the `CellularAssociationIndicationStatus` for the given code.
 
         Args:
-            code (Integer): the code of the ``CellularAssociationIndicationStatus`` to get.
+            code (Integer): `CellularAssociationIndicationStatus` code.
 
         Returns:
-            :class:`.CellularAssociationIndicationStatus`: the ``CellularAssociationIndicationStatus``
-                with the given code.
+            :class:`.CellularAssociationIndicationStatus`: the
+                `CellularAssociationIndicationStatus` with the given code.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The cellular association indication status code."""
-
-    description = property(__get_description)
-    """String. The cellular association indication status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return None
 
 
-CellularAssociationIndicationStatus.lookupTable = {x.code: x for x in CellularAssociationIndicationStatus}
 CellularAssociationIndicationStatus.__doc__ += utils.doc_enum(CellularAssociationIndicationStatus)
 
 
@@ -573,21 +593,23 @@ class DeviceCloudStatus(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``DeviceCloudStatus`` element.
+        Returns the code of the `DeviceCloudStatus` element.
 
         Returns:
-            Integer: the code of the ``DeviceCloudStatus`` element.
+            Integer: the code of the `DeviceCloudStatus` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``DeviceCloudStatus`` element.
+        Returns the description of the `DeviceCloudStatus` element.
 
         Returns:
-            String: the description of the ``DeviceCloudStatus`` element.
+            String: the description of the `DeviceCloudStatus` element.
         """
         return self.__description
 
@@ -600,22 +622,15 @@ class DeviceCloudStatus(Enum):
             code (Integer): the code of the Device Cloud status to get.
 
         Returns:
-            :class:`.DeviceCloudStatus`: the ``DeviceCloudStatus`` with the given code, ``None`` if there is not any
-                status with the provided code.
+            :class:`.DeviceCloudStatus`: the `DeviceCloudStatus` with the given
+                code, `None` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The Device Cloud status code."""
-
-    description = property(__get_description)
-    """String. The Device Cloud status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return None
 
 
-DeviceCloudStatus.lookupTable = {x.code: x for x in DeviceCloudStatus}
 DeviceCloudStatus.__doc__ += utils.doc_enum(DeviceCloudStatus)
 
 
@@ -627,30 +642,36 @@ class FrameError(Enum):
     INVALID_TYPE = (0x02, "Invalid frame type")
     INVALID_LENGTH = (0x03, "Invalid frame length")
     INVALID_CHECKSUM = (0x04, "Erroneous checksum on last frame")
-    PAYLOAD_TOO_BIG = (0x05, "Payload of last API frame was too big to fit into a buffer")
-    STRING_ENTRY_TOO_BIG = (0x06, "String entry was too big on last API frame sent")
+    PAYLOAD_TOO_BIG = (
+        0x05, "Payload of last API frame was too big to fit into a buffer")
+    STRING_ENTRY_TOO_BIG = (
+        0x06, "String entry was too big on last API frame sent")
     WRONG_STATE = (0x07, "Wrong state to receive frame")
-    WRONG_REQUEST_ID = (0x08, "Device request ID of device response didn't match the number in the request")
+    WRONG_REQUEST_ID = (
+        0x08, "Device request ID of device response do not match the number "
+              "in the request")
 
     def __init__(self, code, description):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``FrameError`` element.
+        Returns the code of the `FrameError` element.
 
         Returns:
-            Integer: the code of the ``FrameError`` element.
+            Integer: the code of the `FrameError` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``FrameError`` element.
+        Returns the description of the `FrameError` element.
 
         Returns:
-            String: the description of the ``FrameError`` element.
+            String: the description of the `FrameError` element.
         """
         return self.__description
 
@@ -663,22 +684,15 @@ class FrameError(Enum):
             code (Integer): the code of the frame error to get.
 
         Returns:
-            :class:`.FrameError`: the ``FrameError`` with the given code, ``None`` if there is not any frame error
-                with the provided code.
+            :class:`.FrameError`: the `FrameError` with the given code, `None`
+                if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The frame error code."""
-
-    description = property(__get_description)
-    """String. The frame error description."""
+        for error in cls:
+            if code == error.code:
+                return error
+        return None
 
 
-FrameError.lookupTable = {x.code: x for x in FrameError}
 FrameError.__doc__ += utils.doc_enum(FrameError)
 
 
@@ -687,37 +701,41 @@ class WiFiAssociationIndicationStatus(Enum):
     """
     Enumerates the different Wi-Fi association indication statuses.
     """
-    SUCCESSFULLY_JOINED = (0x00, "Successfully joined to access point.")
-    INITIALIZING = (0x01, "Initialization in progress.")
-    INITIALIZED = (0x02, "Initialized, but not yet scanning.")
-    DISCONNECTING = (0x13, "Disconnecting from access point.")
+    SUCCESSFULLY_JOINED = (0x00, "Successfully joined to access point")
+    INITIALIZING = (0x01, "Initialization in progress")
+    INITIALIZED = (0x02, "Initialized, but not yet scanning")
+    DISCONNECTING = (0x13, "Disconnecting from access point")
     SSID_NOT_CONFIGURED = (0x23, "SSID not configured")
-    INVALID_KEY = (0x24, "Encryption key invalid (NULL or invalid length).")
-    JOIN_FAILED = (0x27, "SSID found, but join failed.")
-    WAITING_FOR_AUTH = (0x40, "Waiting for WPA or WPA2 authentication.")
-    WAITING_FOR_IP = (0x41, "Joined to a network and waiting for IP address.")
-    SETTING_UP_SOCKETS = (0x42, "Joined to a network and IP configured. Setting up listening sockets.")
-    SCANNING_FOR_SSID = (0xFF, "Scanning for the configured SSID.")
+    INVALID_KEY = (0x24, "Encryption key invalid (NULL or invalid length)")
+    JOIN_FAILED = (0x27, "SSID found, but join failed")
+    WAITING_FOR_AUTH = (0x40, "Waiting for WPA or WPA2 authentication")
+    WAITING_FOR_IP = (0x41, "Joined to a network and waiting for IP address")
+    SETTING_UP_SOCKETS = (
+        0x42, "Joined to a network and IP configured. "
+              "Setting up listening sockets")
+    SCANNING_FOR_SSID = (0xFF, "Scanning for the configured SSID")
 
     def __init__(self, code, description):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``WiFiAssociationIndicationStatus`` element.
+        Returns the code of the `WiFiAssociationIndicationStatus` element.
 
         Returns:
-            Integer: the code of the ``WiFiAssociationIndicationStatus`` element.
+            Integer: the code of the `WiFiAssociationIndicationStatus` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``WiFiAssociationIndicationStatus`` element.
+        Returns the description of the `WiFiAssociationIndicationStatus` element.
 
         Returns:
-            String: the description of the ``WiFiAssociationIndicationStatus`` element.
+            String: the description of the `WiFiAssociationIndicationStatus` element.
         """
         return self.__description
 
@@ -727,25 +745,20 @@ class WiFiAssociationIndicationStatus(Enum):
         Returns the Wi-Fi association indication status for the given code.
 
         Args:
-            code (Integer): the code of the Wi-Fi association indication status to get.
+            code (Integer): the code of the Wi-Fi association indication status
+                to get.
 
         Returns:
-            :class:`.WiFiAssociationIndicationStatus`: the ``WiFiAssociationIndicationStatus`` with the given code,
-                ``None`` if there is not any Wi-Fi association indication status with the provided code.
+            :class:`.WiFiAssociationIndicationStatus`: the
+                `WiFiAssociationIndicationStatus` with the given code, `None`
+                if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The Wi-Fi association indication status code."""
-
-    description = property(__get_description)
-    """String. The Wi-Fi association indication status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return None
 
 
-WiFiAssociationIndicationStatus.lookupTable = {x.code: x for x in WiFiAssociationIndicationStatus}
 WiFiAssociationIndicationStatus.__doc__ += utils.doc_enum(WiFiAssociationIndicationStatus)
 
 
@@ -764,21 +777,23 @@ class NetworkDiscoveryStatus(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``NetworkDiscoveryStatus`` element.
+        Returns the code of the `NetworkDiscoveryStatus` element.
 
         Returns:
-            Integer: the code of the ``NetworkDiscoveryStatus`` element.
+            Integer: the code of the `NetworkDiscoveryStatus` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``NetworkDiscoveryStatus`` element.
+        Returns the description of the `NetworkDiscoveryStatus` element.
 
         Returns:
-            String: the description of the ``NetworkDiscoveryStatus`` element.
+            String: the description of the `NetworkDiscoveryStatus` element.
         """
         return self.__description
 
@@ -791,22 +806,15 @@ class NetworkDiscoveryStatus(Enum):
             code (Integer): the code of the network discovery status to get.
 
         Returns:
-            :class:`.NetworkDiscoveryStatus`: the ``NetworkDiscoveryStatus`` with the given code, ``None`` if
-                there is not any status with the provided code.
+            :class:`.NetworkDiscoveryStatus`: the `NetworkDiscoveryStatus` with
+                the given code, `None` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return None
-
-    code = property(__get_code)
-    """Integer. The network discovery status code."""
-
-    description = property(__get_description)
-    """String. The network discovery status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return None
 
 
-NetworkDiscoveryStatus.lookupTable = {x.code: x for x in NetworkDiscoveryStatus}
 NetworkDiscoveryStatus.__doc__ += utils.doc_enum(NetworkDiscoveryStatus)
 
 
@@ -828,21 +836,23 @@ class ZigbeeRegisterStatus(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``ZigbeeRegisterStatus`` element.
+        Returns the code of the `ZigbeeRegisterStatus` element.
 
         Returns:
-            Integer: the code of the ``ZigbeeRegisterStatus`` element.
+            Integer: the code of the `ZigbeeRegisterStatus` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``ZigbeeRegisterStatus`` element.
+        Returns the description of the `ZigbeeRegisterStatus` element.
 
         Returns:
-            String: the description of the ``ZigbeeRegisterStatus`` element.
+            String: the description of the `ZigbeeRegisterStatus` element.
         """
         return self.__description
 
@@ -855,22 +865,15 @@ class ZigbeeRegisterStatus(Enum):
             code (Integer): the code of the Zigbee Device Register status to get.
 
         Returns:
-            :class:`.ZigbeeRegisterStatus`: the ``ZigbeeRegisterStatus`` with the given code,
-                ``ZigbeeRegisterStatus.UNKNOWN`` if there is not any status with the provided code.
+            :class:`.ZigbeeRegisterStatus`: the `ZigbeeRegisterStatus` with the
+                given code, `ZigbeeRegisterStatus.UNKNOWN` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return ZigbeeRegisterStatus.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The Zigbee Device Register status code."""
-
-    description = property(__get_description)
-    """String. The Zigbee Device Register status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return ZigbeeRegisterStatus.UNKNOWN
 
 
-ZigbeeRegisterStatus.lookupTable = {x.code: x for x in ZigbeeRegisterStatus}
 ZigbeeRegisterStatus.__doc__ += utils.doc_enum(ZigbeeRegisterStatus)
 
 
@@ -896,21 +899,23 @@ class SocketStatus(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``SocketStatus`` element.
+        Returns the code of the `SocketStatus` element.
 
         Returns:
-            Integer: the code of the ``SocketStatus`` element.
+            Integer: the code of the `SocketStatus` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``SocketStatus`` element.
+        Returns the description of the `SocketStatus` element.
 
         Returns:
-            String: the description of the ``SocketStatus`` element.
+            String: the description of the `SocketStatus` element.
         """
         return self.__description
 
@@ -923,22 +928,15 @@ class SocketStatus(Enum):
             code (Integer): the code of the Socket status to get.
 
         Returns:
-            :class:`.SocketStatus`: the ``SocketStatus`` with the given code,
-                ``SocketStatus.UNKNOWN`` if there is not any status with the provided code.
+            :class:`.SocketStatus`: the `SocketStatus` with the given code,
+                `SocketStatus.UNKNOWN` if there not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return SocketStatus.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The Socket status code."""
-
-    description = property(__get_description)
-    """String. The Socket status description."""
+        for status in cls:
+            if code == status.code:
+                return status
+        return SocketStatus.UNKNOWN
 
 
-SocketStatus.lookupTable = {x.code: x for x in SocketStatus}
 SocketStatus.__doc__ += utils.doc_enum(SocketStatus)
 
 
@@ -965,21 +963,23 @@ class SocketState(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``SocketState`` element.
+        Returns the code of the `SocketState` element.
 
         Returns:
-            Integer: the code of the ``SocketState`` element.
+            Integer: the code of the `SocketState` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``SocketState`` element.
+        Returns the description of the `SocketState` element.
 
         Returns:
-            String: the description of the ``SocketState`` element.
+            String: the description of the `SocketState` element.
         """
         return self.__description
 
@@ -992,22 +992,15 @@ class SocketState(Enum):
             code (Integer): the code of the Socket state to get.
 
         Returns:
-            :class:`.SocketState`: the ``SocketState`` with the given code,
-                ``SocketState.UNKNOWN`` if there is not any status with the provided code.
+            :class:`.SocketState`: the `SocketState` with the given code,
+                `SocketState.UNKNOWN` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return SocketState.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The Socket state code."""
-
-    description = property(__get_description)
-    """String. The Socket state description."""
+        for state in cls:
+            if code == state.code:
+                return state
+        return SocketState.UNKNOWN
 
 
-SocketState.lookupTable = {x.code: x for x in SocketState}
 SocketState.__doc__ += utils.doc_enum(SocketState)
 
 
@@ -1028,21 +1021,23 @@ class SocketInfoState(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
-        Returns the code of the ``SocketInfoState`` element.
+        Returns the code of the `SocketInfoState` element.
 
         Returns:
-            Integer: the code of the ``SocketInfoState`` element.
+            Integer: the code of the `SocketInfoState` element.
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
-        Returns the description of the ``SocketInfoState`` element.
+        Returns the description of the `SocketInfoState` element.
 
         Returns:
-            String: the description of the ``SocketInfoState`` element.
+            String: the description of the `SocketInfoState` element.
         """
         return self.__description
 
@@ -1055,13 +1050,13 @@ class SocketInfoState(Enum):
             code (Integer): the code of the Socket info state to get.
 
         Returns:
-            :class:`.SocketInfoState`: the ``SocketInfoState`` with the given code,
-                ``SocketInfoState.UNKNOWN`` if there is not any state with the provided code.
+            :class:`.SocketInfoState`: the `SocketInfoState` with the given
+                code, `SocketInfoState.UNKNOWN` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return SocketInfoState.UNKNOWN
+        for state in cls:
+            if code == state.code:
+                return state
+        return SocketInfoState.UNKNOWN
 
     @classmethod
     def get_by_description(cls, description):
@@ -1072,20 +1067,13 @@ class SocketInfoState(Enum):
             description (String): the description of the Socket info state to get.
 
         Returns:
-            :class:`.SocketInfoState`: the ``SocketInfoState`` with the given description,
-                ``SocketInfoState.UNKNOWN`` if there is not any state with the provided description.
+            :class:`.SocketInfoState`: the `SocketInfoState` with the given
+                description, `SocketInfoState.UNKNOWN` if not found.
         """
-        for x in SocketInfoState:
-            if x.description.lower() == description.lower():
-                return x
+        for state in SocketInfoState:
+            if state.description.lower() == description.lower():
+                return state
         return SocketInfoState.UNKNOWN
 
-    code = property(__get_code)
-    """Integer. The Socket info state code."""
 
-    description = property(__get_description)
-    """String. The Socket info state description."""
-
-
-SocketInfoState.lookupTable = {x.code: x for x in SocketInfoState}
 SocketInfoState.__doc__ += utils.doc_enum(SocketInfoState)

--- a/digi/xbee/packets/aft.py
+++ b/digi/xbee/packets/aft.py
@@ -19,16 +19,18 @@ from digi.xbee.util import utils
 @unique
 class ApiFrameType(Enum):
     """
-    This enumeration lists all the available frame types used in any XBee protocol.
-    
+    This enumeration lists all the available frame types used in any XBee
+    protocol.
+
     | Inherited properties:
     |     **name** (String): the name (id) of this ApiFrameType.
     |     **value** (String): the value of this ApiFrameType.
-    
+
     """
     TX_64 = (0x00, "TX (Transmit) Request 64-bit address")
     TX_16 = (0x01, "TX (Transmit) Request 16-bit address")
-    REMOTE_AT_COMMAND_REQUEST_WIFI = (0x07, "Remote AT Command Request (Wi-Fi)")
+    REMOTE_AT_COMMAND_REQUEST_WIFI = (
+        0x07, "Remote AT Command Request (Wi-Fi)")
     AT_COMMAND = (0x08, "AT Command")
     AT_COMMAND_QUEUE = (0x09, "AT Command Queue")
     TRANSMIT_REQUEST = (0x10, "Transmit Request")
@@ -52,13 +54,15 @@ class ApiFrameType(Enum):
     RX_16 = (0x81, "RX (Receive) Packet 16-bit Address")
     RX_IO_64 = (0x82, "IO Data Sample RX 64-bit Address Indicator")
     RX_IO_16 = (0x83, "IO Data Sample RX 16-bit Address Indicator")
-    REMOTE_AT_COMMAND_RESPONSE_WIFI = (0x87, "Remote AT Command Response (Wi-Fi)")
+    REMOTE_AT_COMMAND_RESPONSE_WIFI = (
+        0x87, "Remote AT Command Response (Wi-Fi)")
     AT_COMMAND_RESPONSE = (0x88, "AT Command Response")
     TX_STATUS = (0x89, "TX (Transmit) Status")
     MODEM_STATUS = (0x8A, "Modem Status")
     TRANSMIT_STATUS = (0x8B, "Transmit Status")
     DIGIMESH_ROUTE_INFORMATION = (0x8D, "Route Information")
-    IO_DATA_SAMPLE_RX_INDICATOR_WIFI = (0x8F, "IO Data Sample RX Indicator (Wi-Fi)")
+    IO_DATA_SAMPLE_RX_INDICATOR_WIFI = (
+        0x8F, "IO Data Sample RX Indicator (Wi-Fi)")
     RECEIVE_PACKET = (0x90, "Receive Packet")
     EXPLICIT_RX_INDICATOR = (0x91, "Explicit RX Indicator")
     IO_DATA_SAMPLE_RX_INDICATOR = (0x92, "IO Data Sample RX Indicator")
@@ -88,7 +92,8 @@ class ApiFrameType(Enum):
         self.__code = code
         self.__description = description
 
-    def __get_code(self):
+    @property
+    def code(self):
         """
         Returns the code of the ApiFrameType element.
 
@@ -97,7 +102,8 @@ class ApiFrameType(Enum):
         """
         return self.__code
 
-    def __get_description(self):
+    @property
+    def description(self):
         """
         Returns the description of the ApiFrameType element.
 
@@ -115,21 +121,13 @@ class ApiFrameType(Enum):
             code (Integer): the code of the API frame type to get.
 
         Returns:
-            :class:`.ApiFrameType`: the API frame type associated to the given code or ``UNKNOWN`` if
-                the given code is not a valid ApiFrameType code.
+            :class:`.ApiFrameType`: the API frame type associated to the given
+                code or `UNKNOWN` if not found.
         """
-        try:
-            return cls.lookupTable[code]
-        except KeyError:
-            return ApiFrameType.UNKNOWN
-
-    code = property(__get_code)
-    """Integer. The API frame type code."""
-
-    description = property(__get_description)
-    """String. The API frame type description."""
+        for frame_type in cls:
+            if code == frame_type.code:
+                return frame_type
+        return ApiFrameType.UNKNOWN
 
 
-# Dictionary<Integer, ApiFrameType: Used to determine the ApiFrameType from Integer.
-ApiFrameType.lookupTable = {x.code: x for x in ApiFrameType}
 ApiFrameType.__doc__ += utils.doc_enum(ApiFrameType)

--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -13,19 +13,20 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 from abc import ABCMeta, abstractmethod
+from enum import Enum, unique
+
 from digi.xbee.packets.aft import ApiFrameType
 from digi.xbee.models.atcomm import SpecialByte
 from digi.xbee.models.mode import OperatingMode
 from digi.xbee.exception import InvalidPacketException, InvalidOperatingModeException
 from digi.xbee.util import utils
-from enum import Enum, unique
 
 
 @unique
 class DictKeys(Enum):
     """
-    This enumeration contains all keys used in dictionaries returned by ``to_dict()``
-    method of :class:`.XBeePacket`.
+    This enumeration contains all keys used in dictionaries returned by
+    `to_dict()` method of :class:`.XBeePacket`.
     """
 
     HEADER_BYTE = "header"
@@ -104,10 +105,11 @@ class DictKeys(Enum):
 class XBeePacket:
     """
     This abstract class represents the basic structure of an XBee packet.
- 
-    Derived classes should implement their own payload generation depending on their type.
-    
-    Generic actions like checksum compute or packet length calculation is performed here.
+    Derived classes should implement their own payload generation depending on
+    their type.
+
+    Generic actions like checksum compute or packet length calculation is
+    performed here.
     """
 
     __HASH_SEED = 23
@@ -121,17 +123,15 @@ class XBeePacket:
         """
         Class constructor. Instantiates a new :class:`.XBeePacket` object.
         """
-        pass
 
     def __len__(self):
         """
-        Returns the length value of the XBeePacket.
-        
-        The length is the number of bytes between the length field and the checksum field.
-        
+        Returns the length value of the XBeePacket. The length is the number of
+        bytes between the length field and the checksum field.
+
         Returns:
             Integer: length value of the XBeePacket.
-            
+
         .. seealso::
            | :mod:`.factory`
         """
@@ -140,7 +140,7 @@ class XBeePacket:
     def __str__(self):
         """
         Returns the packet information as dictionary.
-        
+
         Returns:
             Dictionary: the packet information.
         """
@@ -154,7 +154,7 @@ class XBeePacket:
             other: the object to compare.
 
         Returns:
-            Boolean: ``True`` if the objects are equal, ``False`` otherwise.
+            Boolean: `True` if the objects are equal, `False` otherwise.
         """
         if not isinstance(other, XBeePacket):
             return False
@@ -168,19 +168,19 @@ class XBeePacket:
             Integer: hash code value for the object.
         """
         res = self.__HASH_SEED
-        for b in self.output():
-            res = 31 * (res + b)
+        for byte in self.output():
+            res = 31 * (res + byte)
         return res
 
     def get_checksum(self):
         """
         Returns the checksum value of this XBeePacket.
-        
-        The checksum is the last 8 bits of the sum of the bytes between the length field and the checksum field.
-        
+        The checksum is the last 8 bits of the sum of the bytes between the
+        length field and the checksum field.
+
         Returns:
             Integer: checksum value of this XBeePacket.
-        
+
         .. seealso::
            | :mod:`.factory`
         """
@@ -188,11 +188,12 @@ class XBeePacket:
 
     def output(self, escaped=False):
         """
-        Returns the raw bytearray of this XBeePacket, ready to be send by the serial port.
-        
+        Returns the raw bytearray of this XBeePacket, ready to be send by the
+        serial port.
+
         Args:
-            escaped (Boolean): indicates if the raw bytearray will be escaped or not.
-        
+            escaped (Boolean): indicates if the raw bytearray must be escaped.
+
         Returns:
             Bytearray: raw bytearray of the XBeePacket.
         """
@@ -205,9 +206,9 @@ class XBeePacket:
     def to_dict(self):
         """
         Returns a dictionary with all information of the XBeePacket fields.
-        
+
         Returns:
-            Dictionary: dictionary with all information of the XBeePacket fields.
+            Dictionary: dictionary with all info of the XBeePacket fields.
         """
         return {DictKeys.HEADER_BYTE:     SpecialByte.HEADER_BYTE.code,
                 DictKeys.LENGTH:          len(self),
@@ -217,49 +218,53 @@ class XBeePacket:
     @staticmethod
     def create_packet(raw, operating_mode):
         """
-        Abstract method.
-        Creates a full XBeePacket with the given parameters.
-        This function ensures that the XBeePacket returned is valid and is well built (if not exceptions are raised).
-        
-        If _OPERATING_MODE is API2 (API escaped) this method des-escape 'raw' and build the XBeePacket.
-        Then, you can use :meth:`.XBeePacket.output` to get the escaped bytearray or not escaped.
-        
+        Abstract method. Creates a full XBeePacket with the given parameters.
+        This function ensures that the XBeePacket returned is valid and is well
+        built (if not exceptions are raised).
+
+        If _OPERATING_MODE is API2 (API escaped) this method des-escape 'raw'
+        and build the XBeePacket. Then, you can use :meth:`.XBeePacket.output`
+        to get the escaped bytearray or not escaped.
+
         Args:
-            raw (Bytearray): bytearray with which the frame will be built. Must be a full frame
-                represented by a bytearray.
-            operating_mode (:class:`.OperatingMode`): The mode in which the frame ('byteArray') was captured.
-            
+            raw (Bytearray): bytearray with which the frame will be built.
+                Must be a full frame represented by a bytearray.
+            operating_mode (:class:`.OperatingMode`): The mode in which the
+                frame ('byteArray') was captured.
+
         Returns:
             :class:`.XBeePacket`: the XBee packet created.
-        
+
         Raises:
-            InvalidPacketException: if something is wrong with ``raw`` and the packet cannot be built well.
+            InvalidPacketException: if something is wrong with `raw` and the
+                packet cannot be built well.
         """
         raise NotImplementedError("Implement this function.")
 
     @abstractmethod
     def get_frame_spec_data(self):
         """
-        Returns the data between the length field and the checksum field as bytearray.
-        This data is never escaped.
-        
+        Returns the data between the length field and the checksum field as
+        bytearray. This data is never escaped.
+
         Returns:
-            Bytearray: the data between the length field and the checksum field as bytearray.
-        
+            Bytearray: the data between the length field and the checksum field
+                as bytearray.
+
         .. seealso::
            | :mod:`.factory`
         """
-        pass
 
     @abstractmethod
     def _get_frame_spec_data_dict(self):
         """
-        Similar to :meth:`.XBeePacket.get_frame_spec_data` but returns the data as dictionary.
-        
+        Similar to :meth:`.XBeePacket.get_frame_spec_data` but returns the data
+        as dictionary.
+
         Returns:
-            Dictionary: the data between the length field and the checksum field as bytearray.
+            Dictionary: the data between the length field and the checksum
+                field as dictionary.
         """
-        pass
 
     @staticmethod
     def _escape_data(data):
@@ -290,7 +295,7 @@ class XBeePacket:
             data (Bytearray): the bytearray to unescape.
 
         Returns:
-            Bytearray: ``data`` unescaped.
+            Bytearray: `data` unescaped.
         """
         new_data = bytearray(0)
         des_escape = False
@@ -305,11 +310,12 @@ class XBeePacket:
     def __build_complete_frame_without_header(self, frame_spec_data):
         """
         Builds a complete non-escaped frame from the given frame specific data.
-        Complete frame is: Start delimiter + length + frame specific data + checksum.
-        
+        Complete frame is:
+            Start delimiter + length + frame specific data + checksum.
+
         Args:
             frame_spec_data (Bytearray): the frame specific data.
-            
+
         Returns:
             Bytearray: the complete frame as bytearray.
         """
@@ -321,12 +327,11 @@ class XBeePacket:
 class XBeeAPIPacket(XBeePacket):
     """
     This abstract class provides the basic structure of a API frame.
-    
-    Derived classes should implement their own methods to generate the API 
+    Derived classes should implement their own methods to generate the API
     data and frame ID in case they support it.
-    
+
     Basic operations such as frame type retrieval are performed in this class.
-    
+
     .. seealso::
        | :class:`.XBeePacket`
     """
@@ -334,10 +339,12 @@ class XBeeAPIPacket(XBeePacket):
 
     def __init__(self, api_frame_type):
         """
-        Class constructor. Instantiates a new :class:`.XBeeAPIPacket` object with the provided parameters.
-        
+        Class constructor. Instantiates a new :class:`.XBeeAPIPacket` object
+        with the provided parameters.
+
         Args:
-            api_frame_type (:class:`.ApiFrameType` or Integer): The API frame type.
+            api_frame_type (:class:`.ApiFrameType` or Integer): The API frame
+                type.
 
         .. seealso::
            | :class:`.ApiFrameType`
@@ -356,7 +363,7 @@ class XBeeAPIPacket(XBeePacket):
     def get_frame_spec_data(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeePacket.get_frame_spec_data`
         """
@@ -369,7 +376,7 @@ class XBeeAPIPacket(XBeePacket):
     def get_frame_type(self):
         """
         Returns the frame type of this packet.
-        
+
         Returns:
             :class:`.ApiFrameType`: the frame type of this packet.
 
@@ -393,7 +400,7 @@ class XBeeAPIPacket(XBeePacket):
     def _get_frame_spec_data_dict(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeePacket.get_frame_spec_data_dict`
         """
@@ -404,13 +411,14 @@ class XBeeAPIPacket(XBeePacket):
     def is_broadcast(self):
         """
         Returns whether this packet is broadcast or not.
-        
+
         Returns:
-            Boolean: ``True`` if this packet is broadcast, ``False`` otherwise.
+            Boolean: `True` if this packet is broadcast, `False` otherwise.
         """
         return False
 
-    def __get_frame_id(self):
+    @property
+    def frame_id(self):
         """
         Returns the frame ID of the packet.
 
@@ -419,15 +427,17 @@ class XBeeAPIPacket(XBeePacket):
         """
         return self._frame_id
 
-    def __set_frame_id(self, frame_id):
+    @frame_id.setter
+    def frame_id(self, frame_id):
         """
         Sets the frame ID of the packet.
 
         Args:
-            frame_id (Integer): the new frame ID of the packet. Must be between 0 and 255.
+            frame_id (Integer): the new frame ID of the packet. Must be between
+                0 and 255.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255.")
@@ -437,36 +447,42 @@ class XBeeAPIPacket(XBeePacket):
     def _check_api_packet(raw, min_length=5):
         """
         Checks the not escaped  bytearray 'raw' meets conditions.
-        
+
         Args:
             raw (Bytearray): non-escaped bytearray to be checked.
             min_length (Integer): the minimum length of the packet in bytes.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 5. (start delim. + length (2 bytes) +
-                frame type + checksum = 5 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field:
-                bytes 2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-        
+            InvalidPacketException: if the bytearray length is less than 5.
+                (start delim. + length (2 bytes) + frame type + checksum = 5 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+
         .. seealso::
            | :mod:`.factory`
         """
         if len(raw) < min_length:
-            raise InvalidPacketException(message="Bytearray must have, at least, 5 of complete length (header, length, "
-                                         "frameType, checksum)")
+            raise InvalidPacketException(
+                message="Bytearray must have, at least, 5 of complete length "
+                        "(header, length, frameType, checksum)")
 
         if raw[0] & 0xFF != SpecialByte.HEADER_BYTE.code:
-            raise InvalidPacketException(message="Bytearray must start with the header byte (SpecialByte.HEADER_BYTE.code)")
+            raise InvalidPacketException(
+                message="Bytearray must start with the header byte "
+                        "(SpecialByte.HEADER_BYTE.code)")
 
         # real frame specific data length
         real_length = len(raw[3:-1])
         # length is specified in the length field.
         length_field = utils.length_to_int(raw[1:3])
         if real_length != length_field:
-            raise InvalidPacketException(message="The real length of this frame is distinct than the specified by length "
-                                         "field (bytes 2 and 3)")
+            raise InvalidPacketException(
+                message="The real length of this frame is distinct than the "
+                        "specified by length field (bytes 2 and 3)")
 
         if 0xFF - (sum(raw[3:-1]) & 0xFF) != raw[-1]:
             raise InvalidPacketException(message="Wrong checksum")
@@ -475,33 +491,29 @@ class XBeeAPIPacket(XBeePacket):
     def _get_api_packet_spec_data(self):
         """
         Returns the frame specific data without frame type and frame ID fields.
-        
+
         Returns:
             Bytearray: the frame specific data without frame type and frame ID fields.
         """
-        pass
 
     @abstractmethod
     def needs_id(self):
         """
         Returns whether the packet requires frame ID or not.
-        
+
         Returns:
-            Boolean: ``True`` if the packet needs frame ID, ``False`` otherwise.
+            Boolean: `True` if the packet needs frame ID, `False` otherwise.
         """
-        pass
 
     @abstractmethod
     def _get_api_packet_spec_data_dict(self):
         """
-        Similar to :meth:`XBeeAPIPacket._get_api_packet_spec_data` but returns data as dictionary or list.
-        
+        Similar to :meth:`XBeeAPIPacket._get_api_packet_spec_data` but returns
+        data as dictionary or list.
+
         Returns:
             Dictionary: data as dictionary or list.
         """
-        pass
-
-    frame_id = property(__get_frame_id, __set_frame_id)
 
 
 class GenericXBeePacket(XBeeAPIPacket):
@@ -516,11 +528,13 @@ class GenericXBeePacket(XBeeAPIPacket):
 
     def __init__(self, rf_data):
         """
-        Class constructor. Instantiates a :class:`.GenericXBeePacket` object with the provided parameters.
-        
+        Class constructor. Instantiates a :class:`.GenericXBeePacket` object
+        with the provided parameters.
+
         Args:
-            rf_data (bytearray): the frame specific data without frame type and frame ID.
-        
+            rf_data (bytearray): the frame specific data without frame type and
+                frame ID.
+
         .. seealso::
            | :mod:`.factory`
            | :class:`.XBeeAPIPacket`
@@ -535,22 +549,26 @@ class GenericXBeePacket(XBeeAPIPacket):
 
         Returns:
             :class:`.GenericXBeePacket`: the GenericXBeePacket generated.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 5. (start delim. + length (2 bytes) +
-                frame type + checksum = 5 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.GENERIC`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 5.
+                (start delim. + length (2 bytes) + frame type + checksum = 5 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.GENERIC`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=GenericXBeePacket.__MIN_PACKET_LENGTH)
@@ -564,7 +582,7 @@ class GenericXBeePacket(XBeeAPIPacket):
     def _get_api_packet_spec_data(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
         """
@@ -573,7 +591,7 @@ class GenericXBeePacket(XBeeAPIPacket):
     def needs_id(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket.needs_id`
         """
@@ -582,7 +600,7 @@ class GenericXBeePacket(XBeeAPIPacket):
     def _get_api_packet_spec_data_dict(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data_dict`
         """
@@ -601,7 +619,8 @@ class UnknownXBeePacket(XBeeAPIPacket):
 
     def __init__(self, api_frame, rf_data):
         """
-        Class constructor. Instantiates a :class:`.UnknownXBeePacket` object with the provided parameters.
+        Class constructor. Instantiates a :class:`.UnknownXBeePacket` object
+        with the provided parameters.
 
         Args:
             api_frame (Integer): the API frame integer value of this packet.
@@ -623,19 +642,22 @@ class UnknownXBeePacket(XBeeAPIPacket):
             :class:`.UnknownXBeePacket`: the UnknownXBeePacket generated.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 5. (start delim. + length (2 bytes) +
-                frame type + checksum = 5 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 5.
+                (start delim. + length (2 bytes) + frame type + checksum = 5 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=UnknownXBeePacket.__MIN_PACKET_LENGTH)

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -25,13 +25,13 @@ from digi.xbee.io import IOSample, IOLine
 class ATCommPacket(XBeeAPIPacket):
     """
     This class represents an AT command packet.
-    
+
     Used to query or set module parameters on the local device. This API
     command applies changes after executing the command. (Changes made to
     module parameters take effect once changes are applied.).
-    
+
     Command response is received as an :class:`.ATCommResponsePacket`.
-    
+
     .. seealso::
        | :class:`.ATCommResponsePacket`
        | :class:`.XBeeAPIPacket`
@@ -41,16 +41,17 @@ class ATCommPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, command, parameter=None):
         """
-        Class constructor. Instantiates a new :class:`.ATCommPacket` object with the provided parameters.
-        
+        Class constructor. Instantiates a new :class:`.ATCommPacket` object
+        with the provided parameters.
+
         Args:
             frame_id (Integer): the frame ID of the packet.
             command (String): the AT command of the packet. Must be a string.
             parameter (Bytearray, optional): the AT command parameter. Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if length of `command` is different from 2.
 
         .. seealso::
             | :class:`.XBeeAPIPacket`
@@ -73,22 +74,27 @@ class ATCommPacket(XBeeAPIPacket):
 
         Returns:
             :class:`.ATCommPacket`
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 6. (start delim. + length (2 bytes) + frame
-                type + frame id + checksum = 6 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.AT_COMMAND`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 6.
+                (start delim. + length (2 bytes) + frame type
+                + frame id + checksum = 6 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.AT_COMMAND`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommPacket.__MIN_PACKET_LENGTH)
@@ -128,52 +134,50 @@ class ATCommPacket(XBeeAPIPacket):
         return {DictKeys.COMMAND: self.__command,
                 DictKeys.PARAMETER: list(self.__parameter) if self.__parameter is not None else None}
 
-    def __get_command(self):
+    @property
+    def command(self):
         """
         Returns the AT command of the packet.
-        
+
         Returns:
             String: the AT command of the packet.
         """
         return self.__command
 
-    def __set_command(self, command):
+    @command.setter
+    def command(self, command):
         """
         Sets the AT command of the packet.
-        
+
         Args:
             command (String): the new AT command of the packet. Must have length = 2.
-            
+
         Raises:
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if length of `command` is different from 2.
         """
         if len(command) != 2:
             raise ValueError("Invalid command " + command)
         self.__command = command
 
-    def __get_parameter(self):
+    @property
+    def parameter(self):
         """
         Returns the parameter of the packet.
-        
+
         Returns:
             Bytearray: the parameter of the packet.
         """
         return self.__parameter
 
-    def __set_parameter(self, param):
+    @parameter.setter
+    def parameter(self, param):
         """
         Sets the parameter of the packet.
-        
+
         Args:
             param (Bytearray): the new parameter of the packet.
         """
         self.__parameter = param
-
-    command = property(__get_command, __set_command)
-    """String. AT command."""
-
-    parameter = property(__get_parameter, __set_parameter)
-    """Bytearray. AT command parameter."""
 
 
 class ATCommQueuePacket(XBeeAPIPacket):
@@ -184,7 +188,7 @@ class ATCommQueuePacket(XBeeAPIPacket):
 
     In contrast to the :class:`.ATCommPacket` API packet, new parameter
     values are queued and not applied until either an :class:`.ATCommPacket`
-    is sent or the ``applyChanges()`` method of the :class:`.XBeeDevice`
+    is sent or the `applyChanges()` method of the :class:`.XBeeDevice`
     class is issued.
 
     Command response is received as an :class:`.ATCommResponsePacket`.
@@ -198,7 +202,8 @@ class ATCommQueuePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, command, parameter=None):
         """
-        Class constructor. Instantiates a new :class:`.ATCommQueuePacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.ATCommQueuePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -206,8 +211,8 @@ class ATCommQueuePacket(XBeeAPIPacket):
             parameter (Bytearray, optional): the AT command parameter. Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if length of `command` is different from 2.
 
         .. seealso::
             | :class:`.XBeeAPIPacket`
@@ -232,20 +237,25 @@ class ATCommQueuePacket(XBeeAPIPacket):
             :class:`.ATCommQueuePacket`
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 6. (start delim. + length (2 bytes) + frame
-                type + frame id + checksum = 6 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.AT_COMMAND_QUEUE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 6.
+                (start delim. + length (2 bytes) + frame type
+                + frame id + checksum = 6 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.AT_COMMAND_QUEUE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommQueuePacket.__MIN_PACKET_LENGTH)
@@ -285,7 +295,8 @@ class ATCommQueuePacket(XBeeAPIPacket):
         return {DictKeys.COMMAND: self.__command,
                 DictKeys.PARAMETER: list(self.__parameter) if self.__parameter is not None else None}
 
-    def __get_command(self):
+    @property
+    def command(self):
         """
         Returns the AT command of the packet.
 
@@ -294,7 +305,8 @@ class ATCommQueuePacket(XBeeAPIPacket):
         """
         return self.__command
 
-    def __set_command(self, command):
+    @command.setter
+    def command(self, command):
         """
         Sets the AT command of the packet.
 
@@ -302,13 +314,14 @@ class ATCommQueuePacket(XBeeAPIPacket):
             command (String): the new AT command of the packet. Must have length = 2.
 
         Raises:
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if length of `command` is different from 2.
         """
         if len(command) != 2:
             raise ValueError("Invalid command " + command)
         self.__command = command
 
-    def __get_parameter(self):
+    @property
+    def parameter(self):
         """
         Returns the parameter of the packet.
 
@@ -317,7 +330,8 @@ class ATCommQueuePacket(XBeeAPIPacket):
         """
         return self.__parameter
 
-    def __set_parameter(self, param):
+    @parameter.setter
+    def parameter(self, param):
         """
         Sets the parameter of the packet.
 
@@ -326,26 +340,20 @@ class ATCommQueuePacket(XBeeAPIPacket):
         """
         self.__parameter = param
 
-    command = property(__get_command, __set_command)
-    """String. AT command."""
-
-    parameter = property(__get_parameter, __set_parameter)
-    """Bytearray. AT command parameter."""
-
 
 class ATCommResponsePacket(XBeeAPIPacket):
     """
     This class represents an AT command response packet.
-    
-    In response to an AT command message, the module will send an AT command 
+
+    In response to an AT command message, the module will send an AT command
     response message. Some commands will send back multiple frames (for example,
-    the ``ND`` - Node Discover command).
-    
+    the `ND` - Node Discover command).
+
     This packet is received in response of an :class:`.ATCommPacket`.
-    
+
     Response also includes an :class:`.ATCommandStatus` object with the status
     of the AT command.
-    
+
     .. seealso::
        | :class:`.ATCommPacket`
        | :class:`.ATCommandStatus`
@@ -356,7 +364,8 @@ class ATCommResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, command, response_status=ATCommandStatus.OK, comm_value=None):
         """
-        Class constructor. Instantiates a new :class:`.ATCommResponsePacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.ATCommResponsePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet. Must be between 0 and 255.
@@ -365,8 +374,8 @@ class ATCommResponsePacket(XBeeAPIPacket):
             comm_value (Bytearray, optional): the AT command response value. Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if length of `command` is different from 2.
 
         .. seealso::
            | :class:`.ATCommandStatus`
@@ -397,26 +406,32 @@ class ATCommResponsePacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.ATCommResponsePacket`
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 9. (start delim. + length (2 bytes) +
-                frame type + frame id + at command (2 bytes) + command status + checksum = 9 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.AT_COMMAND_RESPONSE`.
-            InvalidPacketException: if the command status field is not a valid value. See :class:`.ATCommandStatus`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 9.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + at command (2 bytes) + command status + checksum = 9 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.AT_COMMAND_RESPONSE`.
+            InvalidPacketException: if the command status field is not a valid
+                value. See :class:`.ATCommandStatus`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommResponsePacket.__MIN_PACKET_LENGTH)
@@ -461,48 +476,53 @@ class ATCommResponsePacket(XBeeAPIPacket):
                 DictKeys.AT_CMD_STATUS: self.__response_status,
                 DictKeys.RF_DATA: list(self.__comm_value) if self.__comm_value is not None else None}
 
-    def __get_command(self):
+    @property
+    def command(self):
         """
         Returns the AT command of the packet.
-        
+
         Returns:
             String: the AT command of the packet.
         """
         return self.__command
 
-    def __set_command(self, command):
+    @command.setter
+    def command(self, command):
         """
         Sets the AT command of the packet.
-        
+
         Args:
             command (String): the new AT command of the packet. Must have length = 2.
-        
+
         Raises:
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if length of `command` is different from 2.
         """
         if len(command) != 2:
             raise ValueError("Invalid command " + command)
         self.__command = command
 
-    def __get_value(self):
+    @property
+    def command_value(self):
         """
         Returns the AT command response value.
-        
+
         Returns:
             Bytearray: the AT command response value.
         """
         return self.__comm_value
 
-    def __set_value(self, __comm_value):
+    @command_value.setter
+    def command_value(self, __comm_value):
         """
         Sets the AT command response value.
-        
+
         Args:
             __comm_value (Bytearray): the new AT command response value.
         """
         self.__comm_value = __comm_value
 
-    def __get_response_status(self):
+    @property
+    def status(self):
         """
         Returns the AT command response status of the packet.
 
@@ -514,7 +534,8 @@ class ATCommResponsePacket(XBeeAPIPacket):
         """
         return ATCommandStatus.get(self.__response_status)
 
-    def __get_real_response_status(self):
+    @property
+    def real_status(self):
         """
         Returns the AT command response status of the packet.
 
@@ -523,7 +544,8 @@ class ATCommResponsePacket(XBeeAPIPacket):
         """
         return self.__response_status
 
-    def __set_response_status(self, response_status):
+    @status.setter
+    def status(self, response_status):
         """
         Sets the AT command response status of the packet
 
@@ -549,33 +571,21 @@ class ATCommResponsePacket(XBeeAPIPacket):
                 "Response status must be ATCommandStatus or int not {!r}".
                 format(response_status.__class__.__name__))
 
-    command = property(__get_command, __set_command)
-    """String. AT command."""
-
-    command_value = property(__get_value, __set_value)
-    """Bytearray. AT command value."""
-
-    status = property(__get_response_status, __set_response_status)
-    """:class:`.ATCommandStatus`. AT command response status."""
-
-    real_status = property(__get_real_response_status, __set_response_status)
-    """Integer. AT command response status."""
-
 
 class ReceivePacket(XBeeAPIPacket):
     """
     This class represents a receive packet. Packet is built using the parameters
     of the constructor or providing a valid byte array.
-    
-    When the module receives an RF packet, it is sent out the UART using this 
+
+    When the module receives an RF packet, it is sent out the UART using this
     message type.
-    
-    This packet is received when external devices send transmit request 
+
+    This packet is received when external devices send transmit request
     packets to this module.
-    
-    Among received data, some options can also be received indicating 
+
+    Among received data, some options can also be received indicating
     transmission parameters.
-    
+
     .. seealso::
        | :class:`.TransmitPacket`
        | :class:`.ReceiveOptions`
@@ -586,8 +596,9 @@ class ReceivePacket(XBeeAPIPacket):
 
     def __init__(self, x64bit_addr, x16bit_addr, receive_options, rf_data=None):
         """
-        Class constructor. Instantiates a new :class:`.ReceivePacket` object with the provided parameters.
-        
+        Class constructor. Instantiates a new :class:`.ReceivePacket` object
+        with the provided parameters.
+
         Args:
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit source address.
             x16bit_addr (:class:`.XBee16BitAddress`): the 16-bit source address.
@@ -610,25 +621,30 @@ class ReceivePacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.ATCommResponsePacket`
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 16. (start delim. + length (2 bytes) + frame
-                type + frame id + 64bit addr. + 16bit addr. + Receive options + checksum = 16 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.RECEIVE_PACKET`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 16.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + 64bit addr. + 16bit addr. + Receive options + checksum = 16 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.RECEIVE_PACKET`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ReceivePacket.__MIN_PACKET_LENGTH)
@@ -684,7 +700,8 @@ class ReceivePacket(XBeeAPIPacket):
                 DictKeys.RECEIVE_OPTIONS: self.__receive_options,
                 DictKeys.RF_DATA:         list(self.__rf_data) if self.__rf_data is not None else None}
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
 
@@ -696,10 +713,11 @@ class ReceivePacket(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_source_addr.setter
+    def x64bit_source_addr(self, x64bit_addr):
         """
         Sets the 64-bit source address.
-        
+
         Args:
             x64bit_addr (:class:`.XBee64BitAddress`): the new 64-bit source address.
 
@@ -708,7 +726,8 @@ class ReceivePacket(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_source_addr(self):
         """
         Returns the 16-bit source address.
 
@@ -720,10 +739,11 @@ class ReceivePacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_source_addr.setter
+    def x16bit_source_addr(self, x16bit_addr):
         """
         Sets the 16-bit source address.
-        
+
         Args:
             x16bit_addr (:class:`.XBee16BitAddress`): the new 16-bit source address.
 
@@ -732,7 +752,8 @@ class ReceivePacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    def __get_options(self):
+    @property
+    def receive_options(self):
         """
         Returns the receive options bitfield.
 
@@ -744,10 +765,11 @@ class ReceivePacket(XBeeAPIPacket):
         """
         return self.__receive_options
 
-    def __set_options(self, receive_options):
+    @receive_options.setter
+    def receive_options(self, receive_options):
         """
         Sets the receive options bitfield.
-        
+
         Args:
             receive_options (Integer): the new receive options bitfield.
 
@@ -756,7 +778,8 @@ class ReceivePacket(XBeeAPIPacket):
         """
         self.__receive_options = receive_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the received RF data.
 
@@ -767,10 +790,11 @@ class ReceivePacket(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the received RF data.
-        
+
         Args:
             rf_data (Bytearray): the new received RF data.
         """
@@ -779,33 +803,21 @@ class ReceivePacket(XBeeAPIPacket):
         else:
             self.__rf_data = rf_data.copy()
 
-    x64bit_source_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit source address."""
-
-    x16bit_source_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit source address."""
-
-    receive_options = property(__get_options, __set_options)
-    """Integer. Receive options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. Received RF data."""
-
 
 class RemoteATCommandPacket(XBeeAPIPacket):
     """
     This class represents a Remote AT command Request packet. Packet is built
     using the parameters of the constructor or providing a valid byte array.
-    
-    Used to query or set module parameters on a remote device. For parameter 
-    changes on the remote device to take effect, changes must be applied, either 
-    by setting the apply changes options bit, or by sending an ``AC`` command
+
+    Used to query or set module parameters on a remote device. For parameter
+    changes on the remote device to take effect, changes must be applied, either
+    by setting the apply changes options bit, or by sending an `AC` command
     to the remote node.
-    
+
     Remote command options are set as a bitfield.
-    
+
     If configured, command response is received as a :class:`.RemoteATCommandResponsePacket`.
-    
+
     .. seealso::
        | :class:`.RemoteATCommandResponsePacket`
        | :class:`.XBeeAPIPacket`
@@ -815,8 +827,9 @@ class RemoteATCommandPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, x64bit_addr, x16bit_addr, transmit_options, command, parameter=None):
         """
-        Class constructor. Instantiates a new :class:`.RemoteATCommandPacket` object with the provided parameters.
-        
+        Class constructor. Instantiates a new :class:`.RemoteATCommandPacket`
+        object with the provided parameters.
+
         Args:
             frame_id (integer): the frame ID of the packet.
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit destination address.
@@ -824,11 +837,11 @@ class RemoteATCommandPacket(XBeeAPIPacket):
             transmit_options (Integer): bitfield of supported transmission options.
             command (String): AT command to send.
             parameter (Bytearray, optional): AT command parameter. Optional.
-        
+
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if length of ``command`` is different than 2.
-            
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if length of `command` is different from 2.
+
         .. seealso::
            | :class:`.RemoteATCmdOptions`
            | :class:`.XBee16BitAddress`
@@ -853,26 +866,31 @@ class RemoteATCommandPacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.RemoteATCommandPacket`
-            
+
         Raises:
-            InvalidPacketException: if the Bytearray length is less than 19. (start delim. + length (2 bytes) + frame
-                type + frame id + 64bit addr. + 16bit addr. + transmit options + command (2 bytes) + checksum =
-                19 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.REMOTE_AT_COMMAND_REQUEST`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the Bytearray length is less than 19.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + 64bit addr. + 16bit addr. + transmit options
+                + command (2 bytes) + checksum = 19 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.REMOTE_AT_COMMAND_REQUEST`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandPacket.__MIN_PACKET_LENGTH)
@@ -880,14 +898,9 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_REQUEST.code:
             raise InvalidPacketException(message="This packet is not a remote AT command request packet.")
 
-        return RemoteATCommandPacket(
-                raw[4],
-                XBee64BitAddress(raw[5:13]),
-                XBee16BitAddress(raw[13:15]),
-                raw[15],
-                raw[16:18].decode("utf8"),
-                raw[18:-1]
-        )
+        return RemoteATCommandPacket(raw[4], XBee64BitAddress(raw[5:13]),
+                                     XBee16BitAddress(raw[13:15]), raw[15],
+                                     raw[16:18].decode("utf8"), raw[18:-1])
 
     def needs_id(self):
         """
@@ -924,7 +937,8 @@ class RemoteATCommandPacket(XBeeAPIPacket):
                 DictKeys.COMMAND: self.__command,
                 DictKeys.PARAMETER: list(self.__parameter) if self.__parameter is not None else None}
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_dest_addr(self):
         """
         Returns the 64-bit destination address.
 
@@ -936,10 +950,11 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_dest_addr.setter
+    def x64bit_dest_addr(self, x64bit_addr):
         """
         Sets the 64-bit destination address.
-        
+
         Args:
             x64bit_addr (:class:`.XBee64BitAddress`): the new 64-bit destination address.
 
@@ -948,7 +963,8 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_dest_addr(self):
         """
         Returns the 16-bit destination address.
 
@@ -960,10 +976,11 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_dest_addr.setter
+    def x16bit_dest_addr(self, x16bit_addr):
         """
         Sets the 16-bit destination address.
-        
+
         Args:
             x16bit_addr (:class:`.XBee16BitAddress`): the new 16-bit destination address.
 
@@ -972,7 +989,8 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    def __get_transmit_options(self):
+    @property
+    def transmit_options(self):
         """
         Returns the transmit options bitfield.
 
@@ -984,10 +1002,11 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         return self.__transmit_options
 
-    def __set_transmit_options(self, transmit_options):
+    @transmit_options.setter
+    def transmit_options(self, transmit_options):
         """
         Sets the transmit options bitfield.
-        
+
         Args:
             transmit_options (Integer): the new transmit options bitfield.
 
@@ -996,72 +1015,61 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         self.__transmit_options = transmit_options
 
-    def __get_parameter(self):
+    @property
+    def parameter(self):
         """
         Returns the AT command parameter.
-        
+
         Returns:
             Bytearray: the AT command parameter.
         """
         return self.__parameter
 
-    def __set_parameter(self, parameter):
+    @parameter.setter
+    def parameter(self, parameter):
         """
         Sets the AT command parameter.
-        
+
         Args:
             parameter (Bytearray): the new AT command parameter.
         """
         self.__parameter = parameter
 
-    def __get_command(self):
+    @property
+    def command(self):
         """
         Returns the AT command.
-        
+
         Returns:
             String: the AT command.
         """
         return self.__command
 
-    def __set_command(self, command):
+    @command.setter
+    def command(self, command):
         """
         Sets the AT command.
-        
+
         Args:
             command (String): the new AT command.
         """
         self.__command = command
-
-    x64bit_dest_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit destination address."""
-
-    x16bit_dest_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit destination address."""
-
-    transmit_options = property(__get_transmit_options, __set_transmit_options)
-    """Integer. Transmit options bitfield."""
-
-    command = property(__get_command, __set_command)
-    """String. AT command."""
-
-    parameter = property(__get_parameter, __set_parameter)
-    """Bytearray. AT command parameter."""
 
 
 class RemoteATCommandResponsePacket(XBeeAPIPacket):
     """
     This class represents a remote AT command response packet. Packet is built
     using the parameters of the constructor or providing a valid byte array.
-    
-    If a module receives a remote command response RF data frame in response 
+
+    If a module receives a remote command response RF data frame in response
     to a remote AT command request, the module will send a remote AT command
     response message out the UART. Some commands may send back multiple frames,
-    for example, Node Discover (``ND``) command.
-    
+    for example, Node Discover (`ND`) command.
+
     This packet is received in response of a :class:`.RemoteATCommandPacket`.
 
     Response also includes an object with the status of the AT command.
-    
+
     .. seealso::
        | :class:`.RemoteATCommandPacket`
        | :class:`.ATCommandStatus`
@@ -1072,9 +1080,10 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, x64bit_addr, x16bit_addr, command, response_status, comm_value=None):
         """
-        Class constructor. Instantiates a new :class:`.RemoteATCommandResponsePacket` object with the provided
+        Class constructor. Instantiates a new
+        :class:`.RemoteATCommandResponsePacket` object with the provided
         parameters.
-        
+
         Args:
             frame_id (Integer): the frame ID of the packet.
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit source address
@@ -1084,8 +1093,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
             comm_value (Bytearray, optional): the AT command response value. Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if length of `command` is different from 2.
 
         .. seealso::
            | :class:`.ATCommandStatus`
@@ -1120,26 +1129,31 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.RemoteATCommandResponsePacket`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 19. (start delim. + length (2 bytes) + frame
-                type + frame id + 64bit addr. + 16bit addr. + receive options + command (2 bytes) + checksum =
-                19 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.REMOTE_AT_COMMAND_RESPONSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 19.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + 64bit addr. + 16bit addr. + receive options
+                + command (2 bytes) + checksum = 19 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.REMOTE_AT_COMMAND_RESPONSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH)
@@ -1182,7 +1196,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
                 DictKeys.AT_CMD_STATUS: self.__response_status,
                 DictKeys.RF_DATA:       list(self.__comm_value) if self.__comm_value is not None else None}
 
-    def __get_command(self):
+    @property
+    def command(self):
         """
         Returns the AT command of the packet.
 
@@ -1191,7 +1206,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         return self.__command
 
-    def __set_command(self, command):
+    @command.setter
+    def command(self, command):
         """
         Sets the AT command of the packet.
 
@@ -1199,13 +1215,14 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
             command (String): the new AT command of the packet. Must have length = 2.
 
         Raises:
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if length of `command` is different from 2.
         """
         if len(command) != 2:
             raise ValueError("Invalid command " + command)
         self.__command = command
 
-    def __get_value(self):
+    @property
+    def command_value(self):
         """
         Returns the AT command response value.
 
@@ -1214,7 +1231,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         return self.__comm_value
 
-    def __set_value(self, comm_value):
+    @command_value.setter
+    def command_value(self, comm_value):
         """
         Sets the AT command response value.
 
@@ -1223,7 +1241,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         self.__comm_value = comm_value
 
-    def __get_response_status(self):
+    @property
+    def status(self):
         """
         Returns the AT command response status of the packet.
 
@@ -1235,7 +1254,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         return ATCommandStatus.get(self.__response_status)
 
-    def __get_real_response_status(self):
+    @property
+    def real_status(self):
         """
         Returns the AT command response status of the packet.
 
@@ -1244,7 +1264,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         return self.__response_status
 
-    def __set_response_status(self, response_status):
+    @status.setter
+    def status(self, response_status):
         """
         Sets the AT command response status of the packet
 
@@ -1270,7 +1291,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
                 "Response status must be ATCommandStatus or int not {!r}".
                 format(response_status.__class__.__name__))
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
 
@@ -1282,7 +1304,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_source_addr.setter
+    def x64bit_source_addr(self, x64bit_addr):
         """
         Sets the 64-bit source address.
 
@@ -1294,7 +1317,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_source_addr(self):
         """
         Returns the 16-bit source address.
 
@@ -1306,7 +1330,8 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_source_addr.setter
+    def x16bit_source_addr(self, x16bit_addr):
         """
         Sets the 16-bit source address.
 
@@ -1318,58 +1343,39 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    x64bit_source_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit source address."""
-
-    x16bit_source_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit source address."""
-
-    command = property(__get_command, __set_command)
-    """String. AT command."""
-
-    command_value = property(__get_value, __set_value)
-    """Bytearray. AT command value."""
-
-    status = property(__get_response_status, __set_response_status)
-    """:class:`.ATCommandStatus`. AT command response status."""
-
-    real_status = property(__get_real_response_status, __set_response_status)
-    """Integer. AT command response status."""
-
 
 class TransmitPacket(XBeeAPIPacket):
     """
-    This class represents a transmit request packet. Packet is built using the parameters
-    of the constructor or providing a valid API byte array.
-    
+    This class represents a transmit request packet. Packet is built using the
+    parameters of the constructor or providing a valid API byte array.
+
     A transmit request API frame causes the module to send data as an RF
     packet to the specified destination.
-    
-    The 64-bit destination address should be set to ``0x000000000000FFFF``
-    for a broadcast transmission (to all devices).
-    
-    The coordinator can be addressed by either setting the 64-bit address to 
-    all ``0x00``} and the 16-bit address to ``0xFFFE``, OR by setting the
-    64-bit address to the coordinator's 64-bit address and the 16-bit address to 
-    ``0x0000``.
 
-    For all other transmissions, setting the 16-bit address to the correct 
-    16-bit address can help improve performance when transmitting to multiple 
+    The 64-bit destination address should be set to `0x000000000000FFFF`
+    for a broadcast transmission (to all devices).
+
+    The coordinator can be addressed by either setting the 64-bit address to
+    `0x0000000000000000` and the 16-bit address to `0xFFFE`, OR by setting the
+    64-bit address to the coordinator's 64-bit address and the 16-bit address
+    to `0x0000`.
+
+    For all other transmissions, setting the 16-bit address to the correct
+    16-bit address can help improve performance when transmitting to multiple
     destinations.
-    
-    If a 16-bit address is not known, this field should be set to 
-    ``0xFFFE`` (unknown).
+
+    If a 16-bit address is not known, this field should be set to
+    `0xFFFE` (unknown).
 
     The transmit status frame ( :attr:`.ApiFrameType.TRANSMIT_STATUS`) will
     indicate the discovered 16-bit address, if successful (see :class:`.TransmitStatusPacket`).
 
-    The broadcast radius can be set from ``0`` up to ``NH``. If set
-    to ``0``, the value of ``NH`` specifies the broadcast radius
-    (recommended). This parameter is only used for broadcast transmissions.
+    The broadcast radius can be set from `0` up to `NH`. If set to `0`, the
+    value of `NH` specifies the broadcast radius (recommended). This parameter
+    is only used for broadcast transmissions.
 
-    The maximum number of payload bytes can be read with the ``NP``
-    command.
-    
+    The maximum number of payload bytes can be read with the `NP` command.
+
     Several transmit options can be set using the transmit options bitfield.
 
     .. seealso::
@@ -1385,8 +1391,9 @@ class TransmitPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, x64bit_addr, x16bit_addr, broadcast_radius, transmit_options, rf_data=None):
         """
-        Class constructor. Instantiates a new :class:`.TransmitPacket` object with the provided parameters.
-        
+        Class constructor. Instantiates a new :class:`.TransmitPacket` object
+        with the provided parameters.
+
         Args:
             frame_id (integer): the frame ID of the packet.
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit destination address.
@@ -1394,15 +1401,15 @@ class TransmitPacket(XBeeAPIPacket):
             broadcast_radius (Integer): maximum number of hops a broadcast transmission can occur.
             transmit_options (Integer): bitfield of supported transmission options.
             rf_data (Bytearray, optional): RF data that is sent to the destination device. Optional.
-            
+
         .. seealso::
            | :class:`.TransmitOptions`
            | :class:`.XBee16BitAddress`
            | :class:`.XBee64BitAddress`
            | :class:`.XBeeAPIPacket`
-            
+
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
         """
         if frame_id > 255 or frame_id < 0:
             raise ValueError("frame_id must be between 0 and 255.")
@@ -1419,25 +1426,30 @@ class TransmitPacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.TransmitPacket`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 18. (start delim. + length (2 bytes) + frame
-                type + frame id + 64bit addr. + 16bit addr. + Receive options + checksum = 16 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.TRANSMIT_REQUEST`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 18.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + 64bit addr. + 16bit addr. + Receive options + checksum = 16 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.TRANSMIT_REQUEST`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitPacket.__MIN_PACKET_LENGTH)
@@ -1452,7 +1464,7 @@ class TransmitPacket(XBeeAPIPacket):
     def needs_id(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket.needs_id`
         """
@@ -1461,7 +1473,7 @@ class TransmitPacket(XBeeAPIPacket):
     def _get_api_packet_spec_data(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
         """
@@ -1476,7 +1488,7 @@ class TransmitPacket(XBeeAPIPacket):
     def _get_api_packet_spec_data_dict(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data_dict`
         """
@@ -1486,7 +1498,8 @@ class TransmitPacket(XBeeAPIPacket):
                 DictKeys.TRANSMIT_OPTIONS: self.__transmit_options,
                 DictKeys.RF_DATA:          list(self.__rf_data) if self.__rf_data is not None else None}
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the RF data to send.
 
@@ -1497,7 +1510,8 @@ class TransmitPacket(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the RF data to send.
 
@@ -1509,7 +1523,8 @@ class TransmitPacket(XBeeAPIPacket):
         else:
             self.__rf_data = rf_data.copy()
 
-    def __get_transmit_options(self):
+    @property
+    def transmit_options(self):
         """
         Returns the transmit options bitfield.
 
@@ -1521,7 +1536,8 @@ class TransmitPacket(XBeeAPIPacket):
         """
         return self.__transmit_options
 
-    def __set_transmit_options(self, transmit_options):
+    @transmit_options.setter
+    def transmit_options(self, transmit_options):
         """
         Sets the transmit options bitfield.
 
@@ -1533,25 +1549,30 @@ class TransmitPacket(XBeeAPIPacket):
         """
         self.__transmit_options = transmit_options
 
-    def __get_broadcast_radius(self):
+    @property
+    def broadcast_radius(self):
         """
-        Returns the broadcast radius. Broadcast radius is the maximum number of hops a broadcast transmission.
-        
+        Returns the broadcast radius. Broadcast radius is the maximum number of
+        hops a broadcast transmission.
+
         Returns:
             Integer: the broadcast radius.
         """
         return self.__broadcast_radius
 
-    def __set_broadcast_radius(self, br_radius):
+    @broadcast_radius.setter
+    def broadcast_radius(self, br_radius):
         """
-        Sets the broadcast radius. Broadcast radius is the maximum number of hops a broadcast transmission.
-        
+        Sets the broadcast radius. Broadcast radius is the maximum number of
+        hops a broadcast transmission.
+
         Args:
             br_radius (Integer): the new broadcast radius.
         """
         self.__broadcast_radius = br_radius
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_dest_addr(self):
         """
         Returns the 64-bit destination address.
 
@@ -1563,7 +1584,8 @@ class TransmitPacket(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_dest_addr.setter
+    def x64bit_dest_addr(self, x64bit_addr):
         """
         Sets the 64-bit destination address.
 
@@ -1575,7 +1597,8 @@ class TransmitPacket(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_dest_addr(self):
         """
         Returns the 16-bit destination address.
 
@@ -1587,7 +1610,8 @@ class TransmitPacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_dest_addr.setter
+    def x16bit_dest_addr(self, x16bit_addr):
         """
         Sets the 16-bit destination address.
 
@@ -1599,31 +1623,16 @@ class TransmitPacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    x64bit_dest_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit destination address."""
-
-    x16bit_dest_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit destination address."""
-
-    transmit_options = property(__get_transmit_options, __set_transmit_options)
-    """Integer. Transmit options bitfield."""
-
-    broadcast_radius = property(__get_broadcast_radius, __set_broadcast_radius)
-    """Integer. Broadcast radius."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. RF data to send."""
-
 
 class TransmitStatusPacket(XBeeAPIPacket):
     """
     This class represents a transmit status packet. Packet is built using the
     parameters of the constructor or providing a valid raw byte array.
-    
+
     When a Transmit Request is completed, the module sends a transmit status
-    message. This message will indicate if the packet was transmitted 
+    message. This message will indicate if the packet was transmitted
     successfully or if there was a failure.
-    
+
     This packet is the response to standard and explicit transmit requests.
 
     .. seealso::
@@ -1635,8 +1644,9 @@ class TransmitStatusPacket(XBeeAPIPacket):
     def __init__(self, frame_id, x16bit_addr, transmit_retry_count, transmit_status=TransmitStatus.SUCCESS,
                  discovery_status=DiscoveryStatus.NO_DISCOVERY_OVERHEAD):
         """
-        Class constructor. Instantiates a new :class:`.TransmitStatusPacket` object with the provided parameters.
-        
+        Class constructor. Instantiates a new :class:`.TransmitStatusPacket`
+        object with the provided parameters.
+
         Args:
             frame_id (Integer): the frame ID of the packet.
             x16bit_addr (:class:`.XBee16BitAddress`): 16-bit network address the packet was delivered to.
@@ -1646,7 +1656,7 @@ class TransmitStatusPacket(XBeeAPIPacket):
                 Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.DiscoveryStatus`
@@ -1668,26 +1678,31 @@ class TransmitStatusPacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.TransmitStatusPacket`
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 11. (start delim. + length (2 bytes) + frame
-                type + frame id + 16bit addr. + transmit retry count + delivery status + discovery status + checksum =
-                11 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.TRANSMIT_STATUS`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 11.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + 16bit addr. + transmit retry count + delivery status
+                + discovery status + checksum = 11 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.TRANSMIT_STATUS`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitStatusPacket.__MIN_PACKET_LENGTH)
@@ -1733,7 +1748,8 @@ class TransmitStatusPacket(XBeeAPIPacket):
                 DictKeys.TS_STATUS: self.__transmit_status,
                 DictKeys.DS_STATUS: self.__discovery_status}
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_dest_addr(self):
         """
         Returns the 16-bit destination address.
 
@@ -1745,7 +1761,8 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_dest_addr.setter
+    def x16bit_dest_addr(self, x16bit_addr):
         """
         Sets the 16-bit destination address.
 
@@ -1757,7 +1774,8 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    def __get_transmit_status(self):
+    @property
+    def transmit_status(self):
         """
         Returns the transmit status.
 
@@ -1769,7 +1787,8 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         return self.__transmit_status
 
-    def __set_transmit_status(self, transmit_status):
+    @transmit_status.setter
+    def transmit_status(self, transmit_status):
         """
         Sets the transmit status.
 
@@ -1781,7 +1800,8 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         self.__transmit_status = transmit_status
 
-    def __get_transmit_retry_count(self):
+    @property
+    def transmit_retry_count(self):
         """
         Returns the transmit retry count.
 
@@ -1790,7 +1810,8 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         return self.__transmit_retry_count
 
-    def __set_transmit_retry_count(self, transmit_retry_count):
+    @transmit_retry_count.setter
+    def transmit_retry_count(self, transmit_retry_count):
         """
         Sets the transmit retry count.
 
@@ -1799,7 +1820,8 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         self.__transmit_retry_count = transmit_retry_count
 
-    def __get_discovery_status(self):
+    @property
+    def discovery_status(self):
         """
         Returns the discovery status.
 
@@ -1811,7 +1833,8 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         return self.__discovery_status
 
-    def __set_discovery_status(self, discovery_status):
+    @discovery_status.setter
+    def discovery_status(self, discovery_status):
         """
         Sets the discovery status.
 
@@ -1823,27 +1846,15 @@ class TransmitStatusPacket(XBeeAPIPacket):
         """
         self.__discovery_status = discovery_status
 
-    x16bit_dest_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit destination address."""
-
-    transmit_retry_count = property(__get_transmit_retry_count, __set_transmit_retry_count)
-    """Integer. Transmit retry count value."""
-
-    transmit_status = property(__get_transmit_status, __set_transmit_status)
-    """:class:`.TransmitStatus`. Transmit status."""
-
-    discovery_status = property(__get_discovery_status, __set_discovery_status)
-    """:class:`.DiscoveryStatus`. Discovery status."""
-
 
 class ModemStatusPacket(XBeeAPIPacket):
     """
     This class represents a modem status packet. Packet is built using the
     parameters of the constructor or providing a valid API raw byte array.
-    
-    RF module status messages are sent from the module in response to specific 
+
+    RF module status messages are sent from the module in response to specific
     conditions and indicates the state of the modem in that moment.
-    
+
     .. seealso::
        | :class:`.XBeeAPIPacket`
     """
@@ -1853,7 +1864,7 @@ class ModemStatusPacket(XBeeAPIPacket):
     def __init__(self, modem_status):
         """
         Class constructor. Instantiates a new :class:`.ModemStatusPacket` object with the provided parameters.
-        
+
         Args:
             modem_status (:class:`.ModemStatus`): the modem status event.
 
@@ -1868,25 +1879,30 @@ class ModemStatusPacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.ModemStatusPacket`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 6. (start delim. + length (2 bytes) + frame
-                type + modem status + checksum = 6 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.MODEM_STATUS`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 6.
+                (start delim. + length (2 bytes) + frame type
+                + modem status + checksum = 6 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.MODEM_STATUS`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ModemStatusPacket.__MIN_PACKET_LENGTH)
@@ -1923,7 +1939,8 @@ class ModemStatusPacket(XBeeAPIPacket):
         """
         return {DictKeys.MODEM_STATUS: self.__modem_status}
 
-    def __get_modem_status(self):
+    @property
+    def modem_status(self):
         """
         Returns the modem status event.
 
@@ -1935,10 +1952,11 @@ class ModemStatusPacket(XBeeAPIPacket):
         """
         return self.__modem_status
 
-    def __set_modem_status(self, modem_status):
-        """ 
+    @modem_status.setter
+    def modem_status(self, modem_status):
+        """
         Sets the modem status event.
-        
+
         Args:
             modem_status (:class:`.ModemStatus`): the new modem status event to set.
 
@@ -1947,20 +1965,17 @@ class ModemStatusPacket(XBeeAPIPacket):
         """
         self.__modem_status = modem_status
 
-    modem_status = property(__get_modem_status, __set_modem_status)
-    """:class:`.ModemStatus`. Modem status event."""
-
 
 class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
     """
     This class represents an IO data sample RX indicator packet. Packet is built
     using the parameters of the constructor or providing a valid API byte array.
-    
-    When the module receives an IO sample frame from a remote device, it 
-    sends the sample out the UART using this frame type (when ``AO=0``). Only modules
+
+    When the module receives an IO sample frame from a remote device, it sends
+    the sample out the UART using this frame type (when `AO=0`). Only modules
     running API firmware will send IO samples out the UART.
-    
-    Among received data, some options can also be received indicating 
+
+    Among received data, some options can also be received indicating
     transmission parameters.
 
     .. seealso::
@@ -1972,18 +1987,18 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
 
     def __init__(self, x64bit_addr, x16bit_addr, receive_options, rf_data=None):
         """
-        Class constructor. Instantiates a new :class:`.IODataSampleRxIndicatorPacket` object with the provided
-        parameters.
-        
+        Class constructor. Instantiates a new
+        :class:`.IODataSampleRxIndicatorPacket` object with the provided parameters.
+
         Args:
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit source address.
             x16bit_addr (:class:`.XBee16BitAddress`): the 16-bit source address.
             receive_options (Integer): bitfield indicating the receive options.
             rf_data (Bytearray, optional): received RF data. Optional.
-            
+
         Raises:
-            ValueError: if ``rf_data`` is not ``None`` and it's not valid for create an :class:`.IOSample`.
-            
+            ValueError: if `rf_data` is not `None` and it's not valid for create an :class:`.IOSample`.
+
         .. seealso::
            | :class:`.IOSample`
            | :class:`.ReceiveOptions`
@@ -2007,20 +2022,25 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
             :class:`.IODataSampleRxIndicatorPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 20. (start delim. + length (2 bytes) + frame
-                type + 64bit addr. + 16bit addr. + rf data (5 bytes) + checksum = 20 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 20.
+                (start delim. + length (2 bytes) + frame type + 64bit addr.
+                + 16bit addr. + rf data (5 bytes) + checksum = 20 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorPacket.__MIN_PACKET_LENGTH)
@@ -2028,13 +2048,14 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         if raw[3] != ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR.code:
             raise InvalidPacketException(message="This packet is not an IO data sample RX indicator packet.")
 
-        return IODataSampleRxIndicatorPacket(XBee64BitAddress(raw[4:12]), XBee16BitAddress(raw[12:14]),
-                                             raw[14], rf_data=raw[15:-1])
+        return IODataSampleRxIndicatorPacket(
+            XBee64BitAddress(raw[4:12]), XBee16BitAddress(raw[12:14]),
+            raw[14], rf_data=raw[15:-1])
 
     def needs_id(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket.needs_id`
         """
@@ -2094,13 +2115,14 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
     def is_broadcast(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`XBeeAPIPacket.is_broadcast`
         """
         return utils.is_bit_enabled(self.__receive_options, 1)
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
 
@@ -2112,7 +2134,8 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_source_addr.setter
+    def x64bit_source_addr(self, x64bit_addr):
         """
         Sets the 64-bit source address.
 
@@ -2124,7 +2147,8 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_source_addr(self):
         """
         Returns the 16-bit source address.
 
@@ -2136,7 +2160,8 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_source_addr.setter
+    def x16bit_source_addr(self, x16bit_addr):
         """
         Sets the 16-bit source address.
 
@@ -2148,7 +2173,8 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    def __get_options(self):
+    @property
+    def receive_options(self):
         """
         Returns the receive options bitfield.
 
@@ -2160,7 +2186,8 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         """
         return self.__receive_options
 
-    def __set_options(self, receive_options):
+    @receive_options.setter
+    def receive_options(self, receive_options):
         """
         Sets the receive options bitfield.
 
@@ -2172,7 +2199,8 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         """
         self.__receive_options = receive_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the received RF data.
 
@@ -2183,7 +2211,8 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the received RF data.
 
@@ -2201,23 +2230,26 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         else:
             self.__io_sample = None
 
-    def __get_io_sample(self):
+    @property
+    def io_sample(self):
         """
         Returns the IO sample corresponding to the data contained in the packet.
 
         Returns:
-            :class:`.IOSample`: the IO sample of the packet, ``None`` if the packet has not any data or if the
-                sample could not be generated correctly.
+            :class:`.IOSample`: the IO sample of the packet, `None` if the
+                packet has not any data or if the sample could not be generated
+                correctly.
 
         .. seealso::
            | :class:`.IOSample`
         """
         return self.__io_sample
 
-    def __set_io_sample(self, io_sample):
+    @io_sample.setter
+    def io_sample(self, io_sample):
         """
         Sets the IO sample of the packet.
-        
+
         Args:
             io_sample (:class:`.IOSample`): the new IO sample to set.
 
@@ -2225,21 +2257,6 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
            | :class:`.IOSample`
         """
         self.__io_sample = io_sample
-
-    x64bit_source_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit source address."""
-
-    x16bit_source_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit source address."""
-
-    receive_options = property(__get_options, __set_options)
-    """Integer. Receive options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. Received RF data."""
-
-    io_sample = property(__get_io_sample, __set_io_sample)
-    """:class:`.IOSample`: IO sample corresponding to the data contained in the packet."""
 
 
 class ExplicitAddressingPacket(XBeeAPIPacket):
@@ -2256,30 +2273,31 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
     destination, using the specified source and destination endpoints, cluster
     ID, and profile ID.
 
-    The 64-bit destination address should be set to ``0x000000000000FFFF`` for
+    The 64-bit destination address should be set to `0x000000000000FFF` for
     a broadcast transmission (to all devices).
 
-    The coordinator can be addressed by either setting the 64-bit address to all
-    ``0x00`` and the 16-bit address to ``0xFFFE``, OR by setting the 64-bit
-    address to the coordinator's 64-bit address and the 16-bit address to ``0x0000``.
+    The coordinator can be addressed by either setting the 64-bit address to
+    `0x000000000000000` and the 16-bit address to `0xFFFE`, OR by setting the
+    64-bit address to the coordinator's 64-bit address and the 16-bit address
+    to `0x0000`.
 
-    For all other transmissions, setting the 16-bit address to the correct
-    16-bit address can help improve performance when transmitting to
-    multiple destinations.
+    For all other transmissions, setting the 16-bit address to the right 16-bit
+    address can help improve performance when transmitting to multiple destinations.
 
     If a 16-bit address is not known, this field should be set to
-    ``0xFFFE`` (unknown).
+    `0xFFFE` (unknown).
 
-    The transmit status frame ( :attr:`.ApiFrameType.TRANSMIT_STATUS`) will
-    indicate the discovered 16-bit address, if successful (see :class:`.TransmitStatusPacket`)).
+    The transmit status frame (:attr:`.ApiFrameType.TRANSMIT_STATUS`) will
+    indicate the discovered 16-bit address, if successful
+    (see :class:`.TransmitStatusPacket`)).
 
-    The broadcast radius can be set from ``0`` up to ``NH``. If set
-    to ``0``, the value of ``NH`` specifies the broadcast radius
-    (recommended). This parameter is only used for broadcast transmissions.
+    The broadcast radius can be set from `0` up to `NH`. If set to `0`, the
+    value of `NH` specifies the broadcast radius (recommended). This parameter
+    is only used for broadcast transmissions.
 
-    The maximum number of payload bytes can be read with the ``NP``
-    command. Note: if source routing is used, the RF payload will be reduced
-    by two bytes per intermediate hop in the source route.
+    The maximum number of payload bytes can be read with the `NP` command.
+    Note: if source routing is used, the RF payload will be reduced by two
+    bytes per intermediate hop in the source route.
 
     Several transmit options can be set using the transmit options bitfield.
 
@@ -2299,7 +2317,7 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
                  profile_id, broadcast_radius=0x00, transmit_options=0x00, rf_data=None):
         """
         Class constructor. . Instantiates a new :class:`.ExplicitAddressingPacket` object with the provided parameters.
-        
+
         Args:
             frame_id (Integer): the frame ID of the packet.
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit address.
@@ -2311,10 +2329,10 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
             broadcast_radius (Integer): maximum number of hops a broadcast transmission can occur.
             transmit_options (Integer): bitfield of supported transmission options.
             rf_data (Bytearray, optional): RF data that is sent to the destination device. Optional.
-            
+
         Raises:
-            ValueError: if ``frame_id``, ``src_endpoint`` or ``dst_endpoint`` are less than 0 or greater than 255.
-            ValueError: if lengths of ``cluster_id`` or ``profile_id`` (respectively) are less than 0 or greater than
+            ValueError: if `frame_id`, `src_endpoint` or `dst_endpoint` are less than 0 or greater than 255.
+            ValueError: if lengths of `cluster_id` or `profile_id` (respectively) are less than 0 or greater than
                 0xFFFF.
 
         .. seealso::
@@ -2336,8 +2354,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
 
         super().__init__(ApiFrameType.EXPLICIT_ADDRESSING)
         self._frame_id = frame_id
-        self.__x64_addr = x64bit_addr
-        self.__x16_addr = x16bit_addr
+        self.__x64bit_addr = x64bit_addr
+        self.__x16bit_addr = x16bit_addr
         self.__source_endpoint = source_endpoint
         self.__dest_endpoint = dest_endpoint
         self.__cluster_id = cluster_id
@@ -2350,26 +2368,32 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.ExplicitAddressingPacket`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 24. (start delim. + length (2 bytes) + frame
-                type + frame ID + 64bit addr. + 16bit addr. + source endpoint + dest. endpoint + cluster ID (2 bytes) +
-                profile ID (2 bytes) + broadcast radius + transmit options + checksum = 24 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.EXPLICIT_ADDRESSING`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 24.
+                (start delim. + length (2 bytes) + frame type + frame ID
+                + 64bit addr. + 16bit addr. + source endpoint + dest. endpoint
+                + cluster ID (2 bytes) + profile ID (2 bytes)
+                + broadcast radius + transmit options + checksum = 24 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.EXPLICIT_ADDRESSING`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitAddressingPacket.__MIN_PACKET_LENGTH)
@@ -2397,8 +2421,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
         """
-        raw = self.__x64_addr.address
-        raw += self.__x16_addr.address
+        raw = self.__x64bit_addr.address
+        raw += self.__x16bit_addr.address
         raw.append(self.__source_endpoint)
         raw.append(self.__dest_endpoint)
         raw += utils.int_to_bytes(self.__cluster_id, num_bytes=2)
@@ -2416,8 +2440,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data_dict`
         """
-        return {DictKeys.X64BIT_ADDR:      self.__x64_addr.address,
-                DictKeys.X16BIT_ADDR:      self.__x16_addr.address,
+        return {DictKeys.X64BIT_ADDR:      self.__x64bit_addr.address,
+                DictKeys.X16BIT_ADDR:      self.__x16bit_addr.address,
                 DictKeys.SOURCE_ENDPOINT:  self.__source_endpoint,
                 DictKeys.DEST_ENDPOINT:    self.__dest_endpoint,
                 DictKeys.CLUSTER_ID:       self.__cluster_id,
@@ -2426,7 +2450,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
                 DictKeys.TRANSMIT_OPTIONS: self.__transmit_options,
                 DictKeys.RF_DATA:          self.__rf_data}
 
-    def __get_source_endpoint(self):
+    @property
+    def source_endpoint(self):
         """
         Returns the source endpoint of the transmission.
 
@@ -2435,7 +2460,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         return self.__dest_endpoint
 
-    def __set_source_endpoint(self, source_endpoint):
+    @source_endpoint.setter
+    def source_endpoint(self, source_endpoint):
         """
         Sets the source endpoint of the transmission.
 
@@ -2444,7 +2470,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         self.__source_endpoint = source_endpoint
 
-    def __get_dest_endpoint(self):
+    @property
+    def dest_endpoint(self):
         """
         Returns the destination endpoint of the transmission.
 
@@ -2453,7 +2480,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         return self.__dest_endpoint
 
-    def __set_dest_endpoint(self, dest_endpoint):
+    @dest_endpoint.setter
+    def dest_endpoint(self, dest_endpoint):
         """
         Sets the destination endpoint of the transmission.
 
@@ -2462,7 +2490,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         self.__dest_endpoint = dest_endpoint
 
-    def __get_cluster_id(self):
+    @property
+    def cluster_id(self):
         """
         Returns the cluster ID of the transmission.
 
@@ -2471,7 +2500,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         return self.__cluster_id
 
-    def __set_cluster_id(self, cluster_id):
+    @cluster_id.setter
+    def cluster_id(self, cluster_id):
         """
         Sets the cluster ID of the transmission.
 
@@ -2480,7 +2510,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         self.__cluster_id = cluster_id
 
-    def __get_profile_id(self):
+    @property
+    def profile_id(self):
         """
         Returns the profile ID of the transmission.
 
@@ -2489,7 +2520,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         return self.__profile_id
 
-    def __set_profile_id(self, profile_id):
+    @profile_id.setter
+    def profile_id(self, profile_id):
         """
         Sets the profile ID of the transmission.
 
@@ -2498,7 +2530,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         self.__profile_id = profile_id
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the RF data to send.
 
@@ -2509,7 +2542,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the RF data to send.
 
@@ -2521,7 +2555,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         else:
             self.__rf_data = rf_data.copy()
 
-    def __get_transmit_options(self):
+    @property
+    def transmit_options(self):
         """
         Returns the transmit options bitfield.
 
@@ -2533,7 +2568,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         return self.__transmit_options
 
-    def __set_transmit_options(self, transmit_options):
+    @transmit_options.setter
+    def transmit_options(self, transmit_options):
         """
         Sets the transmit options bitfield.
 
@@ -2545,25 +2581,30 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         self.__transmit_options = transmit_options
 
-    def __get_broadcast_radius(self):
+    @property
+    def broadcast_radius(self):
         """
-        Returns the broadcast radius. Broadcast radius is the maximum number of hops a broadcast transmission.
+        Returns the broadcast radius. Broadcast radius is the maximum number
+        of hops a broadcast transmission.
 
         Returns:
             Integer: the broadcast radius.
         """
         return self.__broadcast_radius
 
-    def __set_broadcast_radius(self, br_radius):
+    @broadcast_radius.setter
+    def broadcast_radius(self, br_radius):
         """
-        Sets the broadcast radius. Broadcast radius is the maximum number of hops a broadcast transmission.
+        Sets the broadcast radius. Broadcast radius is the maximum number
+        of hops a broadcast transmission.
 
         Args:
             br_radius (Integer): the new broadcast radius.
         """
         self.__broadcast_radius = br_radius
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_dest_addr(self):
         """
         Returns the 64-bit destination address.
 
@@ -2575,7 +2616,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_dest_addr.setter
+    def x64bit_dest_addr(self, x64bit_addr):
         """
         Sets the 64-bit destination address.
 
@@ -2587,7 +2629,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_dest_addr(self):
         """
         Returns the 16-bit destination address.
 
@@ -2599,7 +2642,8 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_dest_addr.setter
+    def x16bit_dest_addr(self, x16bit_addr):
         """
         Sets the 16-bit destination address.
 
@@ -2611,33 +2655,6 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    x64bit_dest_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit destination address."""
-
-    x16bit_dest_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit destination address."""
-
-    transmit_options = property(__get_transmit_options, __set_transmit_options)
-    """Integer. Transmit options bitfield."""
-
-    broadcast_radius = property(__get_broadcast_radius, __set_broadcast_radius)
-    """Integer. Broadcast radius."""
-
-    source_endpoint = property(__get_source_endpoint, __set_source_endpoint)
-    """Integer. Source endpoint of the transmission."""
-
-    dest_endpoint = property(__get_dest_endpoint, __set_dest_endpoint)
-    """Integer. Destination endpoint of the transmission."""
-
-    cluster_id = property(__get_cluster_id, __set_cluster_id)
-    """Integer. Cluster ID of the transmission."""
-
-    profile_id = property(__get_profile_id, __set_profile_id)
-    """Integer. Profile ID of the transmission."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. RF data to send."""
-
 
 class ExplicitRXIndicatorPacket(XBeeAPIPacket):
     """
@@ -2646,7 +2663,7 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
     payload.
 
     When the modem receives an RF packet it is sent out the UART using this
-    message type (when ``AO=1``).
+    message type (when `AO=1`).
 
     This packet is received when external devices send explicit addressing
     packets to this module.
@@ -2666,7 +2683,7 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
                  dest_endpoint, cluster_id, profile_id, receive_options, rf_data=None):
         """
         Class constructor. Instantiates a new :class:`.ExplicitRXIndicatorPacket` object with the provided parameters.
-        
+
         Args:
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit source address.
             x16bit_addr (:class:`.XBee16BitAddress`): the 16-bit source address.
@@ -2678,8 +2695,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
             rf_data (Bytearray, optional): received RF data. Optional.
 
         Raises:
-            ValueError: if ``src_endpoint`` or ``dst_endpoint`` are less than 0 or greater than 255.
-            ValueError: if lengths of ``cluster_id`` or ``profile_id`` (respectively) are different than 2.
+            ValueError: if `src_endpoint` or `dst_endpoint` are less than 0 or greater than 255.
+            ValueError: if lengths of `cluster_id` or `profile_id` (respectively) are different from 2.
 
         .. seealso::
            | :class:`.XBee16BitAddress`
@@ -2710,26 +2727,32 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.ExplicitRXIndicatorPacket`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 22. (start delim. + length (2 bytes) + frame
-                type + 64bit addr. + 16bit addr. + source endpoint + dest. endpoint + cluster ID (2 bytes) +
-                profile ID (2 bytes) + receive options + checksum = 22 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.EXPLICIT_RX_INDICATOR`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 22.
+                (start delim. + length (2 bytes) + frame type + 64bit addr.
+                + 16bit addr. + source endpoint + dest. endpoint
+                + cluster ID (2 bytes) + profile ID (2 bytes) + receive options
+                + checksum = 22 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.EXPLICIT_RX_INDICATOR`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitRXIndicatorPacket.__MIN_PACKET_LENGTH)
@@ -2762,7 +2785,7 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
     def _get_api_packet_spec_data(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
         """
@@ -2780,7 +2803,7 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
     def _get_api_packet_spec_data_dict(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data_dict`
         """
@@ -2793,7 +2816,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
                 DictKeys.RECEIVE_OPTIONS: self.__receive_options,
                 DictKeys.RF_DATA:         self.__rf_data}
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
 
@@ -2805,7 +2829,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_source_addr.setter
+    def x64bit_source_addr(self, x64bit_addr):
         """
         Sets the 64-bit source address.
 
@@ -2817,7 +2842,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_source_addr(self):
         """
         Returns the 16-bit source address.
 
@@ -2829,7 +2855,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_source_addr.setter
+    def x16bit_source_addr(self, x16bit_addr):
         """
         Sets the 16-bit source address.
 
@@ -2841,7 +2868,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    def __get_source_endpoint(self):
+    @property
+    def source_endpoint(self):
         """
         Returns the source endpoint of the transmission.
 
@@ -2850,7 +2878,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         return self.__source_endpoint
 
-    def __set_source_endpoint(self, source_endpoint):
+    @source_endpoint.setter
+    def source_endpoint(self, source_endpoint):
         """
         Sets the source endpoint of the transmission.
 
@@ -2859,7 +2888,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         self.__source_endpoint = source_endpoint
 
-    def __get_dest_endpoint(self):
+    @property
+    def dest_endpoint(self):
         """
         Returns the destination endpoint of the transmission.
 
@@ -2868,7 +2898,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         return self.__dest_endpoint
 
-    def __set_dest_endpoint(self, dest_endpoint):
+    @dest_endpoint.setter
+    def dest_endpoint(self, dest_endpoint):
         """
         Sets the destination endpoint of the transmission.
 
@@ -2877,7 +2908,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         self.__dest_endpoint = dest_endpoint
 
-    def __get_cluster_id(self):
+    @property
+    def cluster_id(self):
         """
         Returns the cluster ID of the transmission.
 
@@ -2886,7 +2918,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         return self.__cluster_id
 
-    def __set_cluster_id(self, cluster_id):
+    @cluster_id.setter
+    def cluster_id(self, cluster_id):
         """
         Sets the cluster ID of the transmission.
 
@@ -2895,7 +2928,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         self.__cluster_id = cluster_id
 
-    def __get_profile_id(self):
+    @property
+    def profile_id(self):
         """
         Returns the profile ID of the transmission.
 
@@ -2904,7 +2938,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         return self.__profile_id
 
-    def __set_profile_id(self, profile_id):
+    @profile_id.setter
+    def profile_id(self, profile_id):
         """
         Sets the profile ID of the transmission.
 
@@ -2913,7 +2948,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         self.__profile_id = profile_id
 
-    def __get_options(self):
+    @property
+    def receive_options(self):
         """
         Returns the receive options bitfield.
 
@@ -2925,7 +2961,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         return self.__receive_options
 
-    def __set_options(self, receive_options):
+    @receive_options.setter
+    def receive_options(self, receive_options):
         """
         Sets the receive options bitfield.
 
@@ -2937,7 +2974,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         """
         self.__receive_options = receive_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the received RF data.
 
@@ -2948,7 +2986,8 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the received RF data.
 
@@ -2959,27 +2998,3 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
             self.__rf_data = None
         else:
             self.__rf_data = rf_data.copy()
-
-    x64bit_source_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit source address."""
-
-    x16bit_source_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit source address."""
-
-    receive_options = property(__get_options, __set_options)
-    """Integer. Receive options bitfield."""
-
-    source_endpoint = property(__get_source_endpoint, __set_source_endpoint)
-    """Integer. Source endpoint of the transmission."""
-
-    dest_endpoint = property(__get_dest_endpoint, __set_dest_endpoint)
-    """Integer. Destination endpoint of the transmission."""
-
-    cluster_id = property(__get_cluster_id, __set_cluster_id)
-    """Integer. Cluster ID of the transmission."""
-
-    profile_id = property(__get_profile_id, __set_profile_id)
-    """Integer. Profile ID of the transmission."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. Received RF data."""

--- a/digi/xbee/packets/devicecloud.py
+++ b/digi/xbee/packets/devicecloud.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -38,16 +38,18 @@ class DeviceRequestPacket(XBeeAPIPacket):
 
     def __init__(self, request_id, target=None, request_data=None):
         """
-        Class constructor. Instantiates a new :class:`.DeviceRequestPacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.DeviceRequestPacket`
+        object with the provided parameters.
 
         Args:
-            request_id (Integer): number that identifies the device request. (0 has no special meaning)
+            request_id (Integer): number that identifies the device request.
+                (0 has no special meaning)
             target (String): device request target.
             request_data (Bytearray, optional): data of the request. Optional.
 
         Raises:
-            ValueError: if ``request_id`` is less than 0 or greater than 255.
-            ValueError: if length of ``target`` is greater than 255.
+            ValueError: if `request_id` is less than 0 or greater than 255.
+            ValueError: if length of `target` is greater than 255.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -74,20 +76,25 @@ class DeviceRequestPacket(XBeeAPIPacket):
             :class:`.DeviceRequestPacket`
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 9. (start delim. + length (2 bytes) + frame
-                type + request id + transport + flags + target length + checksum = 9 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.DEVICE_REQUEST`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 9.
+                (start delim. + length (2 bytes) + frame type + request id
+                + transport + flags + target length + checksum = 9 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+            ç   :attr:`.ApiFrameType.DEVICE_REQUEST`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceRequestPacket.__MIN_PACKET_LENGTH)
@@ -142,7 +149,8 @@ class DeviceRequestPacket(XBeeAPIPacket):
                 DictKeys.TARGET:     self.__target,
                 DictKeys.RF_DATA:    list(self.__request_data) if self.__request_data is not None else None}
 
-    def __get_request_id(self):
+    @property
+    def request_id(self):
         """
         Returns the request ID of the packet.
 
@@ -151,7 +159,8 @@ class DeviceRequestPacket(XBeeAPIPacket):
         """
         return self.__request_id
 
-    def __set_request_id(self, request_id):
+    @request_id.setter
+    def request_id(self, request_id):
         """
         Sets the request ID of the packet.
 
@@ -159,13 +168,14 @@ class DeviceRequestPacket(XBeeAPIPacket):
             request_id (Integer): the new request ID of the packet. Must be between 0 and 255.
 
         Raises:
-            ValueError: if ``request_id`` is less than 0 or greater than 255.
+            ValueError: if `request_id` is less than 0 or greater than 255.
         """
         if request_id < 0 or request_id > 255:
             raise ValueError("Device request ID must be between 0 and 255.")
         self.__request_id = request_id
 
-    def __get_transport(self):
+    @property
+    def transport(self):
         """
         Returns the transport of the packet.
 
@@ -174,7 +184,8 @@ class DeviceRequestPacket(XBeeAPIPacket):
         """
         return self.__transport
 
-    def __get_flags(self):
+    @property
+    def flags(self):
         """
         Returns the flags of the packet.
 
@@ -183,7 +194,8 @@ class DeviceRequestPacket(XBeeAPIPacket):
         """
         return self.__flags
 
-    def __get_target(self):
+    @property
+    def target(self):
         """
         Returns the device request target of the packet.
 
@@ -192,7 +204,8 @@ class DeviceRequestPacket(XBeeAPIPacket):
         """
         return self.__target
 
-    def __set_target(self, target):
+    @target.setter
+    def target(self, target):
         """
         Sets the device request target of the packet.
 
@@ -200,13 +213,14 @@ class DeviceRequestPacket(XBeeAPIPacket):
             target (String): the new device request target of the packet.
 
         Raises:
-            ValueError: if ``target`` length is greater than 255.
+            ValueError: if `target` length is greater than 255.
         """
         if target is not None and len(target) > 255:
             raise ValueError("Target length cannot exceed 255 bytes.")
         self.__target = target
 
-    def __get_request_data(self):
+    @property
+    def request_data(self):
         """
         Returns the data of the device request.
 
@@ -217,7 +231,8 @@ class DeviceRequestPacket(XBeeAPIPacket):
             return None
         return self.__request_data.copy()
 
-    def __set_request_data(self, request_data):
+    @request_data.setter
+    def request_data(self, request_data):
         """
         Sets the data of the device request.
 
@@ -228,21 +243,6 @@ class DeviceRequestPacket(XBeeAPIPacket):
             self.__request_data = None
         else:
             self.__request_data = request_data.copy()
-
-    request_id = property(__get_request_id, __set_request_id)
-    """Integer. Request ID of the packet."""
-
-    transport = property(__get_transport)
-    """Integer. Transport (reserved)."""
-
-    flags = property(__get_flags)
-    """Integer. Flags (reserved)."""
-
-    target = property(__get_target, __set_target)
-    """String. Request target of the packet."""
-
-    request_data = property(__get_request_data, __set_request_data)
-    """Bytearray. Data of the device request."""
 
 
 class DeviceResponsePacket(XBeeAPIPacket):
@@ -263,7 +263,8 @@ class DeviceResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, request_id, response_data=None):
         """
-        Class constructor. Instantiates a new :class:`.DeviceResponsePacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.DeviceResponsePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -272,8 +273,8 @@ class DeviceResponsePacket(XBeeAPIPacket):
             response_data (Bytearray, optional): data of the response. Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``request_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `request_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -297,20 +298,25 @@ class DeviceResponsePacket(XBeeAPIPacket):
             :class:`.DeviceResponsePacket`
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 8. (start delim. + length (2 bytes) + frame
-                type + frame id + request id + reserved + checksum = 8 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.DEVICE_RESPONSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 8.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + request id + reserved + checksum = 8 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.DEVICE_RESPONSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponsePacket.__MIN_PACKET_LENGTH)
@@ -354,7 +360,8 @@ class DeviceResponsePacket(XBeeAPIPacket):
                 DictKeys.RESERVED:   0x00,
                 DictKeys.RF_DATA:    list(self.__response_data) if self.__response_data is not None else None}
 
-    def __get_request_id(self):
+    @property
+    def request_id(self):
         """
         Returns the request ID of the packet.
 
@@ -363,7 +370,8 @@ class DeviceResponsePacket(XBeeAPIPacket):
         """
         return self.__request_id
 
-    def __set_request_id(self, request_id):
+    @request_id.setter
+    def request_id(self, request_id):
         """
         Sets the request ID of the packet.
 
@@ -371,13 +379,14 @@ class DeviceResponsePacket(XBeeAPIPacket):
             request_id (Integer): the new request ID of the packet. Must be between 0 and 255.
 
         Raises:
-            ValueError: if ``request_id`` is less than 0 or greater than 255.
+            ValueError: if `request_id` is less than 0 or greater than 255.
         """
         if request_id < 0 or request_id > 255:
             raise ValueError("Device request ID must be between 0 and 255.")
         self.__request_id = request_id
 
-    def __get_response_data(self):
+    @property
+    def request_data(self):
         """
         Returns the data of the device response.
 
@@ -388,7 +397,8 @@ class DeviceResponsePacket(XBeeAPIPacket):
             return None
         return self.__response_data.copy()
 
-    def __set_response_data(self, response_data):
+    @request_data.setter
+    def request_data(self, response_data):
         """
         Sets the data of the device response.
 
@@ -399,12 +409,6 @@ class DeviceResponsePacket(XBeeAPIPacket):
             self.__response_data = None
         else:
             self.__response_data = response_data.copy()
-
-    request_id = property(__get_request_id, __set_request_id)
-    """Integer. Request ID of the packet."""
-
-    request_data = property(__get_response_data, __set_response_data)
-    """Bytearray. Data of the device response."""
 
 
 class DeviceResponseStatusPacket(XBeeAPIPacket):
@@ -431,7 +435,7 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
             status (:class:`.DeviceCloudStatus`): device response status.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.DeviceCloudStatus`
@@ -453,20 +457,25 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
             :class:`.DeviceResponseStatusPacket`
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 7. (start delim. + length (2 bytes) + frame
-                type + frame id + device response status + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.DEVICE_RESPONSE_STATUS`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 7.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + device response status + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different
+                from :attr:`.ApiFrameType.DEVICE_RESPONSE_STATUS`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponseStatusPacket.__MIN_PACKET_LENGTH)
@@ -503,7 +512,8 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
         """
         return {DictKeys.DC_STATUS: self.__status}
 
-    def __get_status(self):
+    @property
+    def status(self):
         """
         Returns the status of the device response packet.
 
@@ -515,7 +525,8 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
         """
         return self.__status
 
-    def __set_status(self, status):
+    @status.setter
+    def status(self, status):
         """
         Sets the status of the device response packet.
 
@@ -526,9 +537,6 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
            | :class:`.DeviceCloudStatus`
         """
         self.__status = status
-
-    status = property(__get_status, __set_status)
-    """:class:`.DeviceCloudStatus`. Status of the device response."""
 
 
 class FrameErrorPacket(XBeeAPIPacket):
@@ -547,7 +555,8 @@ class FrameErrorPacket(XBeeAPIPacket):
 
     def __init__(self, frame_error):
         """
-        Class constructor. Instantiates a new :class:`.FrameErrorPacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.FrameErrorPacket` object
+        with the provided parameters.
 
         Args:
             frame_error (:class:`.FrameError`): the frame error.
@@ -568,20 +577,25 @@ class FrameErrorPacket(XBeeAPIPacket):
             :class:`.FrameErrorPacket`
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 6. (start delim. + length (2 bytes) + frame
-                type + frame error + checksum = 6 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.FRAME_ERROR`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 6.
+                (start delim. + length (2 bytes) + frame type + frame error
+                + checksum = 6 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.FRAME_ERROR`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=FrameErrorPacket.__MIN_PACKET_LENGTH)
@@ -618,7 +632,8 @@ class FrameErrorPacket(XBeeAPIPacket):
         """
         return {DictKeys.FRAME_ERROR: self.__frame_error}
 
-    def __get_error(self):
+    @property
+    def error(self):
         """
         Returns the frame error of the packet.
 
@@ -630,7 +645,8 @@ class FrameErrorPacket(XBeeAPIPacket):
         """
         return self.__frame_error
 
-    def __set_error(self, frame_error):
+    @error.setter
+    def error(self, frame_error):
         """
         Sets the frame error of the packet.
 
@@ -641,9 +657,6 @@ class FrameErrorPacket(XBeeAPIPacket):
            | :class:`.FrameError`
         """
         self.__frame_error = frame_error
-
-    error = property(__get_error, __set_error)
-    """:class:`.FrameError`. Frame error of the packet."""
 
 
 class SendDataRequestPacket(XBeeAPIPacket):
@@ -666,7 +679,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, path, content_type, options, file_data=None):
         """
-        Class constructor. Instantiates a new :class:`.SendDataRequestPacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.SendDataRequestPacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -676,7 +690,7 @@ class SendDataRequestPacket(XBeeAPIPacket):
             file_data (Bytearray, optional): data of the file to upload. Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -701,20 +715,26 @@ class SendDataRequestPacket(XBeeAPIPacket):
             :class:`.SendDataRequestPacket`
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 10. (start delim. + length (2 bytes) + frame
-                type + frame id + path length + content type length + transport + options + checksum = 10 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.SEND_DATA_REQUEST`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 10.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + path length + content type length + transport + options
+                + checksum = 10 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.SEND_DATA_REQUEST`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataRequestPacket.__MIN_PACKET_LENGTH)
@@ -778,7 +798,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
                 DictKeys.TRANSMIT_OPTIONS:    self.__options,
                 DictKeys.RF_DATA:             list(self.__file_data) if self.__file_data is not None else None}
 
-    def __get_path(self):
+    @property
+    def path(self):
         """
         Returns the path of the file to upload to Device Cloud.
 
@@ -787,7 +808,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
         """
         return self.__path
 
-    def __set_path(self, path):
+    @path.setter
+    def path(self, path):
         """
         Sets the path of the file to upload to Device Cloud.
 
@@ -796,7 +818,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
         """
         self.__path = path
 
-    def __get_content_type(self):
+    @property
+    def content_type(self):
         """
         Returns the content type of the file to upload.
 
@@ -805,7 +828,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
         """
         return self.__content_type
 
-    def __set_content_type(self, content_type):
+    @content_type.setter
+    def content_type(self, content_type):
         """
         Sets the content type of the file to upload.
 
@@ -814,7 +838,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
         """
         self.__content_type = content_type
 
-    def __get_options(self):
+    @property
+    def options(self):
         """
         Returns the file upload operation options.
 
@@ -826,7 +851,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
         """
         return self.__options
 
-    def __set_options(self, options):
+    @options.setter
+    def options(self, options):
         """
         Sets the file upload operation options.
 
@@ -838,7 +864,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
         """
         self.__options = options
 
-    def __get_file_data(self):
+    @property
+    def file_data(self):
         """
         Returns the data of the file to upload.
 
@@ -849,7 +876,8 @@ class SendDataRequestPacket(XBeeAPIPacket):
             return None
         return self.__file_data.copy()
 
-    def __set_file_data(self, file_data):
+    @file_data.setter
+    def file_data(self, file_data):
         """
         Sets the data of the file to upload.
 
@@ -860,18 +888,6 @@ class SendDataRequestPacket(XBeeAPIPacket):
             self.__file_data = None
         else:
             self.__file_data = file_data.copy()
-
-    path = property(__get_path, __set_path)
-    """String. Path of the file to upload to Device Cloud."""
-
-    content_type = property(__get_content_type, __set_content_type)
-    """String. The content type of the file to upload."""
-
-    options = property(__get_options, __set_options)
-    """:class:`.SendDataRequestOptions`. File upload operation options."""
-
-    file_data = property(__get_file_data, __set_file_data)
-    """Bytearray. Data of the file to upload."""
 
 
 class SendDataResponsePacket(XBeeAPIPacket):
@@ -891,14 +907,15 @@ class SendDataResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, status):
         """
-        Class constructor. Instantiates a new :class:`.SendDataResponsePacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.SendDataResponsePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
             status (:class:`.DeviceCloudStatus`): the file upload status.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.DeviceCloudStatus`
@@ -920,20 +937,25 @@ class SendDataResponsePacket(XBeeAPIPacket):
             :class:`.SendDataResponsePacket`
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 10. (start delim. + length (2 bytes) + frame
-                type + frame id + status + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.SEND_DATA_RESPONSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 10.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + status + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.SEND_DATA_RESPONSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataResponsePacket.__MIN_PACKET_LENGTH)
@@ -970,7 +992,8 @@ class SendDataResponsePacket(XBeeAPIPacket):
         """
         return {DictKeys.DC_STATUS: self.__status}
 
-    def __get_status(self):
+    @property
+    def status(self):
         """
         Returns the file upload status.
 
@@ -982,7 +1005,8 @@ class SendDataResponsePacket(XBeeAPIPacket):
         """
         return self.__status
 
-    def __set_status(self, status):
+    @status.setter
+    def status(self, status):
         """
         Sets the file upload status.
 
@@ -993,6 +1017,3 @@ class SendDataResponsePacket(XBeeAPIPacket):
            | :class:`.DeviceCloudStatus`
         """
         self.__status = status
-
-    status = property(__get_status, __set_status)
-    """:class:`.DeviceCloudStatus`. The file upload status."""

--- a/digi/xbee/packets/digimesh.py
+++ b/digi/xbee/packets/digimesh.py
@@ -1,4 +1,4 @@
-# Copyright 2019, Digi International Inc.
+# Copyright 2019, 2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -55,8 +55,8 @@ class RouteInformationPacket(XBeeAPIPacket):
             src_addr (:class:`.XBee64BitAddress`): The 64-bit address of the
                 source node of this network-level transmission.
             responder_addr (:class:`.XBee64BitAddress`): The 64-bit address of
-                the node that generates this packet after it sends
-                (or attempts to send) the packet to the next hop (successor node).
+                the node that generates this packet after it sends (or attempts
+                to send) the packet to the next hop (successor node).
             successor_addr (:class:`.XBee64BitAddress`): The 64-bit address of
                 the next node after the responder in the route towards the
                 destination, whether or not the packet arrived successfully at
@@ -65,9 +65,9 @@ class RouteInformationPacket(XBeeAPIPacket):
                 data of the packet.
 
         Raises:
-            ValueError: if ``src_event`` is not 0x11 or 0x12.
-            ValueError: if ``timestamp`` is not between 0 and 0xFFFFFFFF.
-            ValueError: if ``ack_timeout_count`` or ``tx_block_count`` are not
+            ValueError: if `src_event` is not 0x11 or 0x12.
+            ValueError: if `timestamp` is not between 0 and 0xFFFFFFFF.
+            ValueError: if `ack_timeout_count` or `tx_block_count` are not
                 between 0 and 255.
 
         .. seealso::
@@ -89,7 +89,7 @@ class RouteInformationPacket(XBeeAPIPacket):
         self.__timestamp = timestamp
         self.__ack_timeout_count = ack_timeout_count
         self.__tx_block_count = tx_block_count
-        self.__reserved = 0
+        self._reserved = 0
         self.__dst_addr = dst_addr
         self.__src_addr = src_addr
         self.__responder_addr = responder_addr
@@ -122,15 +122,15 @@ class RouteInformationPacket(XBeeAPIPacket):
             InvalidPacketException: If the internal length byte of the rest
                 of the frame (without the checksum) is different from its real
                 length.
-            InvalidOperatingModeException: If ``operating_mode`` is not
+            InvalidOperatingModeException: If `operating_mode` is not
                 supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE,
-                                  OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(
                 operating_mode.name + " is not supported.")
 
@@ -155,7 +155,7 @@ class RouteInformationPacket(XBeeAPIPacket):
                                         XBee64BitAddress(raw[29:37]),
                                         XBee64BitAddress(raw[37:45]),
                                         additional_data)
-        packet.__reserved = raw[12]
+        packet._reserved = raw[12]
 
         return packet
 
@@ -180,7 +180,7 @@ class RouteInformationPacket(XBeeAPIPacket):
         ret += utils.int_to_bytes(self.__timestamp, num_bytes=4)
         ret.append(self.__ack_timeout_count)
         ret.append(self.__tx_block_count)
-        ret.append(self.__reserved)
+        ret.append(self._reserved)
         ret += self.__dst_addr.address
         ret += self.__src_addr.address
         ret += self.__responder_addr.address
@@ -227,7 +227,7 @@ class RouteInformationPacket(XBeeAPIPacket):
             src_event (Integer): The new source event.
 
         Raises:
-            ValueError: if ``src_event`` is not 0x11 or 0x12.
+            ValueError: if `src_event` is not 0x11 or 0x12.
         """
         if src_event not in [0x11, 0x12]:
             raise ValueError("Source event must be 0x11 or 0x12.")
@@ -267,7 +267,7 @@ class RouteInformationPacket(XBeeAPIPacket):
             timestamp (Integer): The number of microseconds.
 
         Raises:
-            ValueError: if ``timestamp`` is not between 0 and 0xFFFFFFFF.
+            ValueError: if `timestamp` is not between 0 and 0xFFFFFFFF.
         """
         if timestamp < 0 or timestamp > 0xFFFFFFFF:  # 4 bytes
             raise ValueError("Timestamp must be between 0 and %d." % 0xFFFFFFFF)
@@ -293,7 +293,7 @@ class RouteInformationPacket(XBeeAPIPacket):
             ack_timeout_count (Integer): The number of MAC ACK timeouts that occur.
 
         Raises:
-            ValueError: if ``ack_timeout_count`` is not between 0 and 255.
+            ValueError: if `ack_timeout_count` is not between 0 and 255.
         """
         if ack_timeout_count < 0 or ack_timeout_count > 0xFF:  # 1 byte
             raise ValueError("ACK timeout count must be between 0 and 255")
@@ -323,7 +323,7 @@ class RouteInformationPacket(XBeeAPIPacket):
                 blocked due to reception in progress.
 
         Raises:
-            ValueError: if ``tx_block_count`` is not between 0 and 255.
+            ValueError: if `tx_block_count` is not between 0 and 255.
         """
         if tx_block_count < 0 or tx_block_count > 0xFF:  # 1 byte
             raise ValueError("TX blocked count must be between 0 and 255")

--- a/digi/xbee/packets/network.py
+++ b/digi/xbee/packets/network.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -23,9 +23,9 @@ from digi.xbee.exception import InvalidOperatingModeException, InvalidPacketExce
 
 class RXIPv4Packet(XBeeAPIPacket):
     """
-    This class represents an RX (Receive) IPv4 packet. Packet is built 
+    This class represents an RX (Receive) IPv4 packet. Packet is built
     using the parameters of the constructor or providing a valid byte array.
-    
+
     .. seealso::
        | :class:`.TXIPv4Packet`
        | :class:`.XBeeAPIPacket`
@@ -34,7 +34,8 @@ class RXIPv4Packet(XBeeAPIPacket):
 
     def __init__(self, source_address, dest_port, source_port, ip_protocol, data=None):
         """
-        Class constructor. Instantiates a new :class:`.RXIPv4Packet` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.RXIPv4Packet` object
+        with the provided parameters.
 
         Args:
             source_address (:class:`.IPv4Address`): IPv4 address of the source device.
@@ -44,8 +45,8 @@ class RXIPv4Packet(XBeeAPIPacket):
             data (Bytearray, optional): data that is sent to the destination device. Optional.
 
         Raises:
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535 or
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
+            ValueError: if `dest_port` is less than 0 or greater than 65535 or
+            ValueError: if `source_port` is less than 0 or greater than 65535.
 
         .. seealso::
            | :class:`.IPProtocol`
@@ -67,26 +68,32 @@ class RXIPv4Packet(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             RXIPv4Packet.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 15. (start delim + length (2 bytes) + frame
-                type + source address (4 bytes) + dest port (2 bytes) + source port (2 bytes) + network protocol +
-                status + checksum = 15 bytes)
-            InvalidPacketException: if the length field of ``raw`` is different than its real length. (length field:
-                bytes 2 and 3)
-            InvalidPacketException: if the first byte of ``raw`` is not the header byte. See :class:`.SPECIAL_BYTE`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`ApiFrameType.RX_IPV4`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 15.
+                (start delim + length (2 bytes) + frame type
+                + source address(4 bytes) + dest port (2 bytes)
+                + source port (2 bytes) + network protocol + status
+                 + checksum = 15 bytes)
+            InvalidPacketException: if the length field of `raw` is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of `raw` is not the
+                header byte. See :class:`.SPECIAL_BYTE`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`ApiFrameType.RX_IPV4`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RXIPv4Packet.__MIN_PACKET_LENGTH)
@@ -101,13 +108,14 @@ class RXIPv4Packet(XBeeAPIPacket):
     def needs_id(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket.needs_id`
         """
         return True
 
-    def __get_source_address(self):
+    @property
+    def source_address(self):
         """
         Returns the IPv4 address of the source device.
 
@@ -116,7 +124,8 @@ class RXIPv4Packet(XBeeAPIPacket):
         """
         return self.__source_address
 
-    def __set_source_address(self, source_address):
+    @source_address.setter
+    def source_address(self, source_address):
         """
         Sets the IPv4 source address.
 
@@ -126,7 +135,8 @@ class RXIPv4Packet(XBeeAPIPacket):
         if source_address is not None:
             self.__source_address = source_address
 
-    def __get_dest_port(self):
+    @property
+    def dest_port(self):
         """
         Returns the destination port.
 
@@ -135,7 +145,8 @@ class RXIPv4Packet(XBeeAPIPacket):
         """
         return self.__dest_port
 
-    def __set_dest_port(self, dest_port):
+    @dest_port.setter
+    def dest_port(self, dest_port):
         """
         Sets the destination port.
 
@@ -143,13 +154,14 @@ class RXIPv4Packet(XBeeAPIPacket):
             dest_port (Integer): the new destination port.
 
         Raises:
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535.
+            ValueError: if `dest_port` is less than 0 or greater than 65535.
         """
         if dest_port < 0 or dest_port > 65535:
             raise ValueError("Destination port must be between 0 and 65535")
         self.__dest_port = dest_port
 
-    def __get_source_port(self):
+    @property
+    def source_port(self):
         """
         Returns the source port.
 
@@ -158,7 +170,8 @@ class RXIPv4Packet(XBeeAPIPacket):
         """
         return self.__source_port
 
-    def __set_source_port(self, source_port):
+    @source_port.setter
+    def source_port(self, source_port):
         """
         Sets the source port.
 
@@ -166,13 +179,14 @@ class RXIPv4Packet(XBeeAPIPacket):
             source_port (Integer): the new source port.
 
         Raises:
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
+            ValueError: if `source_port` is less than 0 or greater than 65535.
         """
         if source_port < 0 or source_port > 65535:
             raise ValueError("Source port must be between 0 and 65535")
         self.__source_port = source_port
 
-    def __get_ip_protocol(self):
+    @property
+    def ip_protocol(self):
         """
         Returns the IP protocol used for transmitted data.
 
@@ -181,7 +195,8 @@ class RXIPv4Packet(XBeeAPIPacket):
         """
         return self.__ip_protocol
 
-    def __set_ip_protocol(self, ip_protocol):
+    @ip_protocol.setter
+    def ip_protocol(self, ip_protocol):
         """
         Sets the IP protocol used for transmitted data.
 
@@ -190,7 +205,8 @@ class RXIPv4Packet(XBeeAPIPacket):
         """
         self.__ip_protocol = ip_protocol
 
-    def __get_data(self):
+    @property
+    def data(self):
         """
         Returns the data of the packet.
 
@@ -201,7 +217,8 @@ class RXIPv4Packet(XBeeAPIPacket):
             return self.__data
         return self.__data.copy()
 
-    def __set_data(self, data):
+    @data.setter
+    def data(self, data):
         """
         Sets the data of the packet.
 
@@ -243,21 +260,6 @@ class RXIPv4Packet(XBeeAPIPacket):
                 DictKeys.STATUS:        self.__status,
                 DictKeys.RF_DATA:       bytearray(self.__data)}
 
-    source_address = property(__get_source_address, __set_source_address)
-    """:class:`ipaddress.IPv4Address`. IPv4 address of the source device."""
-
-    dest_port = property(__get_dest_port, __set_dest_port)
-    """Integer. Destination port."""
-
-    source_port = property(__get_source_port, __set_source_port)
-    """Integer. Source port."""
-
-    ip_protocol = property(__get_ip_protocol, __set_ip_protocol)
-    """:class:`.IPProtocol`. IP protocol used in the transmission."""
-
-    data = property(__get_data, __set_data)
-    """Bytearray. Data of the packet."""
-
 
 class TXIPv4Packet(XBeeAPIPacket):
     """
@@ -277,9 +279,11 @@ class TXIPv4Packet(XBeeAPIPacket):
 
     __MIN_PACKET_LENGTH = 16
 
-    def __init__(self, frame_id, dest_address, dest_port, source_port, ip_protocol, transmit_options, data=None):
+    def __init__(self, frame_id, dest_address, dest_port, source_port,
+                 ip_protocol, transmit_options, data=None):
         """
-        Class constructor. Instantiates a new :class:`.TXIPv4Packet` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.TXIPv4Packet` object
+        with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID. Must be between 0 and 255.
@@ -291,9 +295,9 @@ class TXIPv4Packet(XBeeAPIPacket):
             data (Bytearray, optional): data that is sent to the destination device. Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535.
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `dest_port` is less than 0 or greater than 65535.
+            ValueError: if `source_port` is less than 0 or greater than 65535.
 
         .. seealso::
            | :class:`.IPProtocol`
@@ -323,22 +327,28 @@ class TXIPv4Packet(XBeeAPIPacket):
             TXIPv4Packet.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 16. (start delim + length (2 bytes) + frame
-                type + frame id + dest address (4 bytes) + dest port (2 bytes) + source port (2 bytes) + network
-                protocol + transmit options + checksum = 16 bytes)
-            InvalidPacketException: if the length field of ``raw`` is different than its real length. (length field:
-                bytes 2 and 3)
-            InvalidPacketException: if the first byte of ``raw`` is not the header byte. See :class:`.SPECIAL_BYTE`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`ApiFrameType.TX_IPV4`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 16.
+                (start delim + length (2 bytes) + frame type + frame id
+                + dest address (4 bytes) + dest port (2 bytes)
+                + source port (2 bytes) + network protocol + transmit options
+                + checksum = 16 bytes)
+            InvalidPacketException: if the length field of `raw` is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of `raw` is not the
+                header byte. See :class:`.SPECIAL_BYTE`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`ApiFrameType.TX_IPV4`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
-            raise InvalidOperatingModeException(op_mode =operating_mode)
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
+            raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TXIPv4Packet.__MIN_PACKET_LENGTH)
 
@@ -358,7 +368,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         return True
 
-    def __get_dest_address(self):
+    @property
+    def dest_address(self):
         """
         Returns the IPv4 address of the destination device.
 
@@ -367,7 +378,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         return self.__dest_address
 
-    def __set_dest_address(self, dest_address):
+    @dest_address.setter
+    def dest_address(self, dest_address):
         """
         Sets the IPv4 destination address.
 
@@ -377,7 +389,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         if dest_address is not None:
             self.__dest_address = dest_address
 
-    def __get_dest_port(self):
+    @property
+    def dest_port(self):
         """
         Returns the destination port.
 
@@ -386,7 +399,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         return self.__dest_port
 
-    def __set_dest_port(self, dest_port):
+    @dest_port.setter
+    def dest_port(self, dest_port):
         """
         Sets the destination port.
 
@@ -394,13 +408,14 @@ class TXIPv4Packet(XBeeAPIPacket):
             dest_port (Integer): the new destination port.
 
         Raises:
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535.
+            ValueError: if `dest_port` is less than 0 or greater than 65535.
         """
         if dest_port < 0 or dest_port > 65535:
             raise ValueError("Destination port must be between 0 and 65535")
         self.__dest_port = dest_port
 
-    def __get_source_port(self):
+    @property
+    def source_port(self):
         """
         Returns the source port.
 
@@ -409,7 +424,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         return self.__source_port
 
-    def __set_source_port(self, source_port):
+    @source_port.setter
+    def source_port(self, source_port):
         """
         Sets the source port.
 
@@ -417,14 +433,15 @@ class TXIPv4Packet(XBeeAPIPacket):
             source_port (Integer): the new source port.
 
         Raises:
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
+            ValueError: if `source_port` is less than 0 or greater than 65535.
         """
         if source_port < 0 or source_port > 65535:
             raise ValueError("Source port must be between 0 and 65535")
 
         self.__source_port = source_port
 
-    def __get_ip_protocol(self):
+    @property
+    def ip_protocol(self):
         """
         Returns the IP protocol used for transmitted data.
 
@@ -433,7 +450,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         return self.__ip_protocol
 
-    def __set_ip_protocol(self, ip_protocol):
+    @ip_protocol.setter
+    def ip_protocol(self, ip_protocol):
         """
         Sets the network protocol used for transmitted data.
 
@@ -442,7 +460,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         self.__ip_protocol = ip_protocol
 
-    def __get_transmit_options(self):
+    @property
+    def transmit_options(self):
         """
         Returns the transmit options of the packet.
 
@@ -451,7 +470,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         return self.__transmit_options
 
-    def __set_transmit_options(self, transmit_options):
+    @transmit_options.setter
+    def transmit_options(self, transmit_options):
         """
         Sets the transmit options bitfield of the packet.
 
@@ -461,7 +481,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         self.__transmit_options = transmit_options
 
-    def __get_data(self):
+    @property
+    def data(self):
         """
         Returns the data of the packet.
 
@@ -470,7 +491,8 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         return self.__data if self.__data is None else self.__data.copy()
 
-    def __set_data(self, data):
+    @data.setter
+    def data(self, data):
         """
         Sets the data of the packet.
 
@@ -503,26 +525,8 @@ class TXIPv4Packet(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._get_API_packet_spec_data_dict`
         """
         return {DictKeys.DEST_IPV4_ADDR: "%s (%s)" % (self.__dest_address.packed, self.__dest_address.exploded),
-                DictKeys.DEST_PORT:      self.dest_port,
-                DictKeys.SRC_PORT:       self.source_port,
+                DictKeys.DEST_PORT:      self.__dest_port,
+                DictKeys.SRC_PORT:       self.__source_port,
                 DictKeys.IP_PROTOCOL:    "%s (%s)" % (self.__ip_protocol.code, self.__ip_protocol.description),
                 DictKeys.OPTIONS:        self.__transmit_options,
                 DictKeys.RF_DATA:        bytearray(self.__data)}
-
-    dest_address = property(__get_dest_address, __set_dest_address)
-    """:class:`ipaddress.IPv4Address`. IPv4 address of the destination device."""
-
-    dest_port = property(__get_dest_port, __set_dest_port)
-    """Integer. Destination port."""
-
-    source_port = property(__get_source_port, __set_source_port)
-    """Integer. Source port."""
-
-    ip_protocol = property(__get_ip_protocol, __set_ip_protocol)
-    """:class:`.IPProtocol`. IP protocol."""
-
-    transmit_options = property(__get_transmit_options, __set_transmit_options)
-    """Integer. Transmit options."""
-
-    data = property(__get_data, __set_data)
-    """Bytearray. Data of the packet."""

--- a/digi/xbee/packets/raw.py
+++ b/digi/xbee/packets/raw.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,12 +24,12 @@ from digi.xbee.util import utils
 
 class TX64Packet(XBeeAPIPacket):
     """
-    This class represents a TX (Transmit) 64 Request packet. Packet is built 
+    This class represents a TX (Transmit) 64 Request packet. Packet is built
     using the parameters of the constructor or providing a valid byte array.
-    
-    A TX Request message will cause the module to transmit data as an RF 
+
+    A TX Request message will cause the module to transmit data as an RF
     Packet.
-    
+
     .. seealso::
        | :class:`.XBeeAPIPacket`
     """
@@ -38,7 +38,8 @@ class TX64Packet(XBeeAPIPacket):
 
     def __init__(self, frame_id, x64bit_addr, transmit_options, rf_data=None):
         """
-        Class constructor. Instantiates a new :class:`.TX64Packet` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.TX64Packet` object with
+        the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -52,7 +53,7 @@ class TX64Packet(XBeeAPIPacket):
            | :class:`.XBeeAPIPacket`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame id must be between 0 and 255.")
@@ -67,25 +68,30 @@ class TX64Packet(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.TX64Packet`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 15. (start delim. + length (2 bytes) + frame
-                type + frame id + 64bit addr. + transmit options + checksum = 15 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.TX_64`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 15.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + 64bit addr. + transmit options + checksum = 15 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.TX_64`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in(OperatingMode.ESCAPED_API_MODE,
+                                 OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TX64Packet.__MIN_PACKET_LENGTH)
@@ -128,10 +134,11 @@ class TX64Packet(XBeeAPIPacket):
                 DictKeys.TRANSMIT_OPTIONS: self.__transmit_options,
                 DictKeys.RF_DATA:          self.__rf_data}
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_dest_addr(self):
         """
         Returns the 64-bit destination address.
-        
+
         Returns:
             :class:`.XBee64BitAddress`: the 64-bit destination address.
 
@@ -140,7 +147,8 @@ class TX64Packet(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_dest_addr.setter
+    def x64bit_dest_addr(self, x64bit_addr):
         """
         Sets the 64-bit destination address.
 
@@ -152,7 +160,8 @@ class TX64Packet(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_transmit_options(self):
+    @property
+    def transmit_options(self):
         """
         Returns the transmit options bitfield.
 
@@ -164,7 +173,8 @@ class TX64Packet(XBeeAPIPacket):
         """
         return self.__transmit_options
 
-    def __set_transmit_options(self, transmit_options):
+    @transmit_options.setter
+    def transmit_options(self, transmit_options):
         """
         Sets the transmit options bitfield.
 
@@ -176,7 +186,8 @@ class TX64Packet(XBeeAPIPacket):
         """
         self.__transmit_options = transmit_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the RF data to send.
 
@@ -187,7 +198,8 @@ class TX64Packet(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the RF data to send.
 
@@ -199,24 +211,15 @@ class TX64Packet(XBeeAPIPacket):
         else:
             self.__rf_data = rf_data.copy()
 
-    x64bit_dest_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """XBee64BitAddress. 64-bit destination address."""
-
-    transmit_options = property(__get_transmit_options, __set_transmit_options)
-    """Integer. Transmit options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. RF data to send."""
-
 
 class TX16Packet(XBeeAPIPacket):
     """
-    This class represents a TX (Transmit) 16 Request packet. Packet is built 
+    This class represents a TX (Transmit) 16 Request packet. Packet is built
     using the parameters of the constructor or providing a valid byte array.
-    
+
     A TX request message will cause the module to transmit data as an RF
     packet.
-    
+
     .. seealso::
        | :class:`.XBeeAPIPacket`
     """
@@ -225,7 +228,8 @@ class TX16Packet(XBeeAPIPacket):
 
     def __init__(self, frame_id, x16bit_addr, transmit_options, rf_data=None):
         """
-        Class constructor. Instantiates a new :class:`.TX16Packet` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.TX16Packet` object with
+        the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -239,7 +243,7 @@ class TX16Packet(XBeeAPIPacket):
            | :class:`.XBeeAPIPacket`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame id must be between 0 and 255.")
@@ -254,25 +258,30 @@ class TX16Packet(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.TX16Packet`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 9. (start delim. + length (2 bytes) + frame
-                type + frame id + 16bit addr. + transmit options + checksum = 9 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.TX_16`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 9.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + 16bit addr. + transmit options + checksum = 9 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.TX_16`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TX16Packet.__MIN_PACKET_LENGTH)
@@ -315,7 +324,8 @@ class TX16Packet(XBeeAPIPacket):
                 DictKeys.TRANSMIT_OPTIONS: self.__transmit_options,
                 DictKeys.RF_DATA:          self.__rf_data}
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_dest_addr(self):
         """
         Returns the 16-bit destination address.
 
@@ -327,7 +337,8 @@ class TX16Packet(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_dest_addr.setter
+    def x16bit_dest_addr(self, x16bit_addr):
         """
         Sets the 16-bit destination address.
 
@@ -339,7 +350,8 @@ class TX16Packet(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    def __get_transmit_options(self):
+    @property
+    def transmit_options(self):
         """
         Returns the transmit options bitfield.
 
@@ -351,7 +363,8 @@ class TX16Packet(XBeeAPIPacket):
         """
         return self.__transmit_options
 
-    def __set_transmit_options(self, transmit_options):
+    @transmit_options.setter
+    def transmit_options(self, transmit_options):
         """
         Sets the transmit options bitfield.
 
@@ -363,7 +376,8 @@ class TX16Packet(XBeeAPIPacket):
         """
         self.__transmit_options = transmit_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the RF data to send.
 
@@ -374,7 +388,8 @@ class TX16Packet(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the RF data to send.
 
@@ -385,15 +400,6 @@ class TX16Packet(XBeeAPIPacket):
             self.__rf_data = None
         else:
             self.__rf_data = rf_data.copy()
-
-    x16bit_dest_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """XBee64BitAddress. 16-bit destination address."""
-
-    transmit_options = property(__get_transmit_options, __set_transmit_options)
-    """Integer. Transmit options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. RF data to send."""
 
 
 class TXStatusPacket(XBeeAPIPacket):
@@ -415,14 +421,15 @@ class TXStatusPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, transmit_status):
         """
-        Class constructor. Instantiates a new :class:`.TXStatusPacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.TXStatusPacket` object
+        with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
             transmit_status (:class:`.TransmitStatus`): transmit status. Default: SUCCESS.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.TransmitStatus`
@@ -444,20 +451,25 @@ class TXStatusPacket(XBeeAPIPacket):
             :class:`.TXStatusPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 7. (start delim. + length (2 bytes) + frame
-                type + frame id + transmit status + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.TX_16`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 7.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + transmit status + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.TX_16`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TXStatusPacket.__MIN_PACKET_LENGTH)
@@ -494,7 +506,8 @@ class TXStatusPacket(XBeeAPIPacket):
         """
         return {DictKeys.TS_STATUS: self.__transmit_status}
 
-    def __get_transmit_status(self):
+    @property
+    def transmit_status(self):
         """
         Returns the transmit status.
 
@@ -506,7 +519,8 @@ class TXStatusPacket(XBeeAPIPacket):
         """
         return self.__transmit_status
 
-    def __set_transmit_status(self, transmit_status):
+    @transmit_status.setter
+    def transmit_status(self, transmit_status):
         """
         Sets the transmit status.
 
@@ -518,20 +532,17 @@ class TXStatusPacket(XBeeAPIPacket):
         """
         self.__transmit_status = transmit_status
 
-    transmit_status = property(__get_transmit_status, __set_transmit_status)
-    """:class:`.TransmitStatus`. Transmit status."""
-
 
 class RX64Packet(XBeeAPIPacket):
     """
     This class represents an RX (Receive) 64 request packet. Packet is built
     using the parameters of the constructor or providing a valid API byte array.
-    
-    When the module receives an RF packet, it is sent out the UART using 
+
+    When the module receives an RF packet, it is sent out the UART using
     this message type.
-    
+
     This packet is the response to TX (transmit) 64 request packets.
-    
+
     .. seealso::
        | :class:`.ReceiveOptions`
        | :class:`.TX64Packet`
@@ -542,8 +553,9 @@ class RX64Packet(XBeeAPIPacket):
 
     def __init__(self, x64bit_addr, rssi, receive_options, rf_data=None):
         """
-        Class constructor. Instantiates a :class:`.RX64Packet` object with the provided parameters.
-        
+        Class constructor. Instantiates a :class:`.RX64Packet` object with the
+        provided parameters.
+
         Args:
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit source address.
             rssi (Integer): received signal strength indicator.
@@ -567,25 +579,30 @@ class RX64Packet(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.RX64Packet`
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 15. (start delim. + length (2 bytes) + frame
-                type + 64bit addr. + rssi + receive options + checksum = 15 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.RX_64`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 15.
+                (start delim. + length (2 bytes) + frame type + 64bit addr.
+                + rssi + receive options + checksum = 15 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.RX_64`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64Packet.__MIN_PACKET_LENGTH)
@@ -640,7 +657,8 @@ class RX64Packet(XBeeAPIPacket):
                 DictKeys.RECEIVE_OPTIONS: self.__receive_options,
                 DictKeys.RF_DATA:         self.__rf_data}
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
 
@@ -652,7 +670,8 @@ class RX64Packet(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_source_addr.setter
+    def x64bit_source_addr(self, x64bit_addr):
         """
         Sets the 64-bit source address.
 
@@ -664,25 +683,28 @@ class RX64Packet(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_rssi(self):
+    @property
+    def rssi(self):
         """
         Returns the received Signal Strength Indicator (RSSI).
-        
+
         Returns:
             Integer: the received Signal Strength Indicator (RSSI).
         """
         return self.__rssi
 
-    def __set_rssi(self, rssi):
+    @rssi.setter
+    def rssi(self, rssi):
         """
         Sets the received Signal Strength Indicator (RSSI).
-        
+
         Args:
             rssi (Integer): the new received Signal Strength Indicator (RSSI).
         """
         self.__rssi = rssi
 
-    def __get_options(self):
+    @property
+    def receive_options(self):
         """
         Returns the receive options bitfield.
 
@@ -694,7 +716,8 @@ class RX64Packet(XBeeAPIPacket):
         """
         return self.__receive_options
 
-    def __set_options(self, receive_options):
+    @receive_options.setter
+    def receive_options(self, receive_options):
         """
         Sets the receive options bitfield.
 
@@ -706,7 +729,8 @@ class RX64Packet(XBeeAPIPacket):
         """
         self.__receive_options = receive_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the received RF data.
 
@@ -717,7 +741,8 @@ class RX64Packet(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the received RF data.
 
@@ -729,29 +754,17 @@ class RX64Packet(XBeeAPIPacket):
         else:
             self.__rf_data = rf_data.copy()
 
-    x64bit_source_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit source address."""
-
-    rssi = property(__get_rssi, __set_rssi)
-    """Integer. Received Signal Strength Indicator (RSSI) value."""
-
-    receive_options = property(__get_options, __set_options)
-    """Integer. Receive options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. Received RF data."""
-
 
 class RX16Packet(XBeeAPIPacket):
     """
-    This class represents an RX (Receive) 16 Request packet. Packet is built 
+    This class represents an RX (Receive) 16 Request packet. Packet is built
     using the parameters of the constructor or providing a valid API byte array.
-    
-    When the module receives an RF packet, it is sent out the UART using this 
+
+    When the module receives an RF packet, it is sent out the UART using this
     message type
-    
+
     This packet is the response to TX (Transmit) 16 Request packets.
-    
+
     .. seealso::
        | :class:`.ReceiveOptions`
        | :class:`.TX16Packet`
@@ -762,7 +775,8 @@ class RX16Packet(XBeeAPIPacket):
 
     def __init__(self, x16bit_addr, rssi, receive_options, rf_data=None):
         """
-        Class constructor. Instantiates a :class:`.RX16Packet` object with the provided parameters.
+        Class constructor. Instantiates a :class:`.RX16Packet` object with the
+        provided parameters.
 
         Args:
             x16bit_addr (:class:`.XBee16BitAddress`): the 16-bit source address.
@@ -787,25 +801,30 @@ class RX16Packet(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.RX16Packet`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 9. (start delim. + length (2 bytes) + frame
-                type + 16bit addr. + rssi + receive options + checksum = 9 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.RX_16`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 9.
+            (start delim. + length (2 bytes) + frame type + 16bit addr. + rssi
+                + receive options + checksum = 9 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.RX_16`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16Packet.__MIN_PACKET_LENGTH)
@@ -837,7 +856,7 @@ class RX16Packet(XBeeAPIPacket):
     def _get_api_packet_spec_data(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
         """
@@ -851,7 +870,7 @@ class RX16Packet(XBeeAPIPacket):
     def _get_api_packet_spec_data_dict(self):
         """
         Override method.
-        
+
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data_dict`
         """
@@ -860,7 +879,8 @@ class RX16Packet(XBeeAPIPacket):
                 DictKeys.RECEIVE_OPTIONS: self.__receive_options,
                 DictKeys.RF_DATA:         self.__rf_data}
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_source_addr(self):
         """
         Returns the 16-bit source address.
 
@@ -872,7 +892,8 @@ class RX16Packet(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_source_addr.setter
+    def x16bit_source_addr(self, x16bit_addr):
         """
         Sets the 16-bit source address.
 
@@ -884,7 +905,8 @@ class RX16Packet(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    def __get_rssi(self):
+    @property
+    def rssi(self):
         """
         Returns the received Signal Strength Indicator (RSSI).
 
@@ -893,7 +915,8 @@ class RX16Packet(XBeeAPIPacket):
         """
         return self.__rssi
 
-    def __set_rssi(self, rssi):
+    @rssi.setter
+    def rssi(self, rssi):
         """
         Sets the received Signal Strength Indicator (RSSI).
 
@@ -903,7 +926,8 @@ class RX16Packet(XBeeAPIPacket):
         """
         self.__rssi = rssi
 
-    def __get_options(self):
+    @property
+    def receive_options(self):
         """
         Returns the receive options bitfield.
 
@@ -915,7 +939,8 @@ class RX16Packet(XBeeAPIPacket):
         """
         return self.__receive_options
 
-    def __set_options(self, receive_options):
+    @receive_options.setter
+    def receive_options(self, receive_options):
         """
         Sets the receive options bitfield.
 
@@ -927,7 +952,8 @@ class RX16Packet(XBeeAPIPacket):
         """
         self.__receive_options = receive_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the received RF data.
 
@@ -938,7 +964,8 @@ class RX16Packet(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the received RF data.
 
@@ -949,18 +976,6 @@ class RX16Packet(XBeeAPIPacket):
             self.__rf_data = None
         else:
             self.__rf_data = rf_data.copy()
-
-    x16bit_source_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit source address."""
-
-    rssi = property(__get_rssi, __set_rssi)
-    """Integer. Received Signal Strength Indicator (RSSI) value."""
-
-    receive_options = property(__get_options, __set_options)
-    """Integer. Receive options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. Received RF data."""
 
 
 class RX64IOPacket(XBeeAPIPacket):
@@ -978,7 +993,8 @@ class RX64IOPacket(XBeeAPIPacket):
 
     def __init__(self, x64bit_addr, rssi, receive_options, rf_data):
         """
-        Class constructor. Instantiates an :class:`.RX64IOPacket` object with the provided parameters.
+        Class constructor. Instantiates an :class:`.RX64IOPacket` object with
+        the provided parameters.
 
         Args:
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit source address.
@@ -1007,20 +1023,25 @@ class RX64IOPacket(XBeeAPIPacket):
             :class:`.RX64IOPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 20. (start delim. + length (2 bytes) + frame
-                type + 64bit addr. + rssi + receive options + rf data (5 bytes) + checksum = 20 bytes)
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.RX_IO_64`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 20.
+                (start delim. + length (2 bytes) + frame type + 64bit addr.
+                + rssi + receive options + rf data (5 bytes) + checksum = 20 bytes)
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.RX_IO_64`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64IOPacket.__MIN_PACKET_LENGTH)
@@ -1100,7 +1121,8 @@ class RX64IOPacket(XBeeAPIPacket):
 
         return base
 
-    def __get_64bit_addr(self):
+    @property
+    def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
 
@@ -1112,7 +1134,8 @@ class RX64IOPacket(XBeeAPIPacket):
         """
         return self.__x64bit_addr
 
-    def __set_64bit_addr(self, x64bit_addr):
+    @x64bit_source_addr.setter
+    def x64bit_source_addr(self, x64bit_addr):
         """
         Sets the 64-bit source address.
 
@@ -1124,7 +1147,8 @@ class RX64IOPacket(XBeeAPIPacket):
         """
         self.__x64bit_addr = x64bit_addr
 
-    def __get_rssi(self):
+    @property
+    def rssi(self):
         """
         Returns the received Signal Strength Indicator (RSSI).
 
@@ -1133,7 +1157,8 @@ class RX64IOPacket(XBeeAPIPacket):
         """
         return self.__rssi
 
-    def __set_rssi(self, rssi):
+    @rssi.setter
+    def rssi(self, rssi):
         """
         Sets the received Signal Strength Indicator (RSSI).
 
@@ -1142,7 +1167,8 @@ class RX64IOPacket(XBeeAPIPacket):
         """
         self.__rssi = rssi
 
-    def __get_options(self):
+    @property
+    def receive_options(self):
         """
         Returns the receive options bitfield.
 
@@ -1154,7 +1180,8 @@ class RX64IOPacket(XBeeAPIPacket):
         """
         return self.__receive_options
 
-    def __set_options(self, receive_options):
+    @receive_options.setter
+    def receive_options(self, receive_options):
         """
         Sets the receive options bitfield.
 
@@ -1166,7 +1193,8 @@ class RX64IOPacket(XBeeAPIPacket):
         """
         self.__receive_options = receive_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the received RF data.
 
@@ -1177,7 +1205,8 @@ class RX64IOPacket(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the received RF data.
 
@@ -1195,20 +1224,23 @@ class RX64IOPacket(XBeeAPIPacket):
         else:
             self.__io_sample = None
 
-    def __get_io_sample(self):
+    @property
+    def io_sample(self):
         """
         Returns the IO sample corresponding to the data contained in the packet.
 
         Returns:
-            :class:`.IOSample`: the IO sample of the packet, ``None`` if the packet has not any data or if the
-                sample could not be generated correctly.
+            :class:`.IOSample`: the IO sample of the packet, `None` if the
+                packet has not any data or if the sample could not be generated
+                correctly.
 
         .. seealso::
            | :class:`.IOSample`
         """
         return self.__io_sample
 
-    def __set_io_sample(self, io_sample):
+    @io_sample.setter
+    def io_sample(self, io_sample):
         """
         Sets the IO sample of the packet.
 
@@ -1220,29 +1252,14 @@ class RX64IOPacket(XBeeAPIPacket):
         """
         self.__io_sample = io_sample
 
-    x64bit_source_addr = property(__get_64bit_addr, __set_64bit_addr)
-    """:class:`.XBee64BitAddress`. 64-bit source address."""
-
-    rssi = property(__get_rssi, __set_rssi)
-    """Integer. Received Signal Strength Indicator (RSSI) value."""
-
-    receive_options = property(__get_options, __set_options)
-    """Integer. Receive options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. Received RF data."""
-
-    io_sample = property(__get_io_sample, __set_io_sample)
-    """:class:`.IOSample`: IO sample corresponding to the data contained in the packet."""
-
 
 class RX16IOPacket(XBeeAPIPacket):
     """
     This class represents an RX16 address IO packet. Packet is built using the
     parameters of the constructor or providing a valid byte array.
-    
+
     I/O data is sent out the UART using an API frame.
-    
+
     .. seealso::
        | :class:`.XBeeAPIPacket`
     """
@@ -1251,14 +1268,15 @@ class RX16IOPacket(XBeeAPIPacket):
 
     def __init__(self, x16bit_addr, rssi, receive_options, rf_data):
         """
-        Class constructor. Instantiates an :class:`.RX16IOPacket` object with the provided parameters.
-        
+        Class constructor. Instantiates an :class:`.RX16IOPacket` object with
+        the provided parameters.
+
         Args:
             x16bit_addr (:class:`.XBee16BitAddress`): the 16-bit source address.
             rssi (Integer): received signal strength indicator.
             receive_options (Integer): bitfield indicating the receive options.
             rf_data (Bytearray): received RF data.
-            
+
         .. seealso::
            | :class:`.ReceiveOptions`
            | :class:`.XBee16BitAddress`
@@ -1267,7 +1285,7 @@ class RX16IOPacket(XBeeAPIPacket):
         super().__init__(ApiFrameType.RX_IO_16)
         self.__x16bit_addr = x16bit_addr
         self.__rssi = rssi
-        self.__options = receive_options
+        self.__receive_options = receive_options
         self.__rf_data = rf_data
         self.__io_sample = IOSample(rf_data) if rf_data is not None and len(rf_data) >= 5 else None
 
@@ -1275,25 +1293,30 @@ class RX16IOPacket(XBeeAPIPacket):
     def create_packet(raw, operating_mode):
         """
         Override method.
-        
+
         Returns:
             :class:`.RX16IOPacket`.
-            
+
         Raises:
-            InvalidPacketException: if the bytearray length is less than 14. (start delim. + length (2 bytes) + frame
-                type + 16bit addr. + rssi + receive options + rf data (5 bytes) + checksum = 14 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is different than :attr:`.ApiFrameType.RX_IO_16`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
-            
+            InvalidPacketException: if the bytearray length is less than 14.
+                (start delim. + length (2 bytes) + frame type + 16bit addr.
+                + rssi + receive options + rf data (5 bytes) + checksum = 14 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :attr:`.ApiFrameType.RX_IO_16`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
+
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16IOPacket.__MIN_PACKET_LENGTH)
@@ -1331,7 +1354,7 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         ret = self.__x16bit_addr.address
         ret.append(self.__rssi)
-        ret.append(self.__options)
+        ret.append(self.__receive_options)
         if self.__rf_data is not None:
             ret += self.__rf_data
         return ret
@@ -1345,7 +1368,7 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         base = {DictKeys.X16BIT_ADDR:     self.__x16bit_addr.address,
                 DictKeys.RSSI:            self.__rssi,
-                DictKeys.RECEIVE_OPTIONS: self.__options}
+                DictKeys.RECEIVE_OPTIONS: self.__receive_options}
 
         if self.__io_sample is not None:
             base[DictKeys.NUM_SAMPLES] = 1
@@ -1373,7 +1396,8 @@ class RX16IOPacket(XBeeAPIPacket):
 
         return base
 
-    def __get_16bit_addr(self):
+    @property
+    def x16bit_source_addr(self):
         """
         Returns the 16-bit source address.
 
@@ -1385,7 +1409,8 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         return self.__x16bit_addr
 
-    def __set_16bit_addr(self, x16bit_addr):
+    @x16bit_source_addr.setter
+    def x16bit_source_addr(self, x16bit_addr):
         """
         Sets the 16-bit source address.
 
@@ -1397,7 +1422,8 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         self.__x16bit_addr = x16bit_addr
 
-    def __get_rssi(self):
+    @property
+    def rssi(self):
         """
         Returns the received Signal Strength Indicator (RSSI).
 
@@ -1406,7 +1432,8 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         return self.__rssi
 
-    def __set_rssi(self, rssi):
+    @rssi.setter
+    def rssi(self, rssi):
         """
         Sets the received Signal Strength Indicator (RSSI).
 
@@ -1416,7 +1443,8 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         self.__rssi = rssi
 
-    def __get_options(self):
+    @property
+    def receive_options(self):
         """
         Returns the receive options bitfield.
 
@@ -1428,7 +1456,8 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         return self.__receive_options
 
-    def __set_options(self, receive_options):
+    @receive_options.setter
+    def receive_options(self, receive_options):
         """
         Sets the receive options bitfield.
 
@@ -1440,7 +1469,8 @@ class RX16IOPacket(XBeeAPIPacket):
         """
         self.__receive_options = receive_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the received RF data.
 
@@ -1451,7 +1481,8 @@ class RX16IOPacket(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the received RF data.
 
@@ -1469,20 +1500,23 @@ class RX16IOPacket(XBeeAPIPacket):
         else:
             self.__io_sample = None
 
-    def __get_io_sample(self):
+    @property
+    def io_sample(self):
         """
         Returns the IO sample corresponding to the data contained in the packet.
 
         Returns:
-            :class:`.IOSample`: the IO sample of the packet, ``None`` if the packet has not any data or if the
-                sample could not be generated correctly.
+            :class:`.IOSample`: the IO sample of the packet, `None` if the
+                packet has not any data or if the sample could not be generated
+                correctly.
 
         .. seealso::
            | :class:`.IOSample`
         """
         return self.__io_sample
 
-    def __set_io_sample(self, io_sample):
+    @io_sample.setter
+    def io_sample(self, io_sample):
         """
         Sets the IO sample of the packet.
 
@@ -1493,18 +1527,3 @@ class RX16IOPacket(XBeeAPIPacket):
            | :class:`.IOSample`
         """
         self.__io_sample = io_sample
-
-    x16bit_source_addr = property(__get_16bit_addr, __set_16bit_addr)
-    """:class:`.XBee16BitAddress`. 16-bit source address."""
-
-    rssi = property(__get_rssi, __set_rssi)
-    """Integer. Received Signal Strength Indicator (RSSI) value."""
-
-    receive_options = property(__get_options, __set_options)
-    """Integer. Receive options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. Received RF data."""
-
-    io_sample = property(__get_io_sample, __set_io_sample)
-    """:class:`.IOSample`: IO sample corresponding to the data contained in the packet."""

--- a/digi/xbee/packets/relay.py
+++ b/digi/xbee/packets/relay.py
@@ -1,4 +1,4 @@
-# Copyright 2019, Digi International Inc.
+# Copyright 2019, 2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -40,7 +40,8 @@ class UserDataRelayPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, local_interface, data=None):
         """
-        Class constructor. Instantiates a new :class:`.UserDataRelayPacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.UserDataRelayPacket`
+        object with the provided parameters.
 
         Args:
             frame_id (integer): the frame ID of the packet.
@@ -52,8 +53,8 @@ class UserDataRelayPacket(XBeeAPIPacket):
            | :class:`.XBeeLocalInterface`
 
         Raises:
-            ValueError: if ``local_interface`` is ``None``.
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `local_interface` is `None`.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
         """
         if local_interface is None:
             raise ValueError("Destination interface cannot be None")
@@ -74,20 +75,25 @@ class UserDataRelayPacket(XBeeAPIPacket):
             :class:`.UserDataRelayPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 7. (start delim. + length (2 bytes) + frame
-                type + frame id + relay interface + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.USER_DATA_RELAY_REQUEST`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 7.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + relay interface + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.USER_DATA_RELAY_REQUEST`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=UserDataRelayPacket.__MIN_PACKET_LENGTH)
@@ -129,7 +135,8 @@ class UserDataRelayPacket(XBeeAPIPacket):
         return {DictKeys.DEST_INTERFACE: self.__local_interface.description,
                 DictKeys.DATA:           list(self.__data) if self.__data is not None else None}
 
-    def __get_data(self):
+    @property
+    def data(self):
         """
         Returns the data to send.
 
@@ -140,7 +147,8 @@ class UserDataRelayPacket(XBeeAPIPacket):
             return None
         return self.__data.copy()
 
-    def __set_data(self, data):
+    @data.setter
+    def data(self, data):
         """
         Sets the data to send.
 
@@ -152,7 +160,8 @@ class UserDataRelayPacket(XBeeAPIPacket):
         else:
             self.__data = data.copy()
 
-    def __get_dest_interface(self):
+    @property
+    def dest_interface(self):
         """
         Returns the the destination interface.
 
@@ -164,7 +173,8 @@ class UserDataRelayPacket(XBeeAPIPacket):
         """
         return self.__local_interface
 
-    def __set_dest_interface(self, local_interface):
+    @dest_interface.setter
+    def dest_interface(self, local_interface):
         """
         Sets the destination interface.
 
@@ -175,12 +185,6 @@ class UserDataRelayPacket(XBeeAPIPacket):
            | :class:`.XBeeLocalInterface`
         """
         self.__local_interface = local_interface
-
-    dest_interface = property(__get_dest_interface, __set_dest_interface)
-    """:class:`.XBeeLocalInterface`. Destination local interface."""
-
-    data = property(__get_data, __set_data)
-    """Bytearray. Data to send."""
 
 
 class UserDataRelayOutputPacket(XBeeAPIPacket):
@@ -212,7 +216,7 @@ class UserDataRelayOutputPacket(XBeeAPIPacket):
             data (Bytearray, optional): Data received from the source interface.
 
         Raises:
-            ValueError: if ``local_interface`` is ``None``.
+            ValueError: if `local_interface` is `None`.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -234,26 +238,33 @@ class UserDataRelayOutputPacket(XBeeAPIPacket):
             :class:`.UserDataRelayOutputPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 6. (start delim. + length (2 bytes) + frame
-                type + relay interface + checksum = 6 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.USER_DATA_RELAY_OUTPUT`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 6.
+                (start delim. + length (2 bytes) + frame type + relay interface
+                + checksum = 6 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.USER_DATA_RELAY_OUTPUT`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=UserDataRelayOutputPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=UserDataRelayOutputPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.USER_DATA_RELAY_OUTPUT.code:
-            raise InvalidPacketException(message="This packet is not a user data relay output packet.")
+            raise InvalidPacketException(
+                message="This packet is not a user data relay output packet.")
 
         return UserDataRelayOutputPacket(XBeeLocalInterface.get(raw[4]), data=raw[5:-1])
 
@@ -289,7 +300,8 @@ class UserDataRelayOutputPacket(XBeeAPIPacket):
         return {DictKeys.SOURCE_INTERFACE: self.__local_interface.description,
                 DictKeys.DATA:             list(self.__data) if self.__data is not None else None}
 
-    def __get_data(self):
+    @property
+    def data(self):
         """
         Returns the received data.
 
@@ -300,7 +312,8 @@ class UserDataRelayOutputPacket(XBeeAPIPacket):
             return None
         return self.__data.copy()
 
-    def __set_data(self, data):
+    @data.setter
+    def data(self, data):
         """
         Sets the received data.
 
@@ -312,7 +325,8 @@ class UserDataRelayOutputPacket(XBeeAPIPacket):
         else:
             self.__data = data.copy()
 
-    def __get_src_interface(self):
+    @property
+    def src_interface(self):
         """
         Returns the the source interface.
 
@@ -324,7 +338,8 @@ class UserDataRelayOutputPacket(XBeeAPIPacket):
         """
         return self.__local_interface
 
-    def __set_src_interface(self, local_interface):
+    @src_interface.setter
+    def src_interface(self, local_interface):
         """
         Sets the source interface.
 
@@ -335,9 +350,3 @@ class UserDataRelayOutputPacket(XBeeAPIPacket):
            | :class:`.XBeeLocalInterface`
         """
         self.__local_interface = local_interface
-
-    src_interface = property(__get_src_interface, __set_src_interface)
-    """:class:`.XBeeLocalInterface`. Source local interface."""
-
-    data = property(__get_data, __set_data)
-    """Bytearray. Received data."""

--- a/digi/xbee/packets/socket.py
+++ b/digi/xbee/packets/socket.py
@@ -1,4 +1,4 @@
-# Copyright 2019, Digi International Inc.
+# Copyright 2019, 2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -41,7 +41,8 @@ class SocketCreatePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, protocol):
         """
-        Class constructor. Instantiates a new :class:`.SocketCreatePacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketCreatePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -52,7 +53,7 @@ class SocketCreatePacket(XBeeAPIPacket):
            | :class:`.IPProtocol`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255")
@@ -70,26 +71,33 @@ class SocketCreatePacket(XBeeAPIPacket):
             :class:`.SocketCreatePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 7. (start delim. + length (2 bytes) + frame
-                type + frame id + protocol + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_CREATE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 7.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + protocol + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_CREATE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketCreatePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketCreatePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_CREATE.code:
-            raise InvalidPacketException(message="This packet is not a Socket Create packet.")
+            raise InvalidPacketException(
+                message="This packet is not a Socket Create packet.")
 
         return SocketCreatePacket(raw[4], IPProtocol.get(raw[5]))
 
@@ -120,7 +128,8 @@ class SocketCreatePacket(XBeeAPIPacket):
         """
         return {DictKeys.IP_PROTOCOL.value: "%s (%s)" % (self.__protocol.code, self.__protocol.description)}
 
-    def __get_protocol(self):
+    @property
+    def protocol(self):
         """
         Returns the communication protocol.
 
@@ -132,7 +141,8 @@ class SocketCreatePacket(XBeeAPIPacket):
         """
         return self.__protocol
 
-    def __set_protocol(self, protocol):
+    @protocol.setter
+    def protocol(self, protocol):
         """
         Sets the communication protocol.
 
@@ -143,9 +153,6 @@ class SocketCreatePacket(XBeeAPIPacket):
            | :class:`.IPProtocol`
         """
         self.__protocol = protocol
-
-    protocol = property(__get_protocol, __set_protocol)
-    """:class:`.IPProtocol`. Communication protocol."""
 
 
 class SocketCreateResponsePacket(XBeeAPIPacket):
@@ -169,7 +176,8 @@ class SocketCreateResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, status):
         """
-        Class constructor. Instantiates a new :class:`.SocketCreateResponsePacket` object with the provided parameters.
+        Class constructor. Instantiates a new
+        :class:`.SocketCreateResponsePacket` object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -181,8 +189,8 @@ class SocketCreateResponsePacket(XBeeAPIPacket):
            | :class:`.SocketStatus`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255")
@@ -203,28 +211,36 @@ class SocketCreateResponsePacket(XBeeAPIPacket):
             :class:`.SocketCreateResponsePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 8. (start delim. + length (2 bytes) + frame
-                type + frame id + socket id + status + checksum = 8 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_CREATE_RESPONSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 8.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket id + status + checksum = 8 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_CREATE_RESPONSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketCreateResponsePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketCreateResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_CREATE_RESPONSE.code:
-            raise InvalidPacketException(message="This packet is not a Socket Create Response packet.")
+            raise InvalidPacketException(
+                message="This packet is not a Socket Create Response packet.")
 
-        return SocketCreateResponsePacket(raw[4], raw[5], SocketStatus.get(raw[6]))
+        return SocketCreateResponsePacket(
+            raw[4], raw[5], SocketStatus.get(raw[6]))
 
     def needs_id(self):
         """
@@ -257,7 +273,8 @@ class SocketCreateResponsePacket(XBeeAPIPacket):
         return {DictKeys.SOCKET_ID.value: utils.hex_to_string(bytearray([self.__socket_id])),
                 DictKeys.STATUS.value:    "%s (%s)" % (self.__status.code, self.__status.description)}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the the socket ID.
 
@@ -266,7 +283,8 @@ class SocketCreateResponsePacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -274,13 +292,14 @@ class SocketCreateResponsePacket(XBeeAPIPacket):
             socket_id (Integer): the new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__socket_id = socket_id
 
-    def __get_status(self):
+    @property
+    def status(self):
         """
         Returns the socket create status.
 
@@ -292,7 +311,8 @@ class SocketCreateResponsePacket(XBeeAPIPacket):
         """
         return self.__status
 
-    def __set_status(self, status):
+    @status.setter
+    def status(self, status):
         """
         Sets the socket create status.
 
@@ -303,12 +323,6 @@ class SocketCreateResponsePacket(XBeeAPIPacket):
            | :class:`.SocketStatus`
         """
         self.__status = status
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    status = property(__get_status, __set_status)
-    """:class:`.SocketStatus`. Socket create status."""
 
 
 class SocketOptionRequestPacket(XBeeAPIPacket):
@@ -331,7 +345,8 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, option, option_data=None):
         """
-        Class constructor. Instantiates a new :class:`.SocketOptionRequestPacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketOptionRequestPacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -344,8 +359,8 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
            | :class:`.SocketOption`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255")
@@ -367,28 +382,36 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
             :class:`.SocketOptionRequestPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 8. (start delim. + length (2 bytes) + frame
-                type + frame id + socket id + option + checksum = 8 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_OPTION_REQUEST`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 8.
+                (start delim. + length (2 bytes) + frame type + frame id
+                    + socket id + option + checksum = 8 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: byte 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_OPTION_REQUEST`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketOptionRequestPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketOptionRequestPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_OPTION_REQUEST.code:
-            raise InvalidPacketException(message="This packet is not a Socket Option Request packet.")
+            raise InvalidPacketException(
+                message="This packet is not a Socket Option Request packet.")
 
-        return SocketOptionRequestPacket(raw[4], raw[5], SocketOption.get(raw[6]), raw[7:-1])
+        return SocketOptionRequestPacket(
+            raw[4], raw[5], SocketOption.get(raw[6]), raw[7:-1])
 
     def needs_id(self):
         """
@@ -422,11 +445,11 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
         """
         return {DictKeys.SOCKET_ID.value:   utils.hex_to_string(bytearray([self.__socket_id])),
                 DictKeys.OPTION_ID.value:   "%s (%s)" % (self.__option.code, self.__option.description),
-                DictKeys.OPTION_DATA.value: utils.hex_to_string(self.__option_data,
-                                                                True) if self.__option_data is not None
-                else None}
+                DictKeys.OPTION_DATA.value: utils.hex_to_string(
+                    self.__option_data, True) if self.__option_data is not None else None}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the the socket ID.
 
@@ -435,7 +458,8 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -443,13 +467,14 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
             socket_id (Integer): the new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__socket_id = socket_id
 
-    def __get_option(self):
+    @property
+    def option(self):
         """
         Returns the socket option.
 
@@ -461,7 +486,8 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
         """
         return self.__option
 
-    def __set_option(self, option):
+    @option.setter
+    def option(self, option):
         """
         Sets the socket option.
 
@@ -473,7 +499,8 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
         """
         self.__option = option
 
-    def __get_option_data(self):
+    @property
+    def option_data(self):
         """
         Returns the socket option data.
 
@@ -482,7 +509,8 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
         """
         return self.__option_data if self.__option_data is None else self.__option_data.copy()
 
-    def __set_option_data(self, option_data):
+    @option_data.setter
+    def option_data(self, option_data):
         """
         Sets the socket option data.
 
@@ -490,15 +518,6 @@ class SocketOptionRequestPacket(XBeeAPIPacket):
             option_data (Bytearray): the new socket option data.
         """
         self.__option_data = None if option_data is None else option_data.copy()
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    option = property(__get_option, __set_option)
-    """:class:`.SocketOption`. Socket option."""
-
-    option_data = property(__get_option_data, __set_option_data)
-    """Bytearray. Socket option data."""
 
 
 class SocketOptionResponsePacket(XBeeAPIPacket):
@@ -518,7 +537,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, option, status, option_data=None):
         """
-        Class constructor. Instantiates a new :class:`.SocketOptionResponsePacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketOptionResponsePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -533,8 +553,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
            | :class:`.SocketStatus`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255")
@@ -557,29 +577,37 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
             :class:`.SocketOptionResponsePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 9. (start delim. + length (2 bytes) + frame
-                type + frame id + socket id + option + status + checksum = 9 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_OPTION_RESPONSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 9.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket id + option + status + checksum = 9 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+            header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_OPTION_RESPONSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketOptionResponsePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketOptionResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_OPTION_RESPONSE.code:
-            raise InvalidPacketException(message="This packet is not a Socket Option Response packet.")
+            raise InvalidPacketException(
+                message="This packet is not a Socket Option Response packet.")
 
-        return SocketOptionResponsePacket(raw[4], raw[5], SocketOption.get(raw[6]), SocketStatus.get(raw[7]),
-                                          raw[8:-1])
+        return SocketOptionResponsePacket(raw[4], raw[5],
+                                          SocketOption.get(raw[6]),
+                                          SocketStatus.get(raw[7]), raw[8:-1])
 
     def needs_id(self):
         """
@@ -618,7 +646,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
                 DictKeys.OPTION_DATA.value: utils.hex_to_string(self.__option_data,
                                                                 True) if self.__option_data is not None else None}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the the socket ID.
 
@@ -627,7 +656,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -635,13 +665,14 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
             socket_id (Integer): the new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__socket_id = socket_id
 
-    def __get_option(self):
+    @property
+    def option(self):
         """
         Returns the socket option.
 
@@ -653,7 +684,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
         """
         return self.__option
 
-    def __set_option(self, option):
+    @option.setter
+    def option(self, option):
         """
         Sets the socket option.
 
@@ -665,7 +697,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
         """
         self.__option = option
 
-    def __get_status(self):
+    @property
+    def status(self):
         """
         Returns the socket option status.
 
@@ -677,7 +710,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
         """
         return self.__status
 
-    def __set_status(self, status):
+    @status.setter
+    def status(self, status):
         """
         Sets the socket option status.
 
@@ -689,7 +723,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
         """
         self.__status = status
 
-    def __get_option_data(self):
+    @property
+    def option_data(self):
         """
         Returns the socket option data.
 
@@ -698,7 +733,8 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
         """
         return self.__option_data if self.__option_data is None else self.__option_data.copy()
 
-    def __set_option_data(self, option_data):
+    @option_data.setter
+    def option_data(self, option_data):
         """
         Sets the socket option data.
 
@@ -706,18 +742,6 @@ class SocketOptionResponsePacket(XBeeAPIPacket):
             option_data (Bytearray): the new socket option data.
         """
         self.__option_data = None if option_data is None else option_data.copy()
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    option = property(__get_option, __set_option)
-    """:class:`.SocketOption`. Socket option."""
-
-    status = property(__get_status, __set_status)
-    """:class:`SocketStatus`. Socket option status"""
-
-    option_data = property(__get_option_data, __set_option_data)
-    """Bytearray. Socket option data."""
 
 
 class SocketConnectPacket(XBeeAPIPacket):
@@ -772,12 +796,12 @@ class SocketConnectPacket(XBeeAPIPacket):
            | :class:`.XBeeAPIPacket`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535.
-            ValueError: if ``dest_address_type`` is different than :attr:`SocketConnectPacket.DEST_ADDRESS_BINARY` and
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
+            ValueError: if `dest_port` is less than 0 or greater than 65535.
+            ValueError: if `dest_address_type` is different than :attr:`SocketConnectPacket.DEST_ADDRESS_BINARY` and
                         :attr:`SocketConnectPacket.DEST_ADDRESS_STRING`.
-            ValueError: if ``dest_address`` is ``None`` or does not follow the format specified in the configured type.
+            ValueError: if `dest_address` is `None` or does not follow the format specified in the configured type.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255")
@@ -790,9 +814,9 @@ class SocketConnectPacket(XBeeAPIPacket):
                                                                             SocketConnectPacket.DEST_ADDRESS_STRING))
         if (dest_address is None
                 or (dest_address_type == SocketConnectPacket.DEST_ADDRESS_BINARY
-                    and (type(dest_address) is not bytearray or len(dest_address) != 4))
+                    and (not isinstance(dest_address, bytearray) or len(dest_address) != 4))
                 or (dest_address_type == SocketConnectPacket.DEST_ADDRESS_STRING
-                    and (type(dest_address) is not str or len(dest_address) < 1))):
+                    and (not isinstance(dest_address, str) or len(dest_address) < 1))):
             raise ValueError("Invalid destination address")
 
         super().__init__(ApiFrameType.SOCKET_CONNECT)
@@ -811,34 +835,42 @@ class SocketConnectPacket(XBeeAPIPacket):
             :class:`.SocketConnectPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 11. (start delim. + length (2 bytes) + frame
-                type + frame id + socket id + dest port (2 bytes) + dest address type + dest_address + checksum =
-                11 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_CONNECT`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 11.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket id + dest port (2 bytes) + dest address type
+                + dest_address + checksum = 11 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_CONNECT`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketConnectPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketConnectPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_CONNECT.code:
-            raise InvalidPacketException(message="This packet is not a Socket Connect packet.")
+            raise InvalidPacketException(
+                message="This packet is not a Socket Connect packet.")
 
         addr_type = raw[8]
         address = raw[9:-1]
         if address is not None and addr_type == SocketConnectPacket.DEST_ADDRESS_STRING:
             address = address.decode("utf8")
 
-        return SocketConnectPacket(raw[4], raw[5], utils.bytes_to_int(raw[6:8]), addr_type, address)
+        return SocketConnectPacket(
+            raw[4], raw[5], utils.bytes_to_int(raw[6:8]), addr_type, address)
 
     def needs_id(self):
         """
@@ -860,7 +892,7 @@ class SocketConnectPacket(XBeeAPIPacket):
         ret.append(self.__socket_id)
         ret += utils.int_to_bytes(self.__dest_port, num_bytes=2)
         ret.append(self.__dest_address_type)
-        ret += self.__dest_address.encode() if type(self.__dest_address) is str else self.__dest_address
+        ret += self.__dest_address.encode() if isinstance(self.__dest_address, str) else self.__dest_address
         return ret
 
     def _get_api_packet_spec_data_dict(self):
@@ -870,16 +902,17 @@ class SocketConnectPacket(XBeeAPIPacket):
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data_dict`
         """
-        return {DictKeys.SOCKET_ID.value:      utils.hex_to_string(bytearray([self.__socket_id])),
-                DictKeys.DEST_PORT.value:      "%s (%s)" % (utils.hex_to_string(utils.int_to_bytes(self.__dest_port,
-                                                                                                   num_bytes=2)),
-                                                            self.__dest_port),
+        return {DictKeys.SOCKET_ID.value: utils.hex_to_string(bytearray([self.__socket_id])),
+                DictKeys.DEST_PORT.value: "%s (%s)"
+                                          % (utils.hex_to_string(utils.int_to_bytes(self.__dest_port, num_bytes=2)),
+                                             self.__dest_port),
                 DictKeys.DEST_ADDR_TYPE.value: utils.hex_to_string(bytearray([self.__dest_address_type])),
-                DictKeys.DEST_ADDR.value:      ("%s (%s)" % (utils.hex_to_string(self.__dest_address.encode()),
-                                                             self.__dest_address)) if type(self.__dest_address) is str
-                else utils.hex_to_string(self.__dest_address)}
+                DictKeys.DEST_ADDR.value:      ("%s (%s)" % (
+                    utils.hex_to_string(
+                        self.__dest_address.encode()), self.__dest_address)) if isinstance(self.__dest_address, str) else utils.hex_to_string(self.__dest_address)}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the the socket ID.
 
@@ -888,7 +921,8 @@ class SocketConnectPacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -896,13 +930,14 @@ class SocketConnectPacket(XBeeAPIPacket):
             socket_id (Integer): the new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__socket_id = socket_id
 
-    def __get_dest_port(self):
+    @property
+    def dest_port(self):
         """
         Returns the destination port.
 
@@ -911,7 +946,8 @@ class SocketConnectPacket(XBeeAPIPacket):
         """
         return self.__dest_port
 
-    def __set_dest_port(self, dest_port):
+    @dest_port.setter
+    def dest_port(self, dest_port):
         """
         Sets the destination port.
 
@@ -919,13 +955,14 @@ class SocketConnectPacket(XBeeAPIPacket):
             dest_port (Integer): the new destination port.
 
         Raises:
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535.
+            ValueError: if `dest_port` is less than 0 or greater than 65535.
         """
         if dest_port < 0 or dest_port > 65535:
             raise ValueError("Destination port must be between 0 and 65535")
         self.__dest_port = dest_port
 
-    def __get_dest_address_type(self):
+    @property
+    def dest_address_type(self):
         """
         Returns the destination address type.
 
@@ -934,7 +971,8 @@ class SocketConnectPacket(XBeeAPIPacket):
         """
         return self.__dest_address_type
 
-    def __set_dest_address_type(self, dest_address_type):
+    @dest_address_type.setter
+    def dest_address_type(self, dest_address_type):
         """
         Sets the destination address type.
 
@@ -942,7 +980,7 @@ class SocketConnectPacket(XBeeAPIPacket):
             dest_address_type (Integer): the new destination address type.
 
         Raises:
-            ValueError: if ``dest_address_type`` is different than :attr:`SocketConnectPacket.DEST_ADDRESS_BINARY` and
+            ValueError: if `dest_address_type` is different than :attr:`SocketConnectPacket.DEST_ADDRESS_BINARY` and
                         :attr:`SocketConnectPacket.DEST_ADDRESS_STRING`.
         """
         if dest_address_type not in (SocketConnectPacket.DEST_ADDRESS_BINARY, SocketConnectPacket.DEST_ADDRESS_STRING):
@@ -950,7 +988,8 @@ class SocketConnectPacket(XBeeAPIPacket):
                                                                             SocketConnectPacket.DEST_ADDRESS_STRING))
         self.__dest_address_type = dest_address_type
 
-    def __get_dest_address(self):
+    @property
+    def dest_address(self):
         """
         Returns the destination address.
 
@@ -959,7 +998,8 @@ class SocketConnectPacket(XBeeAPIPacket):
         """
         return self.__dest_address
 
-    def __set_dest_address(self, dest_address):
+    @dest_address.setter
+    def dest_address(self, dest_address):
         """
         Sets the destination address.
 
@@ -967,28 +1007,16 @@ class SocketConnectPacket(XBeeAPIPacket):
             dest_address (Bytearray or String): the new destination address.
 
         Raises:
-            ValueError: if ``dest_address`` is ``None``.
-            ValueError: if ``dest_address`` does not follow the format specified in the configured type.
+            ValueError: if `dest_address` is `None`.
+            ValueError: if `dest_address` does not follow the format specified in the configured type.
         """
         if (dest_address is None
                 or (self.__dest_address_type == SocketConnectPacket.DEST_ADDRESS_BINARY
-                    and (type(dest_address) is not bytearray or len(dest_address) != 4))
+                    and (not isinstance(dest_address, bytearray) or len(dest_address) != 4))
                 or (self.__dest_address_type == SocketConnectPacket.DEST_ADDRESS_STRING
-                    and (type(dest_address) is not str or len(dest_address) < 1))):
+                    and (not isinstance(dest_address, str) or len(dest_address) < 1))):
             raise ValueError("Invalid destination address")
         self.__dest_address = dest_address
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    dest_port = property(__get_dest_port, __set_dest_port)
-    """Integer. Destination port."""
-
-    dest_address_type = property(__get_dest_address_type, __set_dest_address_type)
-    """Integer. Destination address type."""
-
-    dest_address = property(__get_dest_address, __set_dest_address)
-    """Bytearray. Destination address."""
 
 
 class SocketConnectResponsePacket(XBeeAPIPacket):
@@ -1008,7 +1036,8 @@ class SocketConnectResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, status):
         """
-        Class constructor. Instantiates a new :class:`.SocketConnectPacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketConnectPacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -1020,8 +1049,8 @@ class SocketConnectResponsePacket(XBeeAPIPacket):
            | :class:`.SocketStatus`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255")
@@ -1042,28 +1071,36 @@ class SocketConnectResponsePacket(XBeeAPIPacket):
             :class:`.SocketConnectResponsePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 8. (start delim. + length (2 bytes) + frame
-                type + frame id + socket id + status + checksum = 8 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_CONNECT_RESPONSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 8.
+                (start delim. + length (2 bytes) + frame type + frame id
+                    + socket id + status + checksum = 8 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_CONNECT_RESPONSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketConnectResponsePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketConnectResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_CONNECT_RESPONSE.code:
-            raise InvalidPacketException(message="This packet is not a Socket Connect Response packet.")
+            raise InvalidPacketException(
+                message="This packet is not a Socket Connect Response packet.")
 
-        return SocketConnectResponsePacket(raw[4], raw[5], SocketStatus.get(raw[6]))
+        return SocketConnectResponsePacket(
+            raw[4], raw[5], SocketStatus.get(raw[6]))
 
     def needs_id(self):
         """
@@ -1096,7 +1133,8 @@ class SocketConnectResponsePacket(XBeeAPIPacket):
         return {DictKeys.SOCKET_ID.value: utils.hex_to_string(bytearray([self.__socket_id])),
                 DictKeys.STATUS.value:    "%s (%s)" % (self.__status.code, self.__status.description)}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the the socket ID.
 
@@ -1105,7 +1143,8 @@ class SocketConnectResponsePacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -1113,13 +1152,14 @@ class SocketConnectResponsePacket(XBeeAPIPacket):
             socket_id (Integer): the new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__socket_id = socket_id
 
-    def __get_status(self):
+    @property
+    def status(self):
         """
         Returns the socket connect status.
 
@@ -1131,7 +1171,8 @@ class SocketConnectResponsePacket(XBeeAPIPacket):
         """
         return self.__status
 
-    def __set_status(self, status):
+    @status.setter
+    def status(self, status):
         """
         Sets the socket connect status.
 
@@ -1142,12 +1183,6 @@ class SocketConnectResponsePacket(XBeeAPIPacket):
            | :class:`.SocketStatus`
         """
         self.__status = status
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    status = property(__get_status, __set_status)
-    """:class:`.SocketStatus`. Socket connect status."""
 
 
 class SocketClosePacket(XBeeAPIPacket):
@@ -1166,7 +1201,8 @@ class SocketClosePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id):
         """
-        Class constructor. Instantiates a new :class:`.SocketClosePacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketClosePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -1176,8 +1212,8 @@ class SocketClosePacket(XBeeAPIPacket):
            | :class:`.XBeeAPIPacket`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255")
@@ -1197,20 +1233,25 @@ class SocketClosePacket(XBeeAPIPacket):
             :class:`.SocketClosePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 7. (start delim. + length (2 bytes) + frame
+            InvalidPacketException: if the bytearray length is less than 7.
+                (start delim. + length (2 bytes) + frame
                 type + frame id + socket id + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_CLOSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_CLOSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
         XBeeAPIPacket._check_api_packet(raw, min_length=SocketClosePacket.__MIN_PACKET_LENGTH)
@@ -1247,7 +1288,8 @@ class SocketClosePacket(XBeeAPIPacket):
         """
         return {DictKeys.SOCKET_ID.value: utils.hex_to_string(bytearray([self.__socket_id]))}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -1256,7 +1298,8 @@ class SocketClosePacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -1264,14 +1307,11 @@ class SocketClosePacket(XBeeAPIPacket):
             socket_id (Integer): the new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__socket_id = socket_id
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
 
 
 class SocketCloseResponsePacket(XBeeAPIPacket):
@@ -1295,7 +1335,8 @@ class SocketCloseResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, status):
         """
-        Class constructor. Instantiates a new :class:`.SocketCloseResponsePacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketCloseResponsePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -1307,8 +1348,8 @@ class SocketCloseResponsePacket(XBeeAPIPacket):
            | :class:`.SocketStatus`
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame ID must be between 0 and 255")
@@ -1329,28 +1370,36 @@ class SocketCloseResponsePacket(XBeeAPIPacket):
             :class:`.SocketCloseResponsePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 8. (start delim. + length (2 bytes) + frame
-                type + frame id + socket id + status + checksum = 8 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_CLOSE_RESPONSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 8.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket id + status + checksum = 8 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_CLOSE_RESPONSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketCloseResponsePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketCloseResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_CLOSE_RESPONSE.code:
-            raise InvalidPacketException(message="This packet is not a Socket Close Response packet.")
+            raise InvalidPacketException(
+                message="This packet is not a Socket Close Response packet.")
 
-        return SocketCloseResponsePacket(raw[4], raw[5], SocketStatus.get(raw[6]))
+        return SocketCloseResponsePacket(
+            raw[4], raw[5], SocketStatus.get(raw[6]))
 
     def needs_id(self):
         """
@@ -1383,7 +1432,8 @@ class SocketCloseResponsePacket(XBeeAPIPacket):
         return {DictKeys.SOCKET_ID.value: utils.hex_to_string(bytearray([self.__socket_id])),
                 DictKeys.STATUS.value:    "%s (%s)" % (self.__status.code, self.__status.description)}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the the socket ID.
 
@@ -1392,7 +1442,8 @@ class SocketCloseResponsePacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -1400,13 +1451,14 @@ class SocketCloseResponsePacket(XBeeAPIPacket):
             socket_id (Integer): the new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__socket_id = socket_id
 
-    def __get_status(self):
+    @property
+    def status(self):
         """
         Returns the socket close status.
 
@@ -1418,7 +1470,8 @@ class SocketCloseResponsePacket(XBeeAPIPacket):
         """
         return self.__status
 
-    def __set_status(self, status):
+    @status.setter
+    def status(self, status):
         """
         Sets the socket close status.
 
@@ -1429,12 +1482,6 @@ class SocketCloseResponsePacket(XBeeAPIPacket):
            | :class:`.SocketStatus`
         """
         self.__status = status
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    status = property(__get_status, __set_status)
-    """:class:`.SocketStatus`. Socket close status."""
 
 
 class SocketSendPacket(XBeeAPIPacket):
@@ -1460,8 +1507,8 @@ class SocketSendPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, payload=None):
         """
-        Class constructor. Instantiates a new :class:`.SocketSendPacket` object with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketSendPacket` object
+        with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -1469,8 +1516,8 @@ class SocketSendPacket(XBeeAPIPacket):
             payload (Bytearray, optional): data that is sent.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -1494,26 +1541,33 @@ class SocketSendPacket(XBeeAPIPacket):
             :class:`.SocketSendPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 7. (start delim. + length (2 bytes) + frame
-                type + frame id + socket ID + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_SEND`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 7.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket ID + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_SEND`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketSendPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketSendPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_SEND.code:
-            raise InvalidPacketException("This packet is not a Socket Send (transmit) packet.")
+            raise InvalidPacketException(
+                "This packet is not a Socket Send (transmit) packet.")
 
         return SocketSendPacket(raw[4], raw[5], raw[7:-1])
 
@@ -1552,7 +1606,8 @@ class SocketSendPacket(XBeeAPIPacket):
                 DictKeys.PAYLOAD.value:          utils.hex_to_string(self.__payload,
                                                                      True) if self.__payload is not None else None}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -1561,7 +1616,8 @@ class SocketSendPacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -1569,13 +1625,14 @@ class SocketSendPacket(XBeeAPIPacket):
             socket_id (Integer): The new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255.")
         self.__socket_id = socket_id
 
-    def __get_payload(self):
+    @property
+    def payload(self):
         """
         Returns the payload to send.
 
@@ -1586,7 +1643,8 @@ class SocketSendPacket(XBeeAPIPacket):
             return None
         return self.__payload.copy()
 
-    def __set_payload(self, payload):
+    @payload.setter
+    def payload(self, payload):
         """
         Sets the payload to send.
 
@@ -1597,12 +1655,6 @@ class SocketSendPacket(XBeeAPIPacket):
             self.__payload = None
         else:
             self.__payload = payload.copy()
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    payload = property(__get_payload, __set_payload)
-    """Bytearray. Payload to send."""
 
 
 class SocketSendToPacket(XBeeAPIPacket):
@@ -1627,8 +1679,8 @@ class SocketSendToPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, dest_address, dest_port, payload=None):
         """
-        Class constructor. Instantiates a new :class:`.SocketSendToPacket` object with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketSendToPacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -1638,9 +1690,9 @@ class SocketSendToPacket(XBeeAPIPacket):
             payload (Bytearray, optional): data that is sent.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
+            ValueError: if `dest_port` is less than 0 or greater than 65535.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -1668,27 +1720,35 @@ class SocketSendToPacket(XBeeAPIPacket):
             :class:`.SocketSendToPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 14. (start delim. + length (2 bytes) + frame
-                type + frame id + socket ID + dest address (4 bytes) + dest port (2 bytes) + transmit options +
-                checksum = 14 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_SENDTO`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 14.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket ID + dest address (4 bytes) + dest port (2 bytes)
+                + transmit options + checksum = 14 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_SENDTO`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketSendToPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketSendToPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_SENDTO.code:
-            raise InvalidPacketException("This packet is not a Socket SendTo (Transmit Explicit Data): IPv4 packet.")
+            raise InvalidPacketException(
+                "This packet is not a Socket SendTo (Transmit Explicit Data): "
+                "IPv4 packet.")
 
         return SocketSendToPacket(raw[4], raw[5], IPv4Address(bytes(raw[6:10])),
                                   utils.bytes_to_int(raw[10:12]), raw[13:-1])
@@ -1735,7 +1795,8 @@ class SocketSendToPacket(XBeeAPIPacket):
                 DictKeys.PAYLOAD.value:          utils.hex_to_string(self.__payload,
                                                                      True) if self.__payload is not None else None}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -1744,7 +1805,8 @@ class SocketSendToPacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -1752,13 +1814,14 @@ class SocketSendToPacket(XBeeAPIPacket):
             socket_id (Integer): The new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255.")
         self.__socket_id = socket_id
 
-    def __get_dest_address(self):
+    @property
+    def dest_address(self):
         """
         Returns the IPv4 address of the destination device.
 
@@ -1767,7 +1830,8 @@ class SocketSendToPacket(XBeeAPIPacket):
         """
         return self.__dest_address
 
-    def __set_dest_address(self, dest_address):
+    @dest_address.setter
+    def dest_address(self, dest_address):
         """
         Sets the IPv4 destination address.
 
@@ -1777,7 +1841,8 @@ class SocketSendToPacket(XBeeAPIPacket):
         if dest_address is not None:
             self.__dest_address = dest_address
 
-    def __get_dest_port(self):
+    @property
+    def dest_port(self):
         """
         Returns the destination port.
 
@@ -1786,7 +1851,8 @@ class SocketSendToPacket(XBeeAPIPacket):
         """
         return self.__dest_port
 
-    def __set_dest_port(self, dest_port):
+    @dest_port.setter
+    def dest_port(self, dest_port):
         """
         Sets the destination port.
 
@@ -1794,13 +1860,14 @@ class SocketSendToPacket(XBeeAPIPacket):
             dest_port (Integer): the new destination port.
 
         Raises:
-            ValueError: if ``dest_port`` is less than 0 or greater than 65535.
+            ValueError: if `dest_port` is less than 0 or greater than 65535.
         """
         if dest_port < 0 or dest_port > 65535:
             raise ValueError("Destination port must be between 0 and 65535")
         self.__dest_port = dest_port
 
-    def __get_payload(self):
+    @property
+    def payload(self):
         """
         Returns the payload to send.
 
@@ -1811,7 +1878,8 @@ class SocketSendToPacket(XBeeAPIPacket):
             return None
         return self.__payload.copy()
 
-    def __set_payload(self, payload):
+    @payload.setter
+    def payload(self, payload):
         """
         Sets the payload to send.
 
@@ -1822,18 +1890,6 @@ class SocketSendToPacket(XBeeAPIPacket):
             self.__payload = None
         else:
             self.__payload = payload.copy()
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    dest_address = property(__get_dest_address, __set_dest_address)
-    """:class:`ipaddress.IPv4Address`. IPv4 address of the destination device."""
-
-    dest_port = property(__get_dest_port, __set_dest_port)
-    """Integer. Destination port."""
-
-    payload = property(__get_payload, __set_payload)
-    """Bytearray. Payload to send."""
 
 
 class SocketBindListenPacket(XBeeAPIPacket):
@@ -1862,8 +1918,8 @@ class SocketBindListenPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, source_port):
         """
-        Class constructor. Instantiates a new :class:`.SocketBindListenPacket` object with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketBindListenPacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -1871,9 +1927,9 @@ class SocketBindListenPacket(XBeeAPIPacket):
             source_port (Integer): the port to listen on.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
+            ValueError: if `source_port` is less than 0 or greater than 65535.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -1899,28 +1955,36 @@ class SocketBindListenPacket(XBeeAPIPacket):
             :class:`.SocketBindListenPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 9. (start delim. + length (2 bytes) + frame
-                type + frame id + socket ID + source port (2 bytes) + checksum = 9 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_BIND`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 9.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket ID + source port (2 bytes) + checksum = 9 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_BIND`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketBindListenPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketBindListenPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_BIND.code:
-            raise InvalidPacketException("This packet is not a Socket Bind/Listen packet.")
+            raise InvalidPacketException(
+                "This packet is not a Socket Bind/Listen packet.")
 
-        return SocketBindListenPacket(raw[4], raw[5], utils.bytes_to_int(raw[6:8]))
+        return SocketBindListenPacket(
+            raw[4], raw[5], utils.bytes_to_int(raw[6:8]))
 
     def needs_id(self):
         """
@@ -1955,7 +2019,8 @@ class SocketBindListenPacket(XBeeAPIPacket):
                                                                                               num_bytes=2)),
                                                        self.__source_port)}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -1964,7 +2029,8 @@ class SocketBindListenPacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -1972,13 +2038,14 @@ class SocketBindListenPacket(XBeeAPIPacket):
             socket_id (Integer): The new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255.")
         self.__socket_id = socket_id
 
-    def __get_source_port(self):
+    @property
+    def source_port(self):
         """
         Returns the source port.
 
@@ -1987,7 +2054,8 @@ class SocketBindListenPacket(XBeeAPIPacket):
         """
         return self.__source_port
 
-    def __set_source_port(self, source_port):
+    @source_port.setter
+    def source_port(self, source_port):
         """
         Sets the source port.
 
@@ -1995,17 +2063,11 @@ class SocketBindListenPacket(XBeeAPIPacket):
             source_port (Integer): the new source port.
 
         Raises:
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
+            ValueError: if `source_port` is less than 0 or greater than 65535.
         """
         if source_port < 0 or source_port > 65535:
             raise ValueError("Source port must be between 0 and 65535")
         self.__source_port = source_port
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    source_port = property(__get_source_port, __set_source_port)
-    """Integer. Source port."""
 
 
 class SocketListenResponsePacket(XBeeAPIPacket):
@@ -2025,8 +2087,8 @@ class SocketListenResponsePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, status):
         """
-        Class constructor. Instantiates a new :class:`.SocketListenResponsePacket` object with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketListenResponsePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -2034,8 +2096,8 @@ class SocketListenResponsePacket(XBeeAPIPacket):
             status (:class:`.SocketStatus`): socket listen status.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -2060,28 +2122,36 @@ class SocketListenResponsePacket(XBeeAPIPacket):
             :class:`.SocketListenResponsePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 8. (start delim. + length (2 bytes) + frame
-                type + frame id + socket ID + status + checksum = 8 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_LISTEN_RESPONSE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 8.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket ID + status + checksum = 8 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_LISTEN_RESPONSE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketListenResponsePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketListenResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_LISTEN_RESPONSE.code:
-            raise InvalidPacketException("This packet is not a Socket Listen Response packet.")
+            raise InvalidPacketException(
+                "This packet is not a Socket Listen Response packet.")
 
-        return SocketListenResponsePacket(raw[4], raw[5], SocketStatus.get(raw[6]))
+        return SocketListenResponsePacket(
+            raw[4], raw[5], SocketStatus.get(raw[6]))
 
     def needs_id(self):
         """
@@ -2115,7 +2185,8 @@ class SocketListenResponsePacket(XBeeAPIPacket):
                 DictKeys.STATUS.value:    "%s (%s)" % (utils.hex_to_string(bytearray([self.__status.code])),
                                                        self.__status.description)}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -2124,7 +2195,8 @@ class SocketListenResponsePacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -2132,13 +2204,14 @@ class SocketListenResponsePacket(XBeeAPIPacket):
             socket_id (Integer): The new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255.")
         self.__socket_id = socket_id
 
-    def __get_status(self):
+    @property
+    def status(self):
         """
         Returns the socket listen status.
 
@@ -2150,7 +2223,8 @@ class SocketListenResponsePacket(XBeeAPIPacket):
         """
         return self.__status
 
-    def __set_status(self, status):
+    @status.setter
+    def status(self, status):
         """
         Sets the socket listen status.
 
@@ -2161,12 +2235,6 @@ class SocketListenResponsePacket(XBeeAPIPacket):
            | :class:`.SocketStatus`
         """
         self.__status = status
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    status = property(__get_status, __set_status)
-    """:class:`.SocketStatus`. Socket listen status."""
 
 
 class SocketNewIPv4ClientPacket(XBeeAPIPacket):
@@ -2189,8 +2257,8 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
 
     def __init__(self, socket_id, client_socket_id, remote_address, remote_port):
         """
-        Class constructor. Instantiates a new :class:`.SocketNewIPv4ClientPacket` object with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketNewIPv4ClientPacket`
+        object with the provided parameters.
 
         Args:
             socket_id (Integer): the socket ID of the listener socket.
@@ -2199,9 +2267,9 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
             remote_port (Integer): the remote port number.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
-            ValueError: if ``client_socket_id`` is less than 0 or greater than 255.
-            ValueError: if ``remote_port`` is less than 0 or greater than 65535.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
+            ValueError: if `client_socket_id` is less than 0 or greater than 255.
+            ValueError: if `remote_port` is less than 0 or greater than 65535.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -2228,29 +2296,37 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
             :class:`.SocketNewIPv4ClientPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 13. (start delim. + length (2 bytes) + frame
-                type + socket ID + client socket ID + remote address (4 bytes) + remote port (2 bytes)
-                + checksum = 13 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_NEW_IPV4_CLIENT`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 13.
+                (start delim. + length (2 bytes) + frame type + socket ID
+                + client socket ID + remote address (4 bytes)
+                + remote port (2 bytes) + checksum = 13 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_NEW_IPV4_CLIENT`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketNewIPv4ClientPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketNewIPv4ClientPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_NEW_IPV4_CLIENT.code:
-            raise InvalidPacketException("This packet is not a Socket New IPv4 Client packet.")
+            raise InvalidPacketException(
+                "This packet is not a Socket New IPv4 Client packet.")
 
-        return SocketNewIPv4ClientPacket(raw[4], raw[5], IPv4Address(bytes(raw[6:10])),
+        return SocketNewIPv4ClientPacket(raw[4], raw[5],
+                                         IPv4Address(bytes(raw[6:10])),
                                          utils.bytes_to_int(raw[10:12]))
 
     def needs_id(self):
@@ -2291,7 +2367,8 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
                                                                                                      num_bytes=2)),
                                                               self.__remote_port)}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -2300,7 +2377,8 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -2308,13 +2386,14 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
             socket_id (Integer): The new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__socket_id = socket_id
 
-    def __get_client_socket_id(self):
+    @property
+    def client_socket_id(self):
         """
         Returns the client socket ID.
 
@@ -2323,7 +2402,8 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
         """
         return self.__client_socket_id
 
-    def __set_client_socket_id(self, client_socket_id):
+    @client_socket_id.setter
+    def client_socket_id(self, client_socket_id):
         """
         Sets the client socket ID.
 
@@ -2331,13 +2411,14 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
             client_socket_id (Integer): The new client socket ID.
 
         Raises:
-            ValueError: if ``client_socket_id`` is less than 0 or greater than 255.
+            ValueError: if `client_socket_id` is less than 0 or greater than 255.
         """
         if client_socket_id < 0 or client_socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255")
         self.__client_socket_id = client_socket_id
 
-    def __get_remote_address(self):
+    @property
+    def remote_address(self):
         """
         Returns the remote IPv4 address.
 
@@ -2346,7 +2427,8 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
         """
         return self.__remote_address
 
-    def __set_remote_address(self, remote_address):
+    @remote_address.setter
+    def remote_address(self, remote_address):
         """
         Sets the remote IPv4 address.
 
@@ -2356,7 +2438,8 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
         if remote_address is not None:
             self.__remote_address = remote_address
 
-    def __get_remote_port(self):
+    @property
+    def remote_port(self):
         """
         Returns the remote port.
 
@@ -2365,7 +2448,8 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
         """
         return self.__remote_port
 
-    def __set_remote_port(self, remote_port):
+    @remote_port.setter
+    def remote_port(self, remote_port):
         """
         Sets the remote port.
 
@@ -2373,23 +2457,11 @@ class SocketNewIPv4ClientPacket(XBeeAPIPacket):
             remote_port (Integer): the new remote port.
 
         Raises:
-            ValueError: if ``remote_port`` is less than 0 or greater than 65535.
+            ValueError: if `remote_port` is less than 0 or greater than 65535.
         """
         if remote_port < 0 or remote_port > 65535:
             raise ValueError("Remote port must be between 0 and 65535")
         self.__remote_port = remote_port
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    client_socket_id = property(__get_client_socket_id, __set_client_socket_id)
-    """Integer. Client socket ID."""
-
-    remote_address = property(__get_remote_address, __set_remote_address)
-    """:class:`ipaddress.IPv4Address`. Remote IPv4 address."""
-
-    remote_port = property(__get_remote_port, __set_remote_port)
-    """Integer. Remote port."""
 
 
 class SocketReceivePacket(XBeeAPIPacket):
@@ -2408,8 +2480,8 @@ class SocketReceivePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, payload=None):
         """
-        Class constructor. Instantiates a new :class:`.SocketReceivePacket` object with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketReceivePacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -2417,8 +2489,8 @@ class SocketReceivePacket(XBeeAPIPacket):
             payload (Bytearray, optional): data that is received.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -2442,26 +2514,33 @@ class SocketReceivePacket(XBeeAPIPacket):
             :class:`.SocketReceivePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 7. (start delim. + length (2 bytes) + frame
-                type + frame id + socket ID + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_RECEIVE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 7.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket ID + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_RECEIVE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketReceivePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketReceivePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_RECEIVE.code:
-            raise InvalidPacketException("This packet is not a Socket Receive packet.")
+            raise InvalidPacketException(
+                "This packet is not a Socket Receive packet.")
 
         return SocketReceivePacket(raw[4], raw[5], raw[7:-1])
 
@@ -2499,7 +2578,8 @@ class SocketReceivePacket(XBeeAPIPacket):
                 DictKeys.STATUS.value:    utils.hex_to_string(bytearray([0])),
                 DictKeys.PAYLOAD.value:   utils.hex_to_string(self.__payload) if self.__payload is not None else None}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -2508,7 +2588,8 @@ class SocketReceivePacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -2516,13 +2597,14 @@ class SocketReceivePacket(XBeeAPIPacket):
             socket_id (Integer): The new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255.")
         self.__socket_id = socket_id
 
-    def __get_payload(self):
+    @property
+    def payload(self):
         """
         Returns the payload that was received.
 
@@ -2533,7 +2615,8 @@ class SocketReceivePacket(XBeeAPIPacket):
             return None
         return self.__payload.copy()
 
-    def __set_payload(self, payload):
+    @payload.setter
+    def payload(self, payload):
         """
         Sets the payload that was received.
 
@@ -2544,12 +2627,6 @@ class SocketReceivePacket(XBeeAPIPacket):
             self.__payload = None
         else:
             self.__payload = payload.copy()
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    payload = property(__get_payload, __set_payload)
-    """Bytearray. Payload that was received."""
 
 
 class SocketReceiveFromPacket(XBeeAPIPacket):
@@ -2569,8 +2646,8 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, socket_id, source_address, source_port, payload=None):
         """
-        Class constructor. Instantiates a new :class:`.SocketReceiveFromPacket` object with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketReceiveFromPacket`
+        object with the provided parameters.
 
         Args:
             frame_id (Integer): the frame ID of the packet.
@@ -2580,9 +2657,9 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
             payload (Bytearray, optional): data that is received.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
+            ValueError: if `source_port` is less than 0 or greater than 65535.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -2610,30 +2687,38 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
             :class:`.SocketReceiveFromPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 13. (start delim. + length (2 bytes) + frame
-                type + frame id + socket ID + source address (4 bytes) + source port (2 bytes) + status +
-                checksum = 14 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_RECEIVE_FROM`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 13.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + socket ID + source address (4 bytes) + source port (2 bytes)
+                + status + Checksum = 14 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_RECEIVE_FROM`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketReceiveFromPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketReceiveFromPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_RECEIVE_FROM.code:
-            raise InvalidPacketException("This packet is not a Socket Receive From packet.")
+            raise InvalidPacketException(
+                "This packet is not a Socket Receive From packet.")
 
-        return SocketReceiveFromPacket(raw[4], raw[5], IPv4Address(bytes(raw[6:10])),
-                                       utils.bytes_to_int(raw[10:12]), raw[13:-1])
+        return SocketReceiveFromPacket(
+            raw[4], raw[5], IPv4Address(bytes(raw[6:10])),
+            utils.bytes_to_int(raw[10:12]), raw[13:-1])
 
     def needs_id(self):
         """
@@ -2677,7 +2762,8 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
                 DictKeys.PAYLOAD.value:       utils.hex_to_string(self.__payload,
                                                                   True) if self.__payload is not None else None}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -2686,7 +2772,8 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -2694,13 +2781,14 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
             socket_id (Integer): The new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255.")
         self.__socket_id = socket_id
 
-    def __get_source_address(self):
+    @property
+    def source_address(self):
         """
         Returns the IPv4 address of the source device.
 
@@ -2709,7 +2797,8 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
         """
         return self.__source_address
 
-    def __set_source_address(self, source_address):
+    @source_address.setter
+    def source_address(self, source_address):
         """
         Sets the IPv4 source address.
 
@@ -2719,7 +2808,8 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
         if source_address is not None:
             self.__source_address = source_address
 
-    def __get_source_port(self):
+    @property
+    def source_port(self):
         """
         Returns the source port.
 
@@ -2728,7 +2818,8 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
         """
         return self.__source_port
 
-    def __set_source_port(self, source_port):
+    @source_port.setter
+    def source_port(self, source_port):
         """
         Sets the destination port.
 
@@ -2736,13 +2827,14 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
             source_port (Integer): the new source port.
 
         Raises:
-            ValueError: if ``source_port`` is less than 0 or greater than 65535.
+            ValueError: if `source_port` is less than 0 or greater than 65535.
         """
         if source_port < 0 or source_port > 65535:
             raise ValueError("Source port must be between 0 and 65535")
         self.__source_port = source_port
 
-    def __get_payload(self):
+    @property
+    def payload(self):
         """
         Returns the payload to send.
 
@@ -2753,7 +2845,8 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
             return None
         return self.__payload.copy()
 
-    def __set_payload(self, payload):
+    @payload.setter
+    def payload(self, payload):
         """
         Sets the payload to send.
 
@@ -2764,18 +2857,6 @@ class SocketReceiveFromPacket(XBeeAPIPacket):
             self.__payload = None
         else:
             self.__payload = payload.copy()
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    source_address = property(__get_source_address, __set_source_address)
-    """:class:`ipaddress.IPv4Address`. IPv4 address of the source device."""
-
-    source_port = property(__get_source_port, __set_source_port)
-    """Integer. Source port."""
-
-    payload = property(__get_payload, __set_payload)
-    """Bytearray. Payload that has been received."""
 
 
 class SocketStatePacket(XBeeAPIPacket):
@@ -2794,15 +2875,15 @@ class SocketStatePacket(XBeeAPIPacket):
 
     def __init__(self, socket_id, state):
         """
-        Class constructor. Instantiates a new :class:`.SocketStatePacket` object with the
-        provided parameters.
+        Class constructor. Instantiates a new :class:`.SocketStatePacket`
+        object with the provided parameters.
 
         Args:
             socket_id (Integer): the socket identifier.
             state (:class:`.SocketState`): socket status.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.SockeState`
@@ -2824,26 +2905,33 @@ class SocketStatePacket(XBeeAPIPacket):
             :class:`.SocketStatePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 7. (start delim. + length (2 bytes) + frame
-                type + socket ID + state + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.SOCKET_STATUS`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 7.
+                (start delim. + length (2 bytes) + frame type + socket ID
+                 + state + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.SOCKET_STATUS`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=SocketStatePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=SocketStatePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SOCKET_STATE.code:
-            raise InvalidPacketException("This packet is not a Socket State packet.")
+            raise InvalidPacketException(
+                "This packet is not a Socket State packet.")
 
         return SocketStatePacket(raw[4], SocketState.get(raw[5]))
 
@@ -2879,7 +2967,8 @@ class SocketStatePacket(XBeeAPIPacket):
                 DictKeys.STATUS.value:    "%s (%s)" % (utils.hex_to_string(bytearray([self.__state.code])),
                                                        self.__state.description)}
 
-    def __get_socket_id(self):
+    @property
+    def socket_id(self):
         """
         Returns the socket ID.
 
@@ -2888,7 +2977,8 @@ class SocketStatePacket(XBeeAPIPacket):
         """
         return self.__socket_id
 
-    def __set_socket_id(self, socket_id):
+    @socket_id.setter
+    def socket_id(self, socket_id):
         """
         Sets the socket ID.
 
@@ -2896,13 +2986,14 @@ class SocketStatePacket(XBeeAPIPacket):
             socket_id (Integer): The new socket ID.
 
         Raises:
-            ValueError: if ``socket_id`` is less than 0 or greater than 255.
+            ValueError: if `socket_id` is less than 0 or greater than 255.
         """
         if socket_id < 0 or socket_id > 255:
             raise ValueError("Socket ID must be between 0 and 255.")
         self.__socket_id = socket_id
 
-    def __get_state(self):
+    @property
+    def state(self):
         """
         Returns the socket state.
 
@@ -2914,7 +3005,8 @@ class SocketStatePacket(XBeeAPIPacket):
         """
         return self.__state
 
-    def __set_state(self, status):
+    @state.setter
+    def state(self, status):
         """
         Sets the socket state.
 
@@ -2925,9 +3017,3 @@ class SocketStatePacket(XBeeAPIPacket):
            | :class:`.SocketState`
         """
         self.__state = status
-
-    socket_id = property(__get_socket_id, __set_socket_id)
-    """Integer. Socket ID."""
-
-    state = property(__get_state, __set_state)
-    """:class:`.SocketState`. Socket state."""

--- a/digi/xbee/packets/wifi.py
+++ b/digi/xbee/packets/wifi.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,21 +11,21 @@
 # WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+from ipaddress import IPv4Address
 
 from digi.xbee.packets.base import XBeeAPIPacket, DictKeys
 from digi.xbee.util import utils
 from digi.xbee.exception import InvalidOperatingModeException, InvalidPacketException
 from digi.xbee.packets.aft import ApiFrameType
 from digi.xbee.models.mode import OperatingMode
-from digi.xbee.io import IOSample, IOLine
-from ipaddress import IPv4Address
 from digi.xbee.models.status import ATCommandStatus
+from digi.xbee.io import IOSample, IOLine
 
 
 class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
     """
-    This class represents a IO data sample RX indicator (Wi-Fi) packet. Packet is
-    built using the parameters of the constructor or providing a valid API
+    This class represents a IO data sample RX indicator (Wi-Fi) packet. Packet
+    is built using the parameters of the constructor or providing a valid API
     payload.
 
     When the module receives an IO sample frame from a remote device, it sends
@@ -43,7 +43,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
 
     def __init__(self, source_address, rssi, receive_options, rf_data=None):
         """
-        Class constructor. Instantiates a new :class:`.IODataSampleRxIndicatorWifiPacket` object with the
+        Class constructor. Instantiates a new
+        :class:`.IODataSampleRxIndicatorWifiPacket` object with the
         provided parameters.
 
         Args:
@@ -53,7 +54,7 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
             rf_data (Bytearray, optional): received RF data. Optional.
 
         Raises:
-            ValueError: if ``rf_data`` is not ``None`` and it's not valid for create an :class:`.IOSample`.
+            ValueError: if `rf_data` is not `None` and it's not valid for create an :class:`.IOSample`.
 
         .. seealso::
            | :class:`.IOSample`
@@ -77,28 +78,37 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
             :class:`.IODataSampleRxIndicatorWifiPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 16. (start delim. + length (2 bytes) + frame
-                type + source addr. (4 bytes) + rssi + receive options + rf data (5 bytes) + checksum = 16 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR_WIFI`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 16.
+                (start delim. + length (2 bytes) + frame type
+                + source addr. (4 bytes) + rssi + receive options
+                + rf data (5 bytes) + checksum = 16 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR_WIFI`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorWifiPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=IODataSampleRxIndicatorWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR_WIFI.code:
-            raise InvalidPacketException(message="This packet is not an IO data sample RX indicator Wi-Fi packet.")
+            raise InvalidPacketException(
+                message="This packet is not an IO data sample RX indicator Wi-Fi packet.")
 
-        return IODataSampleRxIndicatorWifiPacket(IPv4Address(bytes(raw[4:8])), raw[7], raw[8], rf_data=raw[9:-1])
+        return IODataSampleRxIndicatorWifiPacket(
+            IPv4Address(bytes(raw[4:8])), raw[7], raw[8], rf_data=raw[9:-1])
 
     def needs_id(self):
         """
@@ -160,7 +170,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
 
         return base
 
-    def __get_source_address(self):
+    @property
+    def source_address(self):
         """
         Returns the IPv4 address of the source device.
 
@@ -172,7 +183,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         """
         return self.__source_address
 
-    def __set_source_address(self, source_address):
+    @source_address.setter
+    def source_address(self, source_address):
         """
         Sets the IPv4 source address.
 
@@ -185,7 +197,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         if source_address is not None:
             self.__source_address = source_address
 
-    def __get_rssi(self):
+    @property
+    def rssi(self):
         """
         Returns the received Signal Strength Indicator (RSSI).
 
@@ -194,7 +207,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         """
         return self.__rssi
 
-    def __set_rssi(self, rssi):
+    @rssi.setter
+    def rssi(self, rssi):
         """
         Sets the received Signal Strength Indicator (RSSI).
 
@@ -203,7 +217,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         """
         self.__rssi = rssi
 
-    def __get_options(self):
+    @property
+    def receive_options(self):
         """
         Returns the receive options bitfield.
 
@@ -215,7 +230,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         """
         return self.__receive_options
 
-    def __set_options(self, receive_options):
+    @receive_options.setter
+    def receive_options(self, receive_options):
         """
         Sets the receive options bitfield.
 
@@ -227,7 +243,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         """
         self.__receive_options = receive_options
 
-    def __get_rf_data(self):
+    @property
+    def rf_data(self):
         """
         Returns the received RF data.
 
@@ -238,7 +255,8 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
             return None
         return self.__rf_data.copy()
 
-    def __set_rf_data(self, rf_data):
+    @rf_data.setter
+    def rf_data(self, rf_data):
         """
         Sets the received RF data.
 
@@ -256,20 +274,23 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         else:
             self.__io_sample = None
 
-    def __get_io_sample(self):
+    @property
+    def io_sample(self):
         """
         Returns the IO sample corresponding to the data contained in the packet.
 
         Returns:
-            :class:`.IOSample`: the IO sample of the packet, ``None`` if the packet has not any data or if the
-                sample could not be generated correctly.
+            :class:`.IOSample`: the IO sample of the packet, `None` if the
+                packet has not any data or if the sample could not be
+                generated correctly.
 
         .. seealso::
            | :class:`.IOSample`
         """
         return self.__io_sample
 
-    def __set_io_sample(self, io_sample):
+    @io_sample.setter
+    def io_sample(self, io_sample):
         """
         Sets the IO sample of the packet.
 
@@ -281,21 +302,6 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         """
         self.__io_sample = io_sample
 
-    source_address = property(__get_source_address, __set_source_address)
-    """:class:`ipaddress.IPv4Address`. IPv4 source address."""
-
-    rssi = property(__get_rssi, __set_rssi)
-    """Integer. Received Signal Strength Indicator (RSSI) value."""
-
-    receive_options = property(__get_options, __set_options)
-    """Integer. Receive options bitfield."""
-
-    rf_data = property(__get_rf_data, __set_rf_data)
-    """Bytearray. Received RF data."""
-
-    io_sample = property(__get_io_sample, __set_io_sample)
-    """:class:`.IOSample`: IO sample corresponding to the data contained in the packet."""
-
 
 class RemoteATCommandWifiPacket(XBeeAPIPacket):
     """
@@ -305,7 +311,7 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
 
     Used to query or set module parameters on a remote device. For parameter
     changes on the remote device to take effect, changes must be applied, either
-    by setting the apply changes options bit, or by sending an ``AC`` command
+    by setting the apply changes options bit, or by sending an `AC` command
     to the remote node.
 
     Remote command options are set as a bitfield.
@@ -321,7 +327,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, dest_address, transmit_options, command, parameter=None):
         """
-        Class constructor. Instantiates a new :class:`.RemoteATCommandWifiPacket` object with the provided parameters.
+        Class constructor. Instantiates a new :class:`.RemoteATCommandWifiPacket`
+        object with the provided parameters.
 
         Args:
             frame_id (integer): the frame ID of the packet.
@@ -331,8 +338,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
             parameter (Bytearray, optional): AT command parameter. Optional.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if length of `command` is different than 2.
 
         .. seealso::
            | :class:`ipaddress.IPv4Address`
@@ -360,34 +367,38 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
             :class:`.RemoteATCommandWifiPacket`
 
         Raises:
-            InvalidPacketException: if the Bytearray length is less than 17. (start delim. + length (2 bytes) + frame
-                type + frame id + dest. addr. (8 bytes) + transmit options + command (2  bytes) + checksum = 17 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.REMOTE_AT_COMMAND_REQUEST_WIFI`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the Bytearray length is less than 17.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + dest. addr. (8 bytes) + transmit options
+                + command (2  bytes) + checksum = 17 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.REMOTE_AT_COMMAND_REQUEST_WIFI`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandWifiPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=RemoteATCommandWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_REQUEST_WIFI.code:
-            raise InvalidPacketException(message="This packet is not a remote AT command request Wi-Fi packet.")
+            raise InvalidPacketException(
+                message="This packet is not a remote AT command request Wi-Fi packet.")
 
-        return RemoteATCommandWifiPacket(
-            raw[4],
-            IPv4Address(bytes(raw[9:13])),
-            raw[13],
-            raw[14:16].decode("utf8"),
-            parameter=raw[16:-1]
-        )
+        return RemoteATCommandWifiPacket(raw[4], IPv4Address(bytes(raw[9:13])),
+                                         raw[13], raw[14:16].decode("utf8"),
+                                         parameter=raw[16:-1])
 
     def needs_id(self):
         """
@@ -424,7 +435,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
                 DictKeys.COMMAND:          self.__command,
                 DictKeys.PARAMETER:        list(self.__parameter) if self.__parameter is not None else None}
 
-    def __get_dest_address(self):
+    @property
+    def dest_address(self):
         """
         Returns the IPv4 address of the destination device.
 
@@ -436,7 +448,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         """
         return self.__dest_address
 
-    def __set_dest_address(self, dest_address):
+    @dest_address.setter
+    def dest_address(self, dest_address):
         """
         Sets the IPv4 destination address.
 
@@ -449,7 +462,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         if dest_address is not None:
             self.__dest_address = dest_address
 
-    def __get_transmit_options(self):
+    @property
+    def transmit_options(self):
         """
         Returns the transmit options bitfield.
 
@@ -461,7 +475,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         """
         return self.__transmit_options
 
-    def __set_transmit_options(self, transmit_options):
+    @transmit_options.setter
+    def transmit_options(self, transmit_options):
         """
         Sets the transmit options bitfield.
 
@@ -473,7 +488,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         """
         self.__transmit_options = transmit_options
 
-    def __get_command(self):
+    @property
+    def command(self):
         """
         Returns the AT command.
 
@@ -482,7 +498,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         """
         return self.__command
 
-    def __set_command(self, command):
+    @command.setter
+    def command(self, command):
         """
         Sets the AT command.
 
@@ -491,7 +508,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         """
         self.__command = command
 
-    def __get_parameter(self):
+    @property
+    def parameter(self):
         """
         Returns the AT command parameter.
 
@@ -500,7 +518,8 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         """
         return self.__parameter
 
-    def __set_parameter(self, parameter):
+    @parameter.setter
+    def parameter(self, parameter):
         """
         Sets the AT command parameter.
 
@@ -509,29 +528,17 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         """
         self.__parameter = parameter
 
-    dest_address = property(__get_dest_address, __set_dest_address)
-    """:class:`ipaddress.IPv4Address`. IPv4 destination address."""
-
-    transmit_options = property(__get_transmit_options, __set_transmit_options)
-    """Integer. Transmit options bitfield."""
-
-    command = property(__get_command, __set_command)
-    """String. AT command."""
-
-    parameter = property(__get_parameter, __set_parameter)
-    """Bytearray. AT command parameter."""
-
 
 class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
     """
-    This class represents a remote AT command response (Wi-Fi) packet. Packet is
-    built using the parameters of the constructor or providing a valid API
+    This class represents a remote AT command response (Wi-Fi) packet. Packet
+    is built using the parameters of the constructor or providing a valid API
     payload.
 
     If a module receives a remote command response RF data frame in response
     to a Remote AT Command Request, the module will send a Remote AT Command
     Response message out the UART. Some commands may send back multiple frames
-    for example, Node Discover (``ND``) command.
+    for example, Node Discover (`ND`) command.
 
     This packet is received in response of a :class:`.RemoteATCommandPacket`.
 
@@ -548,7 +555,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, source_address, command, response_status, comm_value=None):
         """
-        Class constructor. Instantiates a new :class:`.RemoteATCommandResponseWifiPacket` object with the
+        Class constructor. Instantiates a new
+        :class:`.RemoteATCommandResponseWifiPacket` object with the
         provided parameters.
 
         Args:
@@ -559,8 +567,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
             comm_value (Bytearray, optional): the AT command response value.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
+            ValueError: if length of `command` is different than 2.
 
         .. seealso::
            | :class:`.ATCommandStatus`
@@ -587,32 +595,38 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
             :class:`.RemoteATCommandResponseWifiPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 17. (start delim. + length (2 bytes) + frame
-                type + frame id + source addr. (8 bytes) +  command (2 bytes) + receive options + checksum = 17 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.REMOTE_AT_COMMAND_RESPONSE_WIFI`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 17.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + source addr. (8 bytes) +  command (2 bytes) + receive options
+                + checksum = 17 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.REMOTE_AT_COMMAND_RESPONSE_WIFI`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponseWifiPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=RemoteATCommandResponseWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_RESPONSE_WIFI.code:
-            raise InvalidPacketException(message="This packet is not a remote AT command response Wi-Fi packet.")
+            raise InvalidPacketException(
+                message="This packet is not a remote AT command response Wi-Fi packet.")
 
-        return RemoteATCommandResponseWifiPacket(raw[4],
-                                                 IPv4Address(bytes(raw[9:13])),
-                                                 raw[13:15].decode("utf8"),
-                                                 ATCommandStatus.get(raw[15]),
-                                                 comm_value=raw[16:-1])
+        return RemoteATCommandResponseWifiPacket(
+            raw[4], IPv4Address(bytes(raw[9:13])), raw[13:15].decode("utf8"),
+            ATCommandStatus.get(raw[15]), comm_value=raw[16:-1])
 
     def needs_id(self):
         """
@@ -643,7 +657,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
                 DictKeys.AT_CMD_STATUS: self.__response_status,
                 DictKeys.RF_DATA:       list(self.__comm_value) if self.__comm_value is not None else None}
 
-    def __get_source_address(self):
+    @property
+    def source_address(self):
         """
         Returns the IPv4 address of the source device.
 
@@ -655,7 +670,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
         """
         return self.__source_address
 
-    def __set_source_address(self, source_address):
+    @source_address.setter
+    def source_address(self, source_address):
         """
         Sets the IPv4 source address.
 
@@ -668,7 +684,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
         if source_address is not None:
             self.__source_address = source_address
 
-    def __get_command(self):
+    @property
+    def command(self):
         """
         Returns the AT command of the packet.
 
@@ -677,7 +694,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
         """
         return self.__command
 
-    def __set_command(self, command):
+    @command.setter
+    def command(self, command):
         """
         Sets the AT command of the packet.
 
@@ -685,13 +703,14 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
             command (String): the new AT command of the packet. Must have length = 2.
 
         Raises:
-            ValueError: if length of ``command`` is different than 2.
+            ValueError: if length of `command` is different than 2.
         """
         if len(command) != 2:
             raise ValueError("Invalid command " + command)
         self.__command = command
 
-    def __get_response_status(self):
+    @property
+    def status(self):
         """
         Returns the AT command response status of the packet.
 
@@ -703,7 +722,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
         """
         return self.__response_status
 
-    def __set_response_status(self, response_status):
+    @status.setter
+    def status(self, response_status):
         """
         Sets the AT command response status of the packet
 
@@ -715,7 +735,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
         """
         self.__response_status = response_status
 
-    def __get_value(self):
+    @property
+    def command_value(self):
         """
         Returns the AT command response value.
 
@@ -724,7 +745,8 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
         """
         return self.__comm_value
 
-    def __set_value(self, comm_value):
+    @command_value.setter
+    def command_value(self, comm_value):
         """
         Sets the AT command response value.
 
@@ -732,15 +754,3 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
             comm_value (Bytearray): the new AT command response value.
         """
         self.__comm_value = comm_value
-
-    source_address = property(__get_source_address, __set_source_address)
-    """:class:`ipaddress.IPv4Address`. IPv4 source address."""
-
-    command = property(__get_command, __set_command)
-    """String. AT command."""
-
-    status = property(__get_response_status, __set_response_status)
-    """:class:`.ATCommandStatus`. AT command response status."""
-
-    command_value = property(__get_value, __set_value)
-    """Bytearray. AT command value."""

--- a/digi/xbee/packets/zigbee.py
+++ b/digi/xbee/packets/zigbee.py
@@ -51,18 +51,22 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, registrant_address, options, key):
         """
-        Class constructor. Instantiates a new :class:`.RegisterJoiningDevicePacket` object with the
+        Class constructor. Instantiates a new
+        :class:`.RegisterJoiningDevicePacket` object with the
         provided parameters.
 
         Args:
             frame_id (integer): the frame ID of the packet.
-            registrant_address (:class:`.XBee64BitAddress`): the 64-bit address of the destination device.
-            options (:class:`.RegisterKeyOptions`): the register options indicating the key source.
-            key (Bytearray): key of the device to register. Up to 16 bytes if entering a Link Key or up to
-                18 bytes (16-byte code + 2 byte CRC) if entering an Install Code.
+            registrant_address (:class:`.XBee64BitAddress`): the 64-bit address
+                of the destination device.
+            options (:class:`.RegisterKeyOptions`): the register options
+                indicating the key source.
+            key (Bytearray): key of the device to register. Up to 16 bytes if
+                entering a Link Key or up to 18 bytes
+                (16-byte code + 2 byte CRC) if entering an Install Code.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.XBee64BitAddress`
@@ -87,30 +91,38 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
             :class:`.RegisterJoiningDevicePacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 17. (start delim. + length (2 bytes) + frame
-                type + frame id + 64-bit registrant addr. (8 bytes) + 16-bit registrant addr. (2 bytes) + options
+            InvalidPacketException: if the bytearray length is less than 17.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + 64-bit registrant addr. (8 bytes)
+                + 16-bit registrant addr. (2 bytes) + options
                 + checksum = 17 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                2 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.REGISTER_JOINING_DEVICE`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.REGISTER_JOINING_DEVICE`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
+            raise InvalidOperatingModeException(
+                operating_mode.name + " is not supported.")
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=RegisterJoiningDevicePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=RegisterJoiningDevicePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REGISTER_JOINING_DEVICE.code:
-            raise InvalidPacketException("This packet is not a Register Joining Device packet.")
+            raise InvalidPacketException(
+                "This packet is not a Register Joining Device packet.")
 
-        return RegisterJoiningDevicePacket(raw[4],
-                                           XBee64BitAddress(raw[5:13]),
+        return RegisterJoiningDevicePacket(raw[4], XBee64BitAddress(raw[5:13]),
                                            RegisterKeyOptions.get(raw[15]),
                                            raw[16:-1])
 
@@ -151,7 +163,8 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
                                                    self.__options.description),
                 DictKeys.KEY:         list(self.__key) if self.__key is not None else None}
 
-    def __get_registrant_address(self):
+    @property
+    def registrant_address(self):
         """
         Returns the 64-bit registrant address.
 
@@ -163,12 +176,14 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
         """
         return self.__registrant_address
 
-    def __set_registrant_address(self, registrant_address):
+    @registrant_address.setter
+    def registrant_address(self, registrant_address):
         """
         Sets the 64-bit registrant address.
 
         Args:
-            registrant_address (:class:`.XBee64BitAddress`): The new 64-bit registrant address.
+            registrant_address (:class:`.XBee64BitAddress`): The new 64-bit
+                registrant address.
 
         .. seealso::
            | :class:`.XBee64BitAddress`
@@ -176,7 +191,8 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
         if registrant_address is not None:
             self.__registrant_address = registrant_address
 
-    def __get_options(self):
+    @property
+    def options(self):
         """
         Returns the register options value.
 
@@ -188,7 +204,8 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
         """
         return self.__options
 
-    def __set_options(self, options):
+    @options.setter
+    def options(self, options):
         """
         Sets the register options value.
 
@@ -200,7 +217,8 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
         """
         self.__options = options
 
-    def __get_key(self):
+    @property
+    def key(self):
         """
         Returns the register key.
 
@@ -211,7 +229,8 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
             return None
         return self.__key.copy()
 
-    def __set_key(self, key):
+    @key.setter
+    def key(self, key):
         """
         Sets the register key.
 
@@ -222,15 +241,6 @@ class RegisterJoiningDevicePacket(XBeeAPIPacket):
             self.__key = None
         else:
             self.__key = key.copy()
-
-    registrant_address = property(__get_registrant_address, __set_registrant_address)
-    """:class:`.XBee64BitAddress`. Registrant 64-bit address."""
-
-    options = property(__get_options, __set_options)
-    """:class:`.RegisterKeyOptions`. Register options."""
-
-    key = property(__get_key, __set_key)
-    """Bytearray. Register key."""
 
 
 class RegisterDeviceStatusPacket(XBeeAPIPacket):
@@ -252,15 +262,17 @@ class RegisterDeviceStatusPacket(XBeeAPIPacket):
 
     def __init__(self, frame_id, status):
         """
-        Class constructor. Instantiates a new :class:`.RegisterDeviceStatusPacket` object with the
+        Class constructor. Instantiates a new
+        :class:`.RegisterDeviceStatusPacket` object with the
         provided parameters.
 
         Args:
             frame_id (integer): the frame ID of the packet.
-            status (:class:`.ZigbeeRegisterStatus`): status of the register device operation.
+            status (:class:`.ZigbeeRegisterStatus`): status of the register
+                device operation.
 
         Raises:
-            ValueError: if ``frame_id`` is less than 0 or greater than 255.
+            ValueError: if `frame_id` is less than 0 or greater than 255.
 
         .. seealso::
            | :class:`.XBeeAPIPacket`
@@ -282,28 +294,37 @@ class RegisterDeviceStatusPacket(XBeeAPIPacket):
             :class:`.RegisterDeviceStatusPacket`.
 
         Raises:
-            InvalidPacketException: if the bytearray length is less than 17. (start delim. + length (2 bytes) + frame
-                type + frame id + status + checksum = 7 bytes).
-            InvalidPacketException: if the length field of 'raw' is different than its real length. (length field: bytes
-                1 and 3)
-            InvalidPacketException: if the first byte of 'raw' is not the header byte. See :class:`.SpecialByte`.
-            InvalidPacketException: if the calculated checksum is different than the checksum field value (last byte).
-            InvalidPacketException: if the frame type is not :attr:`.ApiFrameType.REGISTER_JOINING_DEVICE_STATUS`.
-            InvalidOperatingModeException: if ``operating_mode`` is not supported.
+            InvalidPacketException: if the bytearray length is less than 17.
+                (start delim. + length (2 bytes) + frame type + frame id
+                + status + checksum = 7 bytes).
+            InvalidPacketException: if the length field of 'raw' is different
+                from its real length. (length field: bytes 1 and 3)
+            InvalidPacketException: if the first byte of 'raw' is not the
+                header byte. See :class:`.SpecialByte`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is not
+                :attr:`.ApiFrameType.REGISTER_JOINING_DEVICE_STATUS`.
+            InvalidOperatingModeException: if `operating_mode` is not supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE, OperatingMode.API_MODE]:
-            raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
+            raise InvalidOperatingModeException(
+                operating_mode.name + " is not supported.")
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=RegisterDeviceStatusPacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=RegisterDeviceStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REGISTER_JOINING_DEVICE_STATUS.code:
-            raise InvalidPacketException("This packet is not a Register Device Status packet.")
+            raise InvalidPacketException(
+                "This packet is not a Register Device Status packet.")
 
-        return RegisterDeviceStatusPacket(raw[4], ZigbeeRegisterStatus.get(raw[5]))
+        return RegisterDeviceStatusPacket(
+            raw[4], ZigbeeRegisterStatus.get(raw[5]))
 
     def needs_id(self):
         """
@@ -333,7 +354,8 @@ class RegisterDeviceStatusPacket(XBeeAPIPacket):
         return {DictKeys.STATUS: "%s (%s)" % (self.__status.code,
                                               self.__status.description)}
 
-    def __get_status(self):
+    @property
+    def status(self):
         """
         Returns the register device status.
 
@@ -345,7 +367,8 @@ class RegisterDeviceStatusPacket(XBeeAPIPacket):
         """
         return self.__status
 
-    def __set_status(self, status):
+    @status.setter
+    def status(self, status):
         """
         Sets the register device status.
 
@@ -357,9 +380,6 @@ class RegisterDeviceStatusPacket(XBeeAPIPacket):
         """
         self.__status = status
 
-    status = property(__get_status, __set_status)
-    """:class:`.ZigbeeRegisterStatus`. Register device status."""
-
 
 class RouteRecordIndicatorPacket(XBeeAPIPacket):
     """
@@ -368,8 +388,8 @@ class RouteRecordIndicatorPacket(XBeeAPIPacket):
     payload.
 
     The route record indicator is received whenever a device sends a Zigbee
-    route record command. This is used with many-to-one routing to create source
-    routes for devices in a network.
+    route record command. This is used with many-to-one routing to create
+    source routes for devices in a network.
 
     Among received data, some options can also be received indicating
     transmission parameters.
@@ -431,15 +451,15 @@ class RouteRecordIndicatorPacket(XBeeAPIPacket):
                 :attr:`.ApiFrameType.ROUTE_RECORD_INDICATOR`.
             InvalidPacketException: If the number of hops does not match with
                 the number of 16-bit addresses.
-            InvalidOperatingModeException: If ``operating_mode`` is not
+            InvalidOperatingModeException: If `operating_mode` is not
                 supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE,
-                                  OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(
                 operating_mode.name + " is not supported.")
 
@@ -456,10 +476,9 @@ class RouteRecordIndicatorPacket(XBeeAPIPacket):
             raise InvalidPacketException("Specified number of hops does not"
                                          "match with the length of addresses.")
 
-        return RouteRecordIndicatorPacket(XBee64BitAddress(raw[4:12]),
-                                          XBee16BitAddress(raw[12:14]),
-                                          raw[14],
-                                          hops)
+        return RouteRecordIndicatorPacket(
+            XBee64BitAddress(raw[4:12]), XBee16BitAddress(raw[12:14]),
+            raw[14], hops)
 
     def needs_id(self):
         """
@@ -690,8 +709,8 @@ class CreateSourceRoutePacket(XBeeAPIPacket):
         Raises:
             InvalidPacketException: If the bytearray length is less than 18.
                 (start delim. + length (2 bytes) + frame type + frame id +
-                 64-bit addr. + 16-bit addr. + Route command options + num of addrs
-                 + hops 16-bit addrs + checksum = 18 bytes).
+                64-bit addr. + 16-bit addr. + Route command options
+                + num of addrs + hops 16-bit addrs + checksum = 18 bytes).
             InvalidPacketException: If the length field of `raw` is different
                 from its real length. (length field: bytes 1 and 3)
             InvalidPacketException: If the first byte of 'raw' is not the
@@ -702,15 +721,15 @@ class CreateSourceRoutePacket(XBeeAPIPacket):
                 :attr:`.ApiFrameType.CREATE_SOURCE_ROUTE`.
             InvalidPacketException: If the number of hops does not match with
                 the number of 16-bit addresses.
-            InvalidOperatingModeException: If ``operating_mode`` is not
+            InvalidOperatingModeException: If `operating_mode` is not
                 supported.
 
         .. seealso::
            | :meth:`.XBeePacket.create_packet`
            | :meth:`.XBeeAPIPacket._check_api_packet`
         """
-        if operating_mode not in [OperatingMode.ESCAPED_API_MODE,
-                                  OperatingMode.API_MODE]:
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
             raise InvalidOperatingModeException(
                 operating_mode.name + " is not supported.")
 
@@ -727,8 +746,9 @@ class CreateSourceRoutePacket(XBeeAPIPacket):
             raise InvalidPacketException("Specified number of hops does not"
                                          "match with the length of addresses.")
 
-        return CreateSourceRoutePacket(raw[4], XBee64BitAddress(raw[5:13]),
-                                       XBee16BitAddress(raw[13:15]), raw[15], hops)
+        return CreateSourceRoutePacket(
+            raw[4], XBee64BitAddress(raw[5:13]), XBee16BitAddress(raw[13:15]),
+            raw[15], hops)
 
     def needs_id(self):
         """

--- a/digi/xbee/util/utils.py
+++ b/digi/xbee/util/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019, Digi International Inc.
+# Copyright 2017-2020, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,35 +24,39 @@ __MASK = 0xFF
 
 def is_bit_enabled(number, position):
     """
-    Returns whether the bit located at ``position`` within ``number`` is enabled or not.
+    Returns whether the bit located at `position` within `number` is enabled.
 
     Args:
         number (Integer): the number to check if a bit is enabled.
-        position (Integer): the position of the bit to check if is enabled in ``number``.
+        position (Integer): the position of the bit to check if is enabled in
+            `number`.
 
     Returns:
-        Boolean: ``True`` if the bit located at ``position`` within ``number`` is enabled, ``False`` otherwise.
+        Boolean: `True` if the bit located at `position` within `number` is
+            enabled, `False` otherwise.
     """
     return ((number & 0xFFFFFFFF) >> position) & 0x01 == 0x01
 
 
 def get_int_from_byte(number, offset, length):
     """
-    Reads an integer value from the given byte using the provived bit offset and length.
+    Reads an integer value from the given byte using the provived bit offset
+    and length.
 
     Args:
         number (Integer): Byte to read the integer from.
-        offset (Integer): Bit offset inside the byte to start reading (LSB = 0, MSB = 7).
+        offset (Integer): Bit offset inside the byte to start reading
+            (LSB = 0, MSB = 7).
         length (Integer): Number of bits to read.
 
     Returns:
         Integer: The integer value read.
 
     Raises:
-        ValueError: If ``number`` is lower than 0 or higher than 255.
-                    If ``offset`` is lower than 0 or higher than 7.
-                    If ``length`` is lower than 0 or higher than 8.
-                    If ``offset + length`` is higher than 8.
+        ValueError: If `number is lower than 0 or higher than 255.
+                    If `offset` is lower than 0 or higher than 7.
+                    If `length` is lower than 0 or higher than 8.
+                    If `offset + length` is higher than 8.
     """
     if number < 0 or number > 255:
         raise ValueError("Number must be between 0 and 255")
@@ -77,16 +81,16 @@ def get_int_from_byte(number, offset, length):
 def hex_string_to_bytes(hex_string):
     """
     Converts a String (composed by hex. digits) into a bytearray with same digits.
-    
+
     Args:
         hex_string (String): String (made by hex. digits) with "0x" header or not.
 
     Returns:
         Bytearray: bytearray containing the numeric value of the hexadecimal digits.
-        
+
     Raises:
         ValueError: if invalid literal for int() with base 16 is provided.
-    
+
     Example:
         >>> a = "0xFFFE"
         >>> for i in hex_string_to_bytes(a): print(i)
@@ -94,14 +98,13 @@ def hex_string_to_bytes(hex_string):
         254
         >>> print(type(hex_string_to_bytes(a)))
         <type 'bytearray'>
-        
+
         >>> b = "FFFE"
         >>> for i in hex_string_to_bytes(b): print(i)
         255
         254
         >>> print(type(hex_string_to_bytes(b)))
         <type 'bytearray'>
-        
     """
     aux = int(hex_string, 16)
     return int_to_bytes(aux)
@@ -110,13 +113,13 @@ def hex_string_to_bytes(hex_string):
 def int_to_bytes(number, num_bytes=None):
     """
     Converts the provided integer into a bytearray.
-    
-    If ``number`` has less bytes than ``num_bytes``, the resultant bytearray
+
+    If `number` has less bytes than `num_bytes`, the resultant bytearray
     is filled with zeros (0x00) starting at the beginning.
-    
-    If ``number`` has more bytes than ``num_bytes``, the resultant bytearray
+
+    If `number` has more bytes than `num_bytes`, the resultant bytearray
     is returned without changes.
-    
+
     Args:
         number (Integer): the number to convert to a bytearray.
         num_bytes (Integer): the number of bytes that the resultant bytearray will have.
@@ -130,7 +133,6 @@ def int_to_bytes(number, num_bytes=None):
         [255,254]
         >>> print(type(int_to_bytes(a)))
         <type 'bytearray'>
-        
     """
     byte_array = bytearray()
     byte_array.insert(0, number & __MASK)
@@ -150,16 +152,16 @@ def length_to_int(byte_array):
     """
     Calculates the length value for the given length field of a packet.
     Length field are bytes 1 and 2 of any packet.
-    
+
     Args:
         byte_array (Bytearray): length field of a packet.
-        
+
     Returns:
         Integer: the length value.
-    
+
     Raises:
-        ValueError: if ``byte_array`` is not a valid length field (it has length distinct than 0).
-    
+        ValueError: if `byte_array` is not a valid length field (it has length distinct than 0).
+
     Example:
         >>> b = bytearray([13,14])
         >>> c = length_to_int(b)
@@ -176,7 +178,7 @@ def length_to_int(byte_array):
 def bytes_to_int(byte_array):
     """
     Converts the provided bytearray in an Integer.
-    This integer is result of concatenate all components of ``byte_array``
+    This integer is result of concatenate all components of `byte_array`
     and convert that hex number to a decimal number.
 
     Args:
@@ -198,24 +200,28 @@ def bytes_to_int(byte_array):
     return int("".join(["%02X" % i for i in byte_array]), 16)
 
 
-def ascii_to_int(ni):
+def ascii_to_int(array):
     """
-    Converts a bytearray containing the ASCII code of each number digit in an Integer.
-    This integer is result of the number formed by all ASCII codes of the bytearray.
-    
+    Converts a bytearray containing the ASCII code of each number digit in an
+    Integer. This integer is result of the number formed by all ASCII codes of
+    the bytearray.
+
+    Args:
+        array (Bytearray): bytearray to convert in integer.
+
     Example:
-        >>> x = bytearray( [0x31,0x30,0x30] )   #0x31 => ASCII code for number 1.
-                                                #0x31,0x30,0x30 <==> 1,0,0
+        >>> x = bytearray( [0x31,0x30,0x30] )  #0x31 => ASCII code for number 1.
+                                               #0x31,0x30,0x30 <==> 1,0,0
         >>> print(ascii_to_int(x))
         100
     """
-    return int("".join([str(i - 0x30) for i in ni]))
+    return int("".join([str(i - 0x30) for i in array]))
 
 
 def int_to_ascii(number):
     """
-    Converts an integer number to a bytearray. Each element of the bytearray is the ASCII
-    code that corresponds to the digit of its position.
+    Converts an integer number to a bytearray. Each element of the bytearray is
+    the ASCII code that corresponds to the digit of its position.
 
     Args:
         number (Integer): the number to convert to an ASCII bytearray.
@@ -235,35 +241,36 @@ def int_to_ascii(number):
 
 def int_to_length(number):
     """
-    Converts am integer into a bytearray of 2 bytes corresponding to the length field of a
-    packet. If this bytearray has length 1, a byte with value 0 is added at the beginning.
+    Converts an integer into a bytearray of 2 bytes corresponding to the
+    length field of a packet. If this bytearray has length 1, a byte with value
+    0 is added at the beginning.
 
     Args:
         number (Integer): the number to convert to a length field.
 
     Returns:
-
+        Bytearray: The bytearray.
 
     Raises:
-        ValueError: if ``number`` is less than 0 or greater than 0xFFFF.
-        
+        ValueError: if `number` is less than 0 or greater than 0xFFFF.
+
     Example:
         >>> a = 0
         >>> print(hex_to_string(int_to_length(a)))
         00 00
-        
+
         >>> a = 8
         >>> print(hex_to_string(int_to_length(a)))
         00 08
-        
+
         >>> a = 200
         >>> print(hex_to_string(int_to_length(a)))
         00 C8
-        
+
         >>> a = 0xFF00
         >>> print(hex_to_string(int_to_length(a)))
         FF 00
-        
+
         >>> a = 0xFF
         >>> print(hex_to_string(int_to_length(a)))
         00 FF
@@ -278,13 +285,13 @@ def int_to_length(number):
 
 def hex_to_string(byte_array, pretty=True):
     """
-    Returns the provided bytearray in a pretty string format. All bytes are separated by blank spaces and
-    printed in hex format.
+    Returns the provided bytearray in a pretty string format. All bytes are
+    separated by blank spaces and printed in hex format.
 
     Args:
         byte_array (Bytearray): the bytearray to print in pretty string.
-        pretty (Boolean, optional): ``True`` for pretty string format, ``False`` for plain string format.
-            Default to ``True``.
+        pretty (Boolean, optional): `True` for pretty string format, `False`
+            for plain string format. Default to `True`.
 
     Returns:
         String: the bytearray formatted in a string format.
@@ -296,21 +303,21 @@ def hex_to_string(byte_array, pretty=True):
 def doc_enum(enum_class, descriptions=None):
     """
     Returns a string with the description of each value of an enumeration.
-    
+
     Args:
         enum_class (Enumeration): the Enumeration to get its values documentation.
-        descriptions (dictionary): each enumeration's item description. The key is the enumeration element name
-            and the value is the description.
-            
+        descriptions (dictionary): each enumeration's item description. The key
+            is the enumeration element name and the value is the description.
+
     Returns:
         String: the string listing all the enumeration values and their descriptions.
     """
     tab = " "*4
     data = "\n| Values:\n"
-    for x in enum_class:
-        data += """| {:s}**{:s}**{:s} {:s}\n""".format(tab, x,
-                                                       ":" if descriptions is not None else " =",
-                                                       str(x.value) if descriptions is None else descriptions[x])
+    for item in enum_class:
+        data += """| {:s}**{:s}**{:s} {:s}\n""".format(
+            tab, item, ":" if descriptions is not None else " =",
+            str(item.value) if descriptions is None else descriptions[item])
     return data + "| \n"
 
 
@@ -321,16 +328,16 @@ def enable_logger(name, level=logging.DEBUG):
     Args:
         name (String): name of the logger to enable.
         level (Integer): logging level value.
-    
+
     Assigns a default formatter and a default handler (for console).
     """
     log = logging.getLogger(name)
     log.disabled = False
-    ch = logging.StreamHandler()
-    ch.setLevel(level)
+    handler = logging.StreamHandler()
+    handler.setLevel(level)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)-7s - %(message)s')
-    ch.setFormatter(formatter)
-    log.addHandler(ch)
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
     log.setLevel(level)
 
 
@@ -349,12 +356,12 @@ def deprecated(version, details="None"):
     """
     Decorates a method to mark as deprecated.
     This adds a deprecation note to the method docstring and also raises a
-    :class:``warning.DeprecationWarning``.
+    :class:`warning.DeprecationWarning`.
 
     Args:
         version (String): Version that deprecates this feature.
-        details (String, optional, default=``None``): Extra details to be added to the
-            method docstring and warning.
+        details (String, optional, default=`None`): Extra details to be added
+            to the method docstring and warning.
     """
     def _function_wrapper(func):
         docstring = func.__doc__ or ""


### PR DESCRIPTION
R1719: The if expression can be replaced with 'test' (simplifiable-if-expression)
R1705: Unnecessary "else" after "return" (no-else-return)
C0103: Attribute name "__atCommand" doesn't conform to snake_case naming style (invalid-name)
R1719: The if expression can be replaced with 'test' (simplifiable-if-expression)

R0205: Class 'XBee16BitAddress' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
C0325: Unnecessary parens after 'not' keyword (superfluous-parens)

C0303: Trailing whitespace (trailing-whitespace)

W0311: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
C0330: Wrong continued indentation (add 1 space)

W0107: Unnecessary pass statement (unnecessary-pass)

Signed-off-by: Tatiana Leon <tatiana.leon@digi.com>