### PR TITLE
get: set: execute: add a new optional arg to set/get/execute parameter methods

### DIFF
--- a/digi/xbee/filesystem.py
+++ b/digi/xbee/filesystem.py
@@ -2401,7 +2401,7 @@ class FileSystemManager:
         cmd = ATStringCommand.NP.command
         try:
             # Reserve 5 bytes for other frame data
-            self.__np_val = utils.bytes_to_int(xbee.get_parameter(cmd)) - 5
+            self.__np_val = utils.bytes_to_int(xbee.get_parameter(cmd, apply=False)) - 5
             # Subtract extra bytes of remote frames
             self.__np_val -= n_extra_bytes
         except XBeeException as exc:

--- a/digi/xbee/models/zdo.py
+++ b/digi/xbee/models/zdo.py
@@ -292,7 +292,7 @@ class _ZDOCommand(metaclass=ABCMeta):
             value[0] = value[0] | APIOutputModeBit.EXPLICIT.code
             value[0] = value[0] & ~APIOutputModeBit.SUPPRESS_ALL_ZDO_MSG.code
 
-            node.set_api_output_mode_value(value)
+            node.set_parameter(ATStringCommand.AO.command, value, apply=True)
 
         except XBeeException as exc:
             raise XBeeException("Could not prepare XBee for ZDO: " + str(exc))
@@ -311,7 +311,7 @@ class _ZDOCommand(metaclass=ABCMeta):
             node = self._xbee.get_local_xbee_device()
 
         try:
-            node.set_api_output_mode_value(self.__saved_ao[0])
+            node.set_parameter(ATStringCommand.AO.command, self.__saved_ao, apply=True)
         except XBeeException as exc:
             self._error = "Could not restore XBee after ZDO: " + str(exc)
 


### PR DESCRIPTION
New optional argument 'apply' for methods:
   * `get_parameter()`
   * `set_parameter()`
   * `execute_parameter()`

This way internal executions can just use it and do not need to read the general apply flag (`is_apply_changes_enabled()`) to update it (`enable_apply_changes()`) and then restore the original value.

Default value for `apply` is `None` to keep the behaviour the method had in previous versions.