### PR TITLE
XBeeSerialPort: exclusive option for serial port

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2317,7 +2317,7 @@ class XBeeDevice(AbstractXBeeDevice):
                  stop_bits=serial.STOPBITS_ONE, parity=serial.PARITY_NONE,
                  flow_control=FlowControl.NONE,
                  _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS,
-                 comm_iface=None):
+                 comm_iface=None, exclusive=None):
         """
         Class constructor. Instantiates a new :class:`.XBeeDevice` with the
         provided parameters.
@@ -2332,6 +2332,7 @@ class XBeeDevice(AbstractXBeeDevice):
             flow_control (Integer, default: :attr:`.FlowControl.NONE`): Port flow control.
             _sync_ops_timeout (Integer, default: 4): Read timeout (in seconds).
             comm_iface (:class:`.XBeeCommunicationInterface`): Communication interface.
+            exclusive (Boolean, optional, default=False) Set exclusive access mode (POSIX only).
 
         Raises:
             All exceptions raised by PySerial's Serial class constructor.
@@ -2343,7 +2344,7 @@ class XBeeDevice(AbstractXBeeDevice):
             serial_port=XBeeSerialPort(baud_rate=baud_rate, port=port,
                                        data_bits=data_bits, stop_bits=stop_bits,
                                        parity=parity, flow_control=flow_control,
-                                       timeout=_sync_ops_timeout) if comm_iface is None else None,
+                                       timeout=_sync_ops_timeout, exclusive=exclusive) if comm_iface is None else None,
             sync_ops_timeout=_sync_ops_timeout, comm_iface=comm_iface)
         # If there is no XBeeNetwork object provided by comm_iface,
         # initialize a default XBeeNetwork

--- a/digi/xbee/serial.py
+++ b/digi/xbee/serial.py
@@ -53,11 +53,12 @@ class XBeeSerialPort(Serial, XBeeCommunicationInterface):
     __DEFAULT_STOP_BITS = STOPBITS_ONE
     __DEFAULT_PARITY = PARITY_NONE
     __DEFAULT_FLOW_CONTROL = FlowControl.NONE
+    __DEFAULT_EXCLUSIVE = None
 
     def __init__(self, baud_rate, port, data_bits=__DEFAULT_DATA_BITS,
                  stop_bits=__DEFAULT_STOP_BITS, parity=__DEFAULT_PARITY,
                  flow_control=__DEFAULT_FLOW_CONTROL,
-                 timeout=__DEFAULT_PORT_TIMEOUT):
+                 timeout=__DEFAULT_PORT_TIMEOUT, exclusive=__DEFAULT_EXCLUSIVE):
         """
         Class constructor. Instantiates a new `XBeeSerialPort` object with the
         given port parameters.
@@ -70,26 +71,29 @@ class XBeeSerialPort(Serial, XBeeCommunicationInterface):
             parity (Char, optional, default=`N`): Parity. Default to 'N' (None).
             flow_control (Integer, optional, default=`None`): Flow control.
             timeout (Integer, optional, default=0.1): Read timeout (seconds).
-
+            exclusive (Boolean, optional, default=False) Set exclusive access mode (POSIX only).
         .. seealso::
            | _PySerial: https://github.com/pyserial/pyserial
         """
         if flow_control == FlowControl.SOFTWARE:
             Serial.__init__(self, port=None, baudrate=baud_rate,
                             bytesize=data_bits, stopbits=stop_bits,
-                            parity=parity, timeout=timeout, xonxoff=True)
+                            parity=parity, timeout=timeout,
+                            exclusive=exclusive, xonxoff=True)
         elif flow_control == FlowControl.HARDWARE_DSR_DTR:
             Serial.__init__(self, port=None, baudrate=baud_rate,
                             bytesize=data_bits, stopbits=stop_bits,
-                            parity=parity, timeout=timeout, dsrdtr=True)
+                            parity=parity, timeout=timeout,
+                            exclusive=exclusive, dsrdtr=True)
         elif flow_control == FlowControl.HARDWARE_RTS_CTS:
             Serial.__init__(self, port=None, baudrate=baud_rate,
                             bytesize=data_bits, stopbits=stop_bits,
-                            parity=parity, timeout=timeout, rtscts=True)
+                            parity=parity, timeout=timeout,
+                            exclusive=exclusive, rtscts=True)
         else:
             Serial.__init__(self, port=None, baudrate=baud_rate,
                             bytesize=data_bits, stopbits=stop_bits,
-                            parity=parity, timeout=timeout)
+                            parity=parity, timeout=timeout, exclusive=exclusive)
         self.setPort(port)
         self._is_reading = False
 


### PR DESCRIPTION
Exposing pyserial exclusive flag.

> Set exclusive access mode (POSIX only). A port cannot be opened in exclusive access mode if it is already open in exclusive access mode.

This option is handy when working on a shared machine to prevent script collision from causing issues.
