### PR TITLE
refresh: digimesh: reset 16-bit address for protocols that does not support it

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -219,10 +219,13 @@ class AbstractXBeeDevice:
             updated = True
 
         new_addr16 = device.get_16bit_addr()
-        if (XBee16BitAddress.is_known_node_addr(new_addr16)
-                and new_addr16 != self._16bit_addr):
-            self._16bit_addr = new_addr16
-            updated = True
+        if new_addr16 != self._16bit_addr:
+            if (device.get_protocol() in (XBeeProtocol.DIGI_MESH,
+                                          XBeeProtocol.DIGI_POINT,
+                                          XBeeProtocol.RAW_802_15_4)
+                    or XBee16BitAddress.is_known_node_addr(new_addr16)):
+                self._16bit_addr = new_addr16
+                updated = True
 
         new_role = device.get_role()
         if (new_role is not None


### PR DESCRIPTION
When a Zigbee local node is updated to be a DigiMesh node, its 16-bit address
is not reset although its information is forced to be re-initalized. This
commit forces the 16-bit address to be 0xFFFE (unknown) for any protocol not
supporting 16-bit addressing.

Related to cc685b12eae508714703ac804d8584b9035ca0bd

https://jira.digi.com/browse/XNM-87