### PR TITLE
encoding: use utf-8 to encode/decode and ignore malformed data

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -633,7 +633,8 @@ class AbstractXBeeDevice:
                     updated = True
             # Node ID:
             if init or not self._node_id:
-                node_id = self.get_parameter(ATStringCommand.NI, apply=False).decode()
+                node_id = str(self.get_parameter(ATStringCommand.NI, apply=False),
+                              encoding='utf8', errors='ignore')
                 if self._node_id != node_id:
                     self._node_id = node_id
                     updated = True
@@ -2597,15 +2598,15 @@ class XBeeDevice(AbstractXBeeDevice):
             raise ValueError("64-bit address cannot be None")
         if x16addr is None:
             raise ValueError("16-bit address cannot be None")
-        if data is None:
-            raise ValueError("Data cannot be None")
+        if not isinstance(data, (str, bytearray, bytes)):
+            raise ValueError("Data must be a string or bytearray")
 
         if self.is_remote():
             raise OperationNotSupportedException(
                 message="Cannot send data to a remote device from a remote device")
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors="ignore")
 
         packet = TransmitPacket(self.get_next_frame_id(), x64addr, x16addr,
                                 0, transmit_options, rf_data=data)
@@ -2647,15 +2648,15 @@ class XBeeDevice(AbstractXBeeDevice):
         """
         if x64addr is None:
             raise ValueError("64-bit address cannot be None")
-        if data is None:
-            raise ValueError("Data cannot be None")
+        if not isinstance(data, (str, bytearray, bytes)):
+            raise ValueError("Data must be a string or bytearray")
 
         if self.is_remote():
             raise OperationNotSupportedException(
                 message="Cannot send data to a remote device from a remote device")
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors="ignore")
 
         if self.get_protocol() == XBeeProtocol.RAW_802_15_4:
             packet = TX64Packet(self.get_next_frame_id(), x64addr,
@@ -2702,15 +2703,15 @@ class XBeeDevice(AbstractXBeeDevice):
         """
         if x16addr is None:
             raise ValueError("16-bit address cannot be None")
-        if data is None:
-            raise ValueError("Data cannot be None")
+        if not isinstance(data, (str, bytearray, bytes)):
+            raise ValueError("Data must be a string or bytearray")
 
         if self.is_remote():
             raise OperationNotSupportedException(
                 message="Cannot send data to a remote device from a remote device")
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors="ignore")
 
         packet = TX16Packet(self.get_next_frame_id(), x16addr,
                             transmit_options, rf_data=data)
@@ -2806,15 +2807,15 @@ class XBeeDevice(AbstractXBeeDevice):
             raise ValueError("64-bit address cannot be None")
         if x16addr is None:
             raise ValueError("16-bit address cannot be None")
-        if data is None:
-            raise ValueError("Data cannot be None")
+        if not isinstance(data, (str, bytearray, bytes)):
+            raise ValueError("Data must be a string or bytearray")
 
         if self.is_remote():
             raise OperationNotSupportedException(
                 message="Cannot send data to a remote device from a remote device")
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors="ignore")
 
         packet = TransmitPacket(self.get_next_frame_id(), x64addr, x16addr, 0,
                                 transmit_options, rf_data=data)
@@ -2848,15 +2849,15 @@ class XBeeDevice(AbstractXBeeDevice):
         """
         if x64addr is None:
             raise ValueError("64-bit address cannot be None")
-        if data is None:
-            raise ValueError("Data cannot be None")
+        if not isinstance(data, (str, bytearray, bytes)):
+            raise ValueError("Data must be a string or bytearray")
 
         if self.is_remote():
             raise OperationNotSupportedException(
                 message="Cannot send data to a remote device from a remote device")
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors="ignore")
 
         if self.get_protocol() == XBeeProtocol.RAW_802_15_4:
             packet = TX64Packet(self.get_next_frame_id(), x64addr,
@@ -2895,15 +2896,15 @@ class XBeeDevice(AbstractXBeeDevice):
         """
         if x16addr is None:
             raise ValueError("16-bit address cannot be None")
-        if data is None:
-            raise ValueError("Data cannot be None")
+        if not isinstance(data, (str, bytearray, bytes)):
+            raise ValueError("Data must be a string or bytearray")
 
         if self.is_remote():
             raise OperationNotSupportedException(
                 message="Cannot send data to a remote device from a remote device")
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors="ignore")
 
         packet = TX16Packet(self.get_next_frame_id(),
                             x16addr,
@@ -3900,7 +3901,7 @@ class XBeeDevice(AbstractXBeeDevice):
             raise InvalidOperatingModeException(
                 message="Invalid mode. Command mode can be only be exited while in AT mode")
 
-        self._serial_port.write("ATCN\r".encode("utf-8"))
+        self._serial_port.write("ATCN\r".encode("utf8"))
         time.sleep(self.__DEFAULT_GUARD_TIME)
 
     def _determine_operating_mode(self):
@@ -4089,7 +4090,7 @@ class XBeeDevice(AbstractXBeeDevice):
             x16addr = XBee16BitAddress.UNKNOWN_ADDRESS
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors='ignore')
 
         return ExplicitAddressingPacket(self._get_next_frame_id(), x64addr,
                                         x16addr, src_endpoint, dest_endpoint,
@@ -4115,14 +4116,18 @@ class XBeeDevice(AbstractXBeeDevice):
         # Clear the serial input stream.
         self._serial_port.flushInput()
         # Send the 'AP' command.
-        self._serial_port.write("ATAP\r".encode("utf-8"))
+        self._serial_port.write("ATAP\r".encode(encoding="utf8"))
         time.sleep(0.1)
         # Read the 'AP' answer.
-        ap_answer = self._serial_port.read_existing().decode("utf-8").rstrip()
+        ap_answer = self._serial_port.read_existing() \
+            .decode(encoding="utf8", errors='ignore').rstrip()
         if len(ap_answer) == 0:
             return OperatingMode.UNKNOWN
         # Return the corresponding operating mode for the AP answer.
-        return OperatingMode.get(int(ap_answer, 16))
+        try:
+            return OperatingMode.get(int(ap_answer, 16))
+        except ValueError:
+            return OperatingMode.UNKNOWN
 
     def get_next_frame_id(self):
         """
@@ -6297,8 +6302,8 @@ class IPDevice(XBeeDevice):
         .. seealso::
            | :class:`ipaddress.IPv4Address`
         """
-        resp = self.get_parameter(ATStringCommand.DL, apply=False)
-        return IPv4Address(resp.decode("utf8"))
+        return IPv4Address(
+            str(self.get_parameter(ATStringCommand.DL, apply=False), encoding="utf8"))
 
     def add_ip_data_received_callback(self, callback):
         """
@@ -6383,8 +6388,8 @@ class IPDevice(XBeeDevice):
             raise ValueError("IP address cannot be None")
         if protocol is None:
             raise ValueError("Protocol cannot be None")
-        if data is None:
-            raise ValueError("Data cannot be None")
+        if not isinstance(data, (str, bytearray, bytes)):
+            raise ValueError("Data must be a string or bytearray")
 
         if not 0 <= dest_port <= 65535:
             raise ValueError("Destination port must be between 0 and 65535")
@@ -6400,7 +6405,7 @@ class IPDevice(XBeeDevice):
             src_port = 0
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors="ignore")
 
         opts = TXIPv4Packet.OPTIONS_CLOSE_SOCKET if close_socket else TXIPv4Packet.OPTIONS_LEAVE_SOCKET_OPEN
 
@@ -6438,8 +6443,8 @@ class IPDevice(XBeeDevice):
             raise ValueError("IP address cannot be None")
         if protocol is None:
             raise ValueError("Protocol cannot be None")
-        if data is None:
-            raise ValueError("Data cannot be None")
+        if not isinstance(data, (str, bytearray, bytes)):
+            raise ValueError("Data must be a string or bytearray")
 
         if not 0 <= dest_port <= 65535:
             raise ValueError("Destination port must be between 0 and 65535")
@@ -6456,7 +6461,7 @@ class IPDevice(XBeeDevice):
             src_port = 0
 
         if isinstance(data, str):
-            data = data.encode("utf8")
+            data = data.encode(encoding="utf8", errors="ignore")
 
         opts = TXIPv4Packet.OPTIONS_CLOSE_SOCKET if close_socket else TXIPv4Packet.OPTIONS_LEAVE_SOCKET_OPEN
 
@@ -7669,9 +7674,9 @@ class WiFiDevice(IPDevice):
             return None
 
         signal_quality = self.__get_signal_quality(version, signal_strength)
-        ssid = (ap_data[index:]).decode("utf8")
 
-        return AccessPoint(ssid, WiFiEncryptionType.get(encryption_type),
+        return AccessPoint(str(ap_data[index:], encoding="utf8"),
+                           WiFiEncryptionType.get(encryption_type),
                            channel=channel, signal_quality=signal_quality)
 
     @staticmethod
@@ -8905,7 +8910,7 @@ class XBeeNetwork:
                                date_time=time.localtime(date_now.timestamp()))
                 info.compress_type = ZIP_DEFLATED
                 with xnet_zip.open(info, 'w') as xnet_file:
-                    tree.write(xnet_file, encoding='utf-8', xml_declaration=False)
+                    tree.write(xnet_file, encoding='utf8', xml_declaration=False)
         except (OSError, IOError) as exc:
             return 1, "%s (%d): %s" % (exc.strerror, exc.errno, exc.filename)
 
@@ -10283,10 +10288,12 @@ class XBeeNetwork:
         try:
             timeout = self._calculate_timeout(default_timeout=XBeeNetwork._DEFAULT_DISCOVERY_TIMEOUT)
             # send "ND" async
-            self._local_xbee.send_packet(ATCommPacket(self._local_xbee.get_next_frame_id(),
-                                                      ATStringCommand.ND.command,
-                                                      parameter=None if node_id is None else bytearray(node_id, 'utf8')),
-                                         sync=False)
+            self._local_xbee.send_packet(
+                ATCommPacket(self._local_xbee.get_next_frame_id(),
+                             ATStringCommand.ND.command,
+                             parameter=None if node_id is None
+                             else bytearray(node_id, encoding='utf8', errors='ignore')),
+                sync=False)
 
             self.__nd_processes.update({str(self._local_xbee.get_64bit_addr()): self})
 
@@ -10612,7 +10619,7 @@ class XBeeNetwork:
             # role is the next byte
             role = Role.get(utils.bytes_to_int(data[i:i+1]))
         return XBee16BitAddress(data[0:2]), XBee64BitAddress(data[2:10]), \
-            node_id.decode(), role, parent_addr
+            node_id.decode('utf8', errors='ignore'), role, parent_addr
 
     def _set_node_reachable(self, node, reachable):
         """

--- a/digi/xbee/io.py
+++ b/digi/xbee/io.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020, Digi International Inc.
+# Copyright 2017-2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -565,7 +565,8 @@ class IOSample:
             Boolean. `True` if the given IOLine has a power supply value,
                 `False` otherwise.
         """
-        return utils.is_bit_enabled(self.__analog_mask, 7)
+        return (utils.is_bit_enabled(self.__analog_mask, 7)
+                and self.__power_supply_voltage is not None)
 
     def get_digital_value(self, io_line):
         """

--- a/digi/xbee/models/atcomm.py
+++ b/digi/xbee/models/atcomm.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020, Digi International Inc.
+# Copyright 2017-2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -276,7 +276,10 @@ class ATCommand:
             raise ValueError("Command length must be 2.")
 
         self.__command = command
-        self.__parameter = parameter
+        if isinstance(parameter, str):
+            self.__parameter = bytearray(parameter, encoding='utf8', errors='ignore')
+        else:
+            self.__parameter = parameter
 
     def __str__(self):
         """
@@ -286,7 +289,7 @@ class ATCommand:
             String: representation of this ATCommand.
         """
         return "Command: %s - Parameter: %s" \
-               % (self.__command, str(self.__parameter))
+               % (self.__command, utils.hex_to_string(self.__parameter))
 
     def __len__(self):
         """
@@ -306,7 +309,7 @@ class ATCommand:
         Returns the AT command.
 
         Returns:
-            :class:`.ATCommand`: the AT command.
+            String: the AT command.
         """
         return self.__command
 
@@ -328,7 +331,9 @@ class ATCommand:
         Returns:
             String: this ATCommand parameter. `None` if there is no parameter.
         """
-        return self.__parameter.decode() if self.__parameter else None
+        if not self.__parameter:
+            return None
+        return str(self.__parameter, encoding='utf8', errors='ignore')
 
     @parameter.setter
     def parameter(self, parameter):
@@ -336,10 +341,10 @@ class ATCommand:
         Sets the AT command parameter.
 
         Args:
-            parameter (Bytearray): the parameter to be set.
+            parameter (Bytearray or String): the parameter to be set.
         """
         if isinstance(parameter, str):
-            self.__parameter = bytearray(parameter, 'utf8')
+            self.__parameter = bytearray(parameter, encoding='utf8', errors='ignore')
         else:
             self.__parameter = parameter
 

--- a/digi/xbee/models/zdo.py
+++ b/digi/xbee/models/zdo.py
@@ -1717,7 +1717,8 @@ class NeighborFinder:
             node = self.__xbee.get_local_xbee_device()
 
         # Create a new remote node
-        n_xb = RemoteDigiMeshDevice(node, x64bit_addr=x64, node_id=node_id.decode())
+        n_xb = RemoteDigiMeshDevice(
+            node, x64bit_addr=x64, node_id=node_id.decode('utf8', errors='ignore'))
         n_xb._role = role
 
         neighbor = Neighbor(n_xb, NeighborRelationship.SIBLING, -1, rssi)

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020, Digi International Inc.
+# Copyright 2017-2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -46,8 +46,8 @@ class ATCommPacket(XBeeAPIPacket):
 
         Args:
             frame_id (Integer): the frame ID of the packet.
-            command (String): the AT command of the packet. Must be a string.
-            parameter (Bytearray, optional): the AT command parameter. Optional.
+            command (String or bytearray): AT command of the packet.
+            parameter (Bytearray, optional): the AT command parameter.
 
         Raises:
             ValueError: if `frame_id` is less than 0 or greater than 255.
@@ -56,14 +56,16 @@ class ATCommPacket(XBeeAPIPacket):
         .. seealso::
             | :class:`.XBeeAPIPacket`
         """
+        if not isinstance(command, (str, bytearray, bytes)):
+            raise ValueError("Command must be a string or bytearray")
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
-
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame id must be between 0 and 255.")
 
         super().__init__(ApiFrameType.AT_COMMAND)
-        self.__command = command
+        self.__command = _encode_at_cmd(command)
         self.__parameter = parameter
         self._frame_id = frame_id
 
@@ -102,7 +104,7 @@ class ATCommPacket(XBeeAPIPacket):
         if raw[3] != ApiFrameType.AT_COMMAND.code:
             raise InvalidPacketException(message="This packet is not an AT command packet.")
 
-        return ATCommPacket(raw[4], raw[5:7].decode("utf8"),
+        return ATCommPacket(raw[4], raw[5:7],
                             parameter=raw[7:-1] if len(raw) > ATCommPacket.__MIN_PACKET_LENGTH else None)
 
     def needs_id(self):
@@ -122,8 +124,8 @@ class ATCommPacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
         """
         if self.__parameter is not None:
-            return bytearray(self.__command, "utf8") + self.__parameter
-        return bytearray(self.__command, "utf8")
+            return bytearray(self.__command) + self.__parameter
+        return bytearray(self.__command)
 
     def _get_api_packet_spec_data_dict(self):
         """
@@ -143,7 +145,7 @@ class ATCommPacket(XBeeAPIPacket):
         Returns:
             String: the AT command of the packet.
         """
-        return self.__command
+        return _decode_at_cmd(self.__command)
 
     @command.setter
     def command(self, command):
@@ -151,14 +153,16 @@ class ATCommPacket(XBeeAPIPacket):
         Sets the AT command of the packet.
 
         Args:
-            command (String): the new AT command of the packet. Must have length = 2.
+            command (String or bytearray): New AT command of the packet.
+                Must have length = 2.
 
         Raises:
             ValueError: if length of `command` is different from 2.
         """
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
-        self.__command = command
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
+        self.__command = _encode_at_cmd(command)
 
     @property
     def parameter(self):
@@ -208,7 +212,7 @@ class ATCommQueuePacket(XBeeAPIPacket):
 
         Args:
             frame_id (Integer): the frame ID of the packet.
-            command (String): the AT command of the packet. Must be a string.
+            command (String or bytearray): the AT command of the packet.
             parameter (Bytearray, optional): the AT command parameter. Optional.
 
         Raises:
@@ -218,14 +222,16 @@ class ATCommQueuePacket(XBeeAPIPacket):
         .. seealso::
             | :class:`.XBeeAPIPacket`
         """
+        if not isinstance(command, (str, bytearray, bytes)):
+            raise ValueError("Command must be a string or bytearray")
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
-
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame id must be between 0 and 255.")
 
         super().__init__(ApiFrameType.AT_COMMAND_QUEUE)
-        self.__command = command
+        self.__command = _encode_at_cmd(command)
         self.__parameter = parameter
         self._frame_id = frame_id
 
@@ -264,7 +270,7 @@ class ATCommQueuePacket(XBeeAPIPacket):
         if raw[3] != ApiFrameType.AT_COMMAND_QUEUE.code:
             raise InvalidPacketException(message="This packet is not an AT command Queue packet.")
 
-        return ATCommQueuePacket(raw[4], raw[5:7].decode("utf8"),
+        return ATCommQueuePacket(raw[4], raw[5:7],
                                  parameter=raw[7:-1] if len(raw) > ATCommQueuePacket.__MIN_PACKET_LENGTH else None)
 
     def needs_id(self):
@@ -284,8 +290,8 @@ class ATCommQueuePacket(XBeeAPIPacket):
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
         """
         if self.__parameter is not None:
-            return bytearray(self.__command, "utf8") + self.__parameter
-        return bytearray(self.__command, "utf8")
+            return bytearray(self.__command) + self.__parameter
+        return bytearray(self.__command)
 
     def _get_api_packet_spec_data_dict(self):
         """
@@ -305,7 +311,7 @@ class ATCommQueuePacket(XBeeAPIPacket):
         Returns:
             String: the AT command of the packet.
         """
-        return self.__command
+        return _decode_at_cmd(self.__command)
 
     @command.setter
     def command(self, command):
@@ -313,14 +319,16 @@ class ATCommQueuePacket(XBeeAPIPacket):
         Sets the AT command of the packet.
 
         Args:
-            command (String): the new AT command of the packet. Must have length = 2.
+            command (String or bytearray): New AT command of the packet.
+                Must have length = 2.
 
         Raises:
             ValueError: if length of `command` is different from 2.
         """
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
-        self.__command = command
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
+        self.__command = _encode_at_cmd(command)
 
     @property
     def parameter(self):
@@ -371,7 +379,7 @@ class ATCommResponsePacket(XBeeAPIPacket):
 
         Args:
             frame_id (Integer): the frame ID of the packet. Must be between 0 and 255.
-            command (String): the AT command of the packet. Must be a string.
+            command (String or bytearray): the AT command of the packet.
             response_status (:class:`.ATCommandStatus` or Integer): the status of the AT command.
             comm_value (Bytearray, optional): the AT command response value. Optional.
 
@@ -385,8 +393,11 @@ class ATCommResponsePacket(XBeeAPIPacket):
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame id must be between 0 and 255.")
+        if not isinstance(command, (str, bytearray, bytes)):
+            raise ValueError("Command must be a string or bytearray")
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
         if response_status is None:
             response_status = ATCommandStatus.OK.code
         elif not isinstance(response_status, (ATCommandStatus, int)):
@@ -395,7 +406,7 @@ class ATCommResponsePacket(XBeeAPIPacket):
 
         super().__init__(ApiFrameType.AT_COMMAND_RESPONSE)
         self._frame_id = frame_id
-        self.__command = command
+        self.__command = _encode_at_cmd(command)
         if isinstance(response_status, ATCommandStatus):
             self.__response_status = response_status.code
         elif 0 <= response_status <= 255:
@@ -439,11 +450,12 @@ class ATCommResponsePacket(XBeeAPIPacket):
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.AT_COMMAND_RESPONSE.code:
-            raise InvalidPacketException(message="This packet is not an AT command response packet.")
+            raise InvalidPacketException(
+                message="This packet is not an AT command response packet.")
         if ATCommandStatus.get(raw[7]) is None:
             raise InvalidPacketException(message="Invalid command status.")
 
-        return ATCommResponsePacket(raw[4], raw[5:7].decode("utf8"), raw[7],
+        return ATCommResponsePacket(raw[4], raw[5:7], raw[7],
                                     comm_value=raw[8:-1] if len(raw) > ATCommResponsePacket.__MIN_PACKET_LENGTH else None)
 
     def needs_id(self):
@@ -462,7 +474,7 @@ class ATCommResponsePacket(XBeeAPIPacket):
         .. seealso::
            | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
         """
-        ret = bytearray(self.__command, "utf8")
+        ret = bytearray(self.__command)
         ret.append(self.__response_status)
         if self.__comm_value is not None:
             ret += self.__comm_value
@@ -487,7 +499,7 @@ class ATCommResponsePacket(XBeeAPIPacket):
         Returns:
             String: the AT command of the packet.
         """
-        return self.__command
+        return _decode_at_cmd(self.__command)
 
     @command.setter
     def command(self, command):
@@ -495,14 +507,16 @@ class ATCommResponsePacket(XBeeAPIPacket):
         Sets the AT command of the packet.
 
         Args:
-            command (String): the new AT command of the packet. Must have length = 2.
+            command (String or bytearray): New AT command of the packet.
+                Must have length = 2.
 
         Raises:
             ValueError: if length of `command` is different from 2.
         """
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
-        self.__command = command
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
+        self.__command = _encode_at_cmd(command)
 
     @property
     def command_value(self):
@@ -838,7 +852,7 @@ class RemoteATCommandPacket(XBeeAPIPacket):
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit destination address.
             x16bit_addr (:class:`.XBee16BitAddress`): the 16-bit destination address.
             transmit_options (Integer): bitfield of supported transmission options.
-            command (String): AT command to send.
+            command (String or bytearray): AT command to send.
             parameter (Bytearray, optional): AT command parameter. Optional.
 
         Raises:
@@ -853,16 +867,18 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         if frame_id < 0 or frame_id > 255:
             raise ValueError("Frame id must be between 0 and 255.")
-
+        if not isinstance(command, (str, bytearray, bytes)):
+            raise ValueError("Command must be a string or bytearray")
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
 
         super().__init__(ApiFrameType.REMOTE_AT_COMMAND_REQUEST)
         self._frame_id = frame_id
         self.__x64bit_addr = x64bit_addr
         self.__x16bit_addr = x16bit_addr
         self.__transmit_options = transmit_options
-        self.__command = command
+        self.__command = _encode_at_cmd(command)
         self.__parameter = parameter
 
     @staticmethod
@@ -899,12 +915,13 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_REQUEST.code:
-            raise InvalidPacketException(message="This packet is not a remote AT command request packet.")
+            raise InvalidPacketException(
+                message="This packet is not a remote AT command request packet.")
 
-        return RemoteATCommandPacket(raw[4], XBee64BitAddress(raw[5:13]),
-                                     XBee16BitAddress(raw[13:15]), raw[15],
-                                     raw[16:18].decode("utf8"),
-                                     parameter=raw[18:-1] if len(raw) > RemoteATCommandPacket.__MIN_PACKET_LENGTH else None)
+        return RemoteATCommandPacket(
+            raw[4], XBee64BitAddress(raw[5:13]), XBee16BitAddress(raw[13:15]),
+            raw[15], raw[16:18],
+            parameter=raw[18:-1] if len(raw) > RemoteATCommandPacket.__MIN_PACKET_LENGTH else None)
 
     def needs_id(self):
         """
@@ -925,7 +942,8 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         ret = self.__x64bit_addr.address
         ret += self.__x16bit_addr.address
         ret.append(self.__transmit_options)
-        ret += bytearray(self.__command, "utf8")
+        ret += self.__command
+
         return ret if self.__parameter is None else ret + self.__parameter
 
     def _get_api_packet_spec_data_dict(self):
@@ -1047,7 +1065,7 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         Returns:
             String: the AT command.
         """
-        return self.__command
+        return _decode_at_cmd(self.__command)
 
     @command.setter
     def command(self, command):
@@ -1055,9 +1073,12 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         Sets the AT command.
 
         Args:
-            command (String): the new AT command.
+            command (String or bytearray): New AT command.
         """
-        self.__command = command
+        if len(command) != 2:
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
+        self.__command = _encode_at_cmd(command)
 
 
 class RemoteATCommandResponsePacket(XBeeAPIPacket):
@@ -1092,7 +1113,7 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
             frame_id (Integer): the frame ID of the packet.
             x64bit_addr (:class:`.XBee64BitAddress`): the 64-bit source address
             x16bit_addr (:class:`.XBee16BitAddress`): the 16-bit source address.
-            command (String): the AT command of the packet. Must be a string.
+            command (String or bytearray): the AT command of the packet.
             response_status (:class:`.ATCommandStatus` or Integer): the status of the AT command.
             comm_value (Bytearray, optional): the AT command response value. Optional.
 
@@ -1108,8 +1129,11 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         if frame_id > 255 or frame_id < 0:
             raise ValueError("frame_id must be between 0 and 255.")
+        if not isinstance(command, (str, bytearray, bytes)):
+            raise ValueError("Command must be a string or bytearray")
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
         if response_status is None:
             response_status = ATCommandStatus.OK.code
         elif not isinstance(response_status, (ATCommandStatus, int)):
@@ -1120,7 +1144,7 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         self._frame_id = frame_id
         self.__x64bit_addr = x64bit_addr
         self.__x16bit_addr = x16bit_addr
-        self.__command = command
+        self.__command = _encode_at_cmd(command)
         if isinstance(response_status, ATCommandStatus):
             self.__response_status = response_status.code
         elif 0 <= response_status <= 255:
@@ -1160,15 +1184,20 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
                                   OperatingMode.API_MODE):
             raise InvalidOperatingModeException(op_mode=operating_mode)
 
-        XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH)
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_RESPONSE.code:
-            raise InvalidPacketException(message="This packet is not a remote AT command response packet.")
+            raise InvalidPacketException(
+                message="This packet is not a remote AT command response packet.")
+
+        value = None
+        if len(raw) > RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH:
+            value = raw[18:-1]
 
         return RemoteATCommandResponsePacket(
             raw[4], XBee64BitAddress(raw[5:13]), XBee16BitAddress(raw[13:15]),
-            raw[15:17].decode("utf8"), raw[17],
-            comm_value=raw[18:-1] if len(raw) > RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH else None)
+            raw[15:17], raw[17], comm_value=value)
 
     def needs_id(self):
         """
@@ -1188,7 +1217,7 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         ret = self.__x64bit_addr.address
         ret += self.__x16bit_addr.address
-        ret += bytearray(self.__command, "utf8")
+        ret += self.__command
         ret.append(self.__response_status)
         if self.__comm_value is not None:
             ret += self.__comm_value
@@ -1209,7 +1238,7 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         Returns:
             String: the AT command of the packet.
         """
-        return self.__command
+        return _decode_at_cmd(self.__command)
 
     @command.setter
     def command(self, command):
@@ -1217,14 +1246,16 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         Sets the AT command of the packet.
 
         Args:
-            command (String): the new AT command of the packet. Must have length = 2.
+            command (String or bytearray): New AT command of the packet.
+                Must have length = 2.
 
         Raises:
             ValueError: if length of `command` is different from 2.
         """
         if len(command) != 2:
-            raise ValueError("Invalid command " + command)
-        self.__command = command
+            raise ValueError("Invalid command %s"
+                             % str(command, encoding='utf8', errors='ignore'))
+        self.__command = _encode_at_cmd(command)
 
     @property
     def command_value(self):
@@ -3006,3 +3037,43 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
             self.__rf_data = None
         else:
             self.__rf_data = rf_data.copy()
+
+
+def _decode_at_cmd(cmd_bytearray):
+    """
+    Decodes the given bytearray to an string with 2 characters.
+
+    Args:
+        cmd_bytearray (Bytearray): The bytearray to decode.
+
+    Returns:
+        String: The decoded AT command string.
+    """
+    cmd = cmd_bytearray.decode('utf8', errors='backslashreplace')[0:2]
+    if len(cmd) != 2:
+        # If the command is corrupted it may be an utf-8 valid character
+        # which value is bigger than 0xFF, for example '€' 0xc280C. In this
+        # situation, add a '?' as the second character not to throw an
+        # exception when creating the package that is valid from the
+        # conforming bytes point of view
+        cmd += '?'
+
+    return cmd
+
+
+def _encode_at_cmd(cmd):
+    """
+    Encodes an string AT command to get a bytearray.
+
+    Args:
+        cmd (String or bytearray): The string to encode.
+
+    Returns:
+        Bytearray: A 2-length bytearray with the command.
+    """
+    if isinstance(cmd, str):
+        cmd = cmd.encode(encoding='utf8', errors='ignore')
+        while len(cmd) != 2:
+            cmd += b'?'
+
+    return cmd

--- a/digi/xbee/packets/devicecloud.py
+++ b/digi/xbee/packets/devicecloud.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020, Digi International Inc.
+# Copyright 2017-2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -129,7 +129,7 @@ class DeviceRequestPacket(XBeeAPIPacket):
         ret += utils.int_to_bytes(self.__flags, num_bytes=1)
         if self.__target is not None:
             ret += utils.int_to_bytes(len(self.__target), num_bytes=1)
-            ret += bytearray(self.__target, "utf8")
+            ret += bytearray(self.__target, encoding="utf8")
         else:
             ret += utils.int_to_bytes(0x00, num_bytes=1)
         if self.__request_data is not None:
@@ -770,12 +770,12 @@ class SendDataRequestPacket(XBeeAPIPacket):
         """
         if self.__path is not None:
             ret = utils.int_to_bytes(len(self.__path), num_bytes=1)
-            ret += bytearray(self.__path, "utf8")
+            ret += bytearray(self.__path, encoding="utf8")
         else:
             ret = utils.int_to_bytes(0x00, num_bytes=1)
         if self.__content_type is not None:
             ret += utils.int_to_bytes(len(self.__content_type), num_bytes=1)
-            ret += bytearray(self.__content_type, "utf8")
+            ret += bytearray(self.__content_type, encoding="utf8")
         else:
             ret += utils.int_to_bytes(0x00, num_bytes=1)
         ret += utils.int_to_bytes(0x00, num_bytes=1)  # Transport is always TCP

--- a/digi/xbee/packets/socket.py
+++ b/digi/xbee/packets/socket.py
@@ -1,4 +1,4 @@
-# Copyright 2019, 2020, Digi International Inc.
+# Copyright 2019-2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -775,8 +775,8 @@ class SocketConnectPacket(XBeeAPIPacket):
     """Indicates the destination address field is a binary IPv4 address in network byte order."""
 
     DEST_ADDRESS_STRING = 1
-    """Indicates the destination address field is a string containing either a dotted quad value or a domain name to be
-    resolved."""
+    """Indicates the destination address field is a string containing either a
+    dotted quad value or a domain name to be resolved."""
 
     def __init__(self, frame_id, socket_id, dest_port, dest_address_type, dest_address):
         """
@@ -868,7 +868,7 @@ class SocketConnectPacket(XBeeAPIPacket):
         addr_type = raw[8]
         address = raw[9:-1]
         if address is not None and addr_type == SocketConnectPacket.DEST_ADDRESS_STRING:
-            address = address.decode("utf8")
+            address = address.decode(encoding="utf8", errors='ignore')
 
         return SocketConnectPacket(
             raw[4], raw[5], utils.bytes_to_int(raw[6:8]), addr_type, address)
@@ -893,7 +893,10 @@ class SocketConnectPacket(XBeeAPIPacket):
         ret.append(self.__socket_id)
         ret += utils.int_to_bytes(self.__dest_port, num_bytes=2)
         ret.append(self.__dest_address_type)
-        ret += self.__dest_address.encode() if isinstance(self.__dest_address, str) else self.__dest_address
+        if isinstance(self.__dest_address, str):
+            ret += self.__dest_address.encode(encoding='utf8')
+        else:
+            ret += self.__dest_address
         return ret
 
     def _get_api_packet_spec_data_dict(self):
@@ -910,7 +913,7 @@ class SocketConnectPacket(XBeeAPIPacket):
                 DictKeys.DEST_ADDR_TYPE.value: utils.hex_to_string(bytearray([self.__dest_address_type])),
                 DictKeys.DEST_ADDR.value:      ("%s (%s)" % (
                     utils.hex_to_string(
-                        self.__dest_address.encode()), self.__dest_address)) if isinstance(self.__dest_address, str) else utils.hex_to_string(self.__dest_address)}
+                        self.__dest_address.encode(encoding="utf8", errors='ignore')), self.__dest_address)) if isinstance(self.__dest_address, str) else utils.hex_to_string(self.__dest_address)}
 
     @property
     def socket_id(self):

--- a/digi/xbee/profile.py
+++ b/digi/xbee/profile.py
@@ -610,7 +610,7 @@ class XBeeProfileSetting:
             return utils.hex_string_to_bytes(self._value)
         if self._type is XBeeSettingType.TEXT:
             if self._format in (XBeeSettingFormat.ASCII, XBeeSettingFormat.PHONE):
-                return bytearray(self._value, 'utf8')
+                return bytearray(self._value, encoding='utf8')
             if self._format in (XBeeSettingFormat.HEX, XBeeSettingFormat.NO_FORMAT):
                 return utils.hex_string_to_bytes(self._value)
             if self._format is XBeeSettingFormat.IPV4:
@@ -618,7 +618,7 @@ class XBeeProfileSetting:
                 return bytearray(octets)
             if (self._format is XBeeSettingFormat.IPV6
                     and _IPV6_SEPARATOR in self._value):
-                return bytearray(self._value, 'utf8')
+                return bytearray(self._value, encoding='utf8')
         elif self._type in (XBeeSettingType.BUTTON, XBeeSettingType.NO_TYPE):
             return bytearray(0)
 

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020, Digi International Inc.
+# Copyright 2017-2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -1565,7 +1565,7 @@ class PacketListener(threading.Thread):
                 x64bit_addr = "local"
 
             if cmd == ATStringCommand.NI.command:
-                node_id = val.decode()
+                node_id = val.decode(encoding='utf8', errors='ignore')
             elif cmd == ATStringCommand.HV.command:
                 hw_version = HardwareVersion.get(val[0])
             elif cmd == ATStringCommand.VR.command:

--- a/digi/xbee/recovery.py
+++ b/digi/xbee/recovery.py
@@ -164,7 +164,7 @@ class _LocalRecoverDevice:
                        "assuming device is in bootloader mode and retrying")
             # Only for XBee 3 modules
             self._xbee_serial_port.apply_settings({_BAUDRATE_KEY: _BOOTLOADER_BAUDRATE})
-            self._xbee_serial_port.write(str.encode(_BOOTLOADER_CONTINUE_KEY))
+            self._xbee_serial_port.write(str.encode(_BOOTLOADER_CONTINUE_KEY, encoding="utf8"))
 
             _log.debug("Retrying to determine the baudrate in recovery mode")
             recovery_baudrate = self._get_recovery_baudrate(_RECOVERY_DETECTION_TRIES)
@@ -234,7 +234,7 @@ class _LocalRecoverDevice:
                 _AT_COMMANDS[_APPLY_CHANGES_KEY],
                 _AT_COMMANDS[_WRITE_REGISTER_KEY],
                 _AT_COMMANDS[_EXIT_MODE_KEY]):
-            self._xbee_serial_port.write(str.encode(command))
+            self._xbee_serial_port.write(str.encode(command, encoding="utf8"))
             if command == _AT_COMMANDS[_EXIT_MODE_KEY]:
                 time.sleep(_DEFAULT_GUARD_TIME)
             timeout = time.time() + 2
@@ -385,7 +385,7 @@ def enter_at_command_mode(port):
     # any data to the device
     time.sleep(1)
     # Send the command mode sequence
-    b_array = bytearray('+', "utf8")
+    b_array = bytearray('+', encoding="utf8")
     port.write(b_array)
     port.write(b_array)
     port.write(b_array)

--- a/digi/xbee/sender.py
+++ b/digi/xbee/sender.py
@@ -1,4 +1,4 @@
-# Copyright 2020, Digi International Inc.
+# Copyright 2020, 2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -212,7 +212,7 @@ class PacketSender:
 
         # Node identifier
         if param == ATStringCommand.NI.command:
-            node_id = value.decode()
+            node_id = str(value, encoding='utf8', errors='ignore')
             changed = node.get_node_id() != node_id
             updated = changed and apply
             if updated:
@@ -471,7 +471,7 @@ class SyncRequestSender:
             received_response = self._is_valid_socket_bind_response(rcv_packet)
         elif s_f_type == ApiFrameType.REGISTER_JOINING_DEVICE:
             received_response = (
-                    r_f_type == ApiFrameType.REGISTER_JOINING_DEVICE_STATUS)
+                r_f_type == ApiFrameType.REGISTER_JOINING_DEVICE_STATUS)
         else:
             received_response = True
 

--- a/digi/xbee/util/xmodem.py
+++ b/digi/xbee/util/xmodem.py
@@ -1,4 +1,4 @@
-# Copyright 2019, 2020, Digi International Inc.
+# Copyright 2019-2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -475,16 +475,16 @@ class _XModemTransferSession:
             XModemException: if there is any error transferring the block 0.
         """
         self._seq_index = 0
-        name = str.encode(os.path.basename(self._src_path), encoding='utf-8')
-        size = str.encode(str(os.path.getsize(self._src_path)), encoding='utf-8')
-        mod_time = str.encode(str(oct(int(os.path.getctime(self._src_path)))), encoding='utf-8')
+        name = str.encode(os.path.basename(self._src_path), encoding='utf8')
+        size = str.encode(str(os.path.getsize(self._src_path)), encoding='utf8')
+        mod_time = str.encode(str(oct(int(os.path.getctime(self._src_path)))), encoding='utf8')
         if (len(name) + len(size) + len(mod_time)) > 110:
             data = bytearray(_XMODEM_BLOCK_SIZE_1K)
         else:
             data = bytearray(_XMODEM_BLOCK_SIZE_128)
         data[0:len(name)] = name
         data[len(name) + 1:len(name) + 1 + len(size)] = size
-        data[len(name) + len(size) + 1] = str.encode(" ", encoding='utf-8')[0]
+        data[len(name) + len(size) + 1] = str.encode(" ", encoding='utf8')[0]
         data[len(name) + len(size) + 2:len(name) + len(size) + len(mod_time)] = mod_time[2:]
         self._send_next_block(data)
 
@@ -883,7 +883,7 @@ class _XModemReadSession:
                 break
             name.append(byte)
             index += 1
-        name = name.decode(encoding='utf-8')
+        name = str(encoding='utf8', errors='ignore')
         self._download_file.name = name
         # File size is the next data block until a '0' (0x00) is found.
         size = bytearray()
@@ -892,7 +892,10 @@ class _XModemReadSession:
                 break
             size.append(byte)
             index += 1
-        size = int(size.decode(encoding='utf-8'))
+        try:
+            size = int(size.decode(encoding='utf8', errors='ignore'))
+        except ValueError:
+            raise XModemException("Bad file size")
         self._download_file.size = size
 
         self._send_ack()


### PR DESCRIPTION
When encode or decode using utf-8 encoding avoid any 'UnicodeError' just
ignore the malformed data.

Malformed data may be received for example when working in DigiMesh encrypted.
If 2 nodes used different encryption keys (KY) data is received corrupted since
the receiver is unencrypting with the wrong key. This data may not be utf-8 in
fields that are expected to be, for example the AT command of a Remote AT
Command frame.

https://jira.digi.com/browse/XBHAWKDM-901