### PR TITLE
firmware update: ota: implement considerations for versions lower than 1009

### DIFF
--- a/digi/xbee/models/atcomm.py
+++ b/digi/xbee/models/atcomm.py
@@ -90,6 +90,7 @@ class ATStringCommand(Enum):
     M0 = ("M0", "PWM0 configuration")
     M1 = ("M1", "PWM1 configuration")
     NB = ("NB", "Parity")
+    NH = ("NH", "Maximum hops")
     NI = ("NI", "Node identifier")
     ND = ("ND", "Node discover")
     NJ = ("NJ", "Join time")


### PR DESCRIPTION
* Zigbee:
  * Version 1009 and prior: only the GBL file is sent over the air
  * Version 1009 and prior: delayed ACK for some packets
    The Query Next Image Response and the final Image Block Response both cause the client to perform a long operation (erasing/verifying OTA update data in the storage slot) On these versions, the network ACK for the transmission is not sent until after this operation completes.
  * Version 1008 and prior: recovering from failed client transmissions
    Client (remote) does not retry requests. If the server (local) does not receive a request from the client, the server should proceed and send the next response, as though it had received the expected client request.
    More than 3 client requests lost in a row is considered as a failure.
  * Version 1007 and prior: OTA commands cannot be sent with fragmentation
    Set AR to 0xFF on the server (local) for the duration of the update

* DigiMesh
  * Version 300A and prior: only the GBL file is sent over the air
  * Version 300A and prior: recovering from failed client transmissions:
    Client (remote) does not retry requests. If the server (local) does not receive a request from the client, the server should proceed and send the next response, as though it had received the expected client request.
    More than 3 client requests lost in a row is considered as a failure.

* 802.15.4:
  * Version 200A and prior: only the GBL file is sent over the air
  * Version 200A and prior: recovering from failed client transmissions:
    Client (remote) does not retry requests. If the server (local) does not receive a request from the client, the server should proceed and send the next response, as though it had received the expected client request.
    More than 3 client requests lost in a row is considered as a failure.

See:
  * Zigbee (1009 an prior)
    https://www.digi.com/resources/documentation/digidocs/90001539/#reference/r_considerations.htm
  * DigiMesh (older than 300A)
    https://www.digi.com/resources/documentation/Digidocs/90002277/#Reference/r_considerations.htm
  * 802.15.4 (older than 200A)
    https://www.digi.com/resources/documentation/digidocs/90002273/#reference/r_considerations.htm

https://onedigi.atlassian.net/browse/XBPL-375