### PR TITLE
filesystem: update min fw with fs API support and max with fs ota support

### DIFF
--- a/digi/xbee/filesystem.py
+++ b/digi/xbee/filesystem.py
@@ -86,16 +86,18 @@ SUPPORTED_HW_VERSIONS = (HardwareVersion.XBEE3.code,
                          HardwareVersion.XBEE3_SMT.code,
                          HardwareVersion.XBEE3_TH.code)
 
+# Update this value when File System API frames are supported
 XB3_MIN_FW_VERSION_FS_API_SUPPORT = {
-    XBeeProtocol.ZIGBEE: 0x100C,
-    XBeeProtocol.DIGI_MESH: 0x300C,
-    XBeeProtocol.RAW_802_15_4: 0x200D
+    XBeeProtocol.ZIGBEE: 0x10FF,
+    XBeeProtocol.DIGI_MESH: 0x30FF,
+    XBeeProtocol.RAW_802_15_4: 0x20FF
 }
 
+# Update this values when the File System OTA support is deprecated
 XB3_MAX_FW_VERSION_FS_OTA_SUPPORT = {
-    XBeeProtocol.ZIGBEE: 0x100B,
-    XBeeProtocol.DIGI_MESH: 0x300B,
-    XBeeProtocol.RAW_802_15_4: 0x200C
+    XBeeProtocol.ZIGBEE: 0x10FF,
+    XBeeProtocol.DIGI_MESH: 0x30FF,
+    XBeeProtocol.RAW_802_15_4: 0x20FF
 }
 
 _DEFAULT_BLOCK_SIZE = 64


### PR DESCRIPTION
Firmwares 100D (Zigbee), 200D (802.15.4), and 300D (DigiMesh) were released and none include files system API support.

This commit updates:
  * The minimum firmware version with file system API support to 10FF (Zigbee), 20FF(802.15.4), and 30FF (DigiMesh).
  * The maximum firmware version with file system OTA support to 10FF (Zigbee), 20FF(802.15.4), and 30FF (DigiMesh).

These minimum and maximum values must be updated when file sytem API support is added to the firmware (minimum value) or when file system OTA support is deprecated (maximum value)