### PR TITLE
hardware: add new versions to the supported hardware list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 v1.4.1 - XX/XX/2021
 -------------------
 
+* Support for new hardware variants:
+
+  * XBee 3 Cellular LTE-M/NB-IoT (Telit)
+  * XBee 3 Reduced RAM
+  * S2C P5
+  * XB3-DMLR
+  * XB3-DMLR868
 * OTA firmware update:
 
   * Implementation of considerations for versions 1009, 300A, 200A or prior

--- a/digi/xbee/filesystem.py
+++ b/digi/xbee/filesystem.py
@@ -82,9 +82,11 @@ _READ_PORT_TIMEOUT = 0.05  # Seconds.
 
 _SECURE_ELEMENT_SUFFIX = "#"
 
-SUPPORTED_HW_VERSIONS = (HardwareVersion.XBEE3.code,
-                         HardwareVersion.XBEE3_SMT.code,
-                         HardwareVersion.XBEE3_TH.code)
+REMOTE_SUPPORTED_HW_VERSIONS = (HardwareVersion.XBEE3.code,
+                                HardwareVersion.XBEE3_SMT.code,
+                                HardwareVersion.XBEE3_TH.code)
+LOCAL_SUPPORTED_HW_VERSIONS = REMOTE_SUPPORTED_HW_VERSIONS \
+                              + (HardwareVersion.XBEE3_RR.code,)
 
 # Update this value when File System API frames are supported
 XB3_MIN_FW_VERSION_FS_API_SUPPORT = {
@@ -3355,7 +3357,10 @@ def check_fs_support(xbee, min_fw_vers=None, max_fw_vers=None):
                 "filesystem support: %s", str(exc))
 
     # Check compatibility
-    if hw_version and hw_version.code not in SUPPORTED_HW_VERSIONS:
+    supported_hw_versions = LOCAL_SUPPORTED_HW_VERSIONS
+    if xbee.is_remote():
+        supported_hw_versions = REMOTE_SUPPORTED_HW_VERSIONS
+    if hw_version and hw_version.code not in supported_hw_versions:
         return False
 
     if not fw_version:

--- a/digi/xbee/models/hw.py
+++ b/digi/xbee/models/hw.py
@@ -93,6 +93,11 @@ class HardwareVersion(Enum):
     CELLULAR_3_LTE_M_VERIZON = (0x4A, "XBee Cellular 3 LTE-M Verizon")
     CELLULAR_3_LTE_M_ATT = (0x4B, "XBee Cellular 3 LTE-M AT&T")
     CELLULAR_3_CAT1_LTE_VERIZON = (0x4D, "XBee Cellular 3 Cat 1 LTE Verizon")
+    CELLULAR_3_LTE_M_TELIT = (0x4E, "XBee 3 Cellular LTE-M/NB-IoT (Telit)")
+    XBEE3_DM_LR = (0x50, "XB3-DMLR")
+    XBEE3_DM_LR_868 = (0x51, "XB3-DMLR868")
+    XBEE3_RR = (0x52, "XBee 3 Reduced RAM")
+    S2C_P5 = (0x53, "S2C P5")
 
     def __init__(self, code, description):
         self.__code = code

--- a/digi/xbee/models/protocol.py
+++ b/digi/xbee/models/protocol.py
@@ -256,7 +256,8 @@ class XBeeProtocol(Enum):
                           HardwareVersion.CELLULAR_3_CAT1_LTE_ATT.code,
                           HardwareVersion.CELLULAR_3_LTE_M_VERIZON.code,
                           HardwareVersion.CELLULAR_3_LTE_M_ATT.code,
-                          HardwareVersion.CELLULAR_3_CAT1_LTE_VERIZON.code):
+                          HardwareVersion.CELLULAR_3_CAT1_LTE_VERIZON.code,
+                          HardwareVersion.CELLULAR_3_LTE_M_TELIT.code):
             return XBeeProtocol.CELLULAR
 
         if hw_version == HardwareVersion.CELLULAR_NBIOT_EUROPE.code:
@@ -264,7 +265,8 @@ class XBeeProtocol(Enum):
 
         if hw_version in (HardwareVersion.XBEE3.code,
                           HardwareVersion.XBEE3_SMT.code,
-                          HardwareVersion.XBEE3_TH.code):
+                          HardwareVersion.XBEE3_TH.code,
+                          HardwareVersion.XBEE3_RR.code):
             if fw_version.startswith("2"):
                 return XBeeProtocol.RAW_802_15_4
             if fw_version.startswith("3"):
@@ -274,6 +276,17 @@ class XBeeProtocol(Enum):
         if hw_version == HardwareVersion.XB8X.code:
             return (XBeeProtocol.DIGI_MESH
                     if br_value != 0 else XBeeProtocol.DIGI_POINT)
+
+        if hw_version in (HardwareVersion.XBEE3_DM_LR.code,
+                          HardwareVersion.XBEE3_DM_LR_868.code):
+            return XBeeProtocol.DIGI_MESH
+
+        if hw_version == HardwareVersion.S2C_P5.code:
+            if fw_version.startswith("C"):
+                return XBeeProtocol.RAW_802_15_4
+            if fw_version.startswith("B"):
+                return XBeeProtocol.DIGI_MESH
+            return XBeeProtocol.ZIGBEE
 
         return XBeeProtocol.ZIGBEE
 

--- a/digi/xbee/profile.py
+++ b/digi/xbee/profile.py
@@ -1039,7 +1039,7 @@ class XBeeProfile:
                     # 0: All regions
                     self._region_lock = 0
                 else:
-                    self._region_lock = int(fw_version_str[1:2], base=0)
+                    self._region_lock = int(fw_version_str[1:2], base=16)
             _log.debug(" - Region lock: %d", self._region_lock)
             # Determine protocol.
             br_value = self._raw_settings.get(ATStringCommand.BR.command, None)

--- a/digi/xbee/recovery.py
+++ b/digi/xbee/recovery.py
@@ -1,4 +1,4 @@
-# Copyright 2019, 2020, Digi International Inc.
+# Copyright 2019-2021, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -30,7 +30,8 @@ from digi.xbee.util import utils
 
 SUPPORTED_HARDWARE_VERSIONS = (HardwareVersion.XBEE3.code,
                                HardwareVersion.XBEE3_SMT.code,
-                               HardwareVersion.XBEE3_TH.code)
+                               HardwareVersion.XBEE3_TH.code,
+                               HardwareVersion.XBEE3_RR.code)
 
 _BAUDRATE_KEY = "baudrate"
 _PARITY_KEY = "parity"


### PR DESCRIPTION
- 0x4E: XBee 3 Cellular LTE-M/NB-IoT (Telit)
- 0x50: XB3-DMLR
- 0x51: XB3-DMLR868
- 0x52: XBee 3 Reduced RAM
- 0x53: S2C P5

https://onedigi.atlassian.net/browse/XBJAPI-535

Signed-off-by: Diego Escalona <diego.escalona@digi.com>