### PR TITLE
devices: add support for XBee statistics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v1.4.2 - XX/XX/202X
+
+* Support to retrieve XBee statistics.
+
+
 v1.4.1 - 12/22/2021
 -------------------
 

--- a/digi/xbee/comm_interface.py
+++ b/digi/xbee/comm_interface.py
@@ -1,4 +1,4 @@
-# Copyright 2019, 2020, Digi International Inc.
+# Copyright 2019-2022, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -135,6 +135,16 @@ class XBeeCommunicationInterface(metaclass=abc.ABCMeta):
                 hardware version (int), firmware version (int),
                 64-bit address (string), 16-bit address (string),
                 node identifier (string), and role (int).
+        """
+        return None
+
+    def get_stats(self):
+        """
+        Returns a statistics object.
+
+        Returns:
+             :class: `.Statistics`: `None` if not implemented,
+              otherwise a `Statistics` object.
         """
         return None
 

--- a/digi/xbee/models/statistics.py
+++ b/digi/xbee/models/statistics.py
@@ -1,0 +1,131 @@
+# Copyright 2022, Digi International Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import copy
+
+from digi.xbee.models.status import TransmitStatus, ATCommandStatus
+from digi.xbee.packets.aft import ApiFrameType
+from digi.xbee.packets.base import DictKeys
+
+
+class Statistics:
+    """
+    This class represents all available XBee statistics.
+    """
+
+    def __init__(self):
+        _dict = {}
+        for elem in ApiFrameType:
+            _dict[elem.name] = {}
+            _dict[elem.name]["pkts"] = 0
+            _dict[elem.name]["bytes"] = 0
+            _dict[elem.name]["errors"] = 0
+        self._tx_dict = copy.deepcopy(_dict)
+        self._rx_dict = copy.deepcopy(_dict)
+
+    def _update_rx_stats(self, rx_packet):
+        """
+        Increases the XBee statistics related with received packets.
+
+        Args:
+            rx_packet (:class: `.XBeeAPIPacket`): The received API packet.
+        """
+        _key = rx_packet.get_frame_type().name
+        if _key not in self._rx_dict.keys():
+            return
+
+        self._rx_dict[_key]["pkts"] += 1
+        self._rx_dict[_key]["bytes"] += rx_packet.effective_len
+
+        if _key in (ApiFrameType.TRANSMIT_STATUS.name, ApiFrameType.TX_STATUS.name):
+            tx_status = rx_packet._get_api_packet_spec_data_dict()[DictKeys.TS_STATUS]
+            if tx_status != TransmitStatus.SUCCESS:
+                self._rx_dict[_key]["errors"] += 1
+
+        if _key == ApiFrameType.REMOTE_AT_COMMAND_RESPONSE.name:
+            if rx_packet.status != ATCommandStatus.OK:
+                self._rx_dict[_key]["errors"] += 1
+
+    def _update_tx_stats(self, tx_packet):
+        """
+        Increments the XBee statistics related with transmitted packets.
+
+        Args:
+            tx_packet (:class: `.XBeeAPIPacket`): The sent API packet.
+        """
+        _key = tx_packet.get_frame_type().name
+        if _key in self._tx_dict.keys():
+            self._tx_dict[_key]["pkts"] += 1
+            self._tx_dict[_key]["bytes"] += tx_packet.effective_len
+
+    @property
+    def tx_packets(self):
+        """
+        Gets the current amount of TX packets.
+
+        Returns:
+            Integer: Number of TX packets.
+        """
+        return sum(self._tx_dict[item]["pkts"] for item in self._tx_dict)
+
+    @property
+    def rx_packets(self):
+        """
+        Gets the current amount of RX packets.
+
+        Returns:
+            Integer: Number of RX packets.
+        """
+        return sum(self._rx_dict[item]["pkts"] for item in self._rx_dict)
+
+    @property
+    def tx_bytes(self):
+        """
+        Gets the current amount of TX bytes.
+
+        Returns:
+            Integer: Number of TX bytes.
+        """
+        return sum(self._tx_dict[item]["bytes"] for item in self._tx_dict)
+
+    @property
+    def rx_bytes(self):
+        """
+        Gets the current amount of RX bytes.
+
+        Returns:
+            Integer: Number of RX bytes.
+        """
+        return sum(self._rx_dict[item]["bytes"] for item in self._rx_dict)
+
+    @property
+    def rmt_cmd_errors(self):
+        """
+        Gets the current amount of remote AT command errors.
+
+        Returns:
+            Integer: Number of remote AT command errors.
+        """
+        return self._rx_dict[ApiFrameType.REMOTE_AT_COMMAND_RESPONSE.name]["errors"]
+
+    @property
+    def tx_errors(self):
+        """
+        Gets the current amount of transmit errors.
+
+        Returns:
+            Integer: Number of transmit errors.
+        """
+        return (self._rx_dict[ApiFrameType.TRANSMIT_STATUS.name]["errors"] +
+                self._rx_dict[ApiFrameType.TX_STATUS.name]["errors"])

--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021, Digi International Inc.
+# Copyright 2017-2022, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -452,6 +452,16 @@ class XBeeAPIPacket(XBeePacket):
             Boolean: `True` if this packet is broadcast, `False` otherwise.
         """
         return False
+
+    @property
+    def effective_len(self):
+        """
+        Returns the effective length of the packet.
+
+        Returns:
+            Integer: Effective length of the packet.
+        """
+        return len(self)
 
     @property
     def frame_id(self):

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021, Digi International Inc.
+# Copyright 2017-2022, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -734,6 +734,16 @@ class ReceivePacket(XBeeAPIPacket):
                 DictKeys.RF_DATA:         list(self.__data) if self.__data is not None else None}
 
     @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2 - 8  # Remove 16-bit and 64-bit addresses
+
+    @property
     def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
@@ -978,6 +988,16 @@ class RemoteATCommandPacket(XBeeAPIPacket):
                 DictKeys.TRANSMIT_OPTIONS: self.__tx_opts,
                 DictKeys.COMMAND: self.__cmd,
                 DictKeys.PARAMETER: list(self.__param) if self.__param is not None else None}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2 - 8  # Remove 16-bit and 64-bit addresses
 
     @property
     def x64bit_dest_addr(self):
@@ -1252,6 +1272,16 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
                 DictKeys.COMMAND:       self.__cmd,
                 DictKeys.AT_CMD_STATUS: self.__resp_st,
                 DictKeys.RF_DATA:       list(self.__comm_val) if self.__comm_val is not None else None}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2 - 8  # Remove 16-bit and 64-bit addresses
 
     @property
     def command(self):
@@ -1564,6 +1594,16 @@ class TransmitPacket(XBeeAPIPacket):
                 DictKeys.RF_DATA:          list(self.__data) if self.__data is not None else None}
 
     @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2 - 8  # Remove 16-bit and 64-bit addresses
+
+    @property
     def rf_data(self):
         """
         Returns the RF data to send.
@@ -1820,6 +1860,16 @@ class TransmitStatusPacket(XBeeAPIPacket):
                 DictKeys.TRANS_R_COUNT: self.__tx_retry_count,
                 DictKeys.TS_STATUS: self.__tx_status,
                 DictKeys.DS_STATUS: self.__discovery_status}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2  # Remove 16-bit address
 
     @property
     def x16bit_dest_addr(self):
@@ -2204,6 +2254,16 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         return utils.is_bit_enabled(self.__rx_opts, 1)
 
     @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2 - 8  # Remove 16-bit and 64-bit addresses
+
+    @property
     def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
@@ -2538,6 +2598,18 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
                 DictKeys.BROADCAST_RADIUS: self.__broadcast_radius,
                 DictKeys.TRANSMIT_OPTIONS: self.__tx_opts,
                 DictKeys.RF_DATA:          self.__data}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        # Remove 16-bit and 64-bit addresses, the source and destination
+        # endpoints, the cluster ID and the profile ID.
+        return len(self) - 2 - 8 - 1 - 1 - 2 - 2
 
     @property
     def source_endpoint(self):
@@ -2913,6 +2985,18 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
                 DictKeys.PROFILE_ID:      self.__profile_id,
                 DictKeys.RECEIVE_OPTIONS: self.__rx_opts,
                 DictKeys.RF_DATA:         self.__data}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        # Remove 16-bit and 64-bit addresses, the source and destination
+        # endpoints, the cluster ID and the profile ID.
+        return len(self) - 2 - 8 - 1 - 1 - 2 - 2
 
     @property
     def x64bit_source_addr(self):

--- a/digi/xbee/packets/raw.py
+++ b/digi/xbee/packets/raw.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021, Digi International Inc.
+# Copyright 2017-2022, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -138,6 +138,16 @@ class TX64Packet(XBeeAPIPacket):
         return {DictKeys.X64BIT_ADDR:      self.__x64bit_addr.address,
                 DictKeys.TRANSMIT_OPTIONS: self.__tx_opts,
                 DictKeys.RF_DATA:          self.__data}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 8  # Remove 64-bit address
 
     @property
     def x64bit_dest_addr(self):
@@ -333,6 +343,16 @@ class TX16Packet(XBeeAPIPacket):
         return {DictKeys.X16BIT_ADDR:      self.__x16bit_addr,
                 DictKeys.TRANSMIT_OPTIONS: self.__tx_opts,
                 DictKeys.RF_DATA:          self.__data}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2  # Remove 16-bit address
 
     @property
     def x16bit_dest_addr(self):
@@ -675,6 +695,16 @@ class RX64Packet(XBeeAPIPacket):
                 DictKeys.RF_DATA:         self.__data}
 
     @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 8  # Remove 64-bit address
+
+    @property
     def x64bit_source_addr(self):
         """
         Returns the 64-bit source address.
@@ -900,6 +930,16 @@ class RX16Packet(XBeeAPIPacket):
                 DictKeys.RSSI:            self.__rssi,
                 DictKeys.RECEIVE_OPTIONS: self.__rx_opts,
                 DictKeys.RF_DATA:         self.__data}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2  # Remove 16-bit address
 
     @property
     def x16bit_source_addr(self):
@@ -1145,6 +1185,16 @@ class RX64IOPacket(XBeeAPIPacket):
             base[DictKeys.RF_DATA] = utils.hex_to_string(self.__data)
 
         return base
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 8  # Remove 64-bit address
 
     @property
     def x64bit_source_addr(self):
@@ -1423,6 +1473,16 @@ class RX16IOPacket(XBeeAPIPacket):
             base[DictKeys.RF_DATA] = utils.hex_to_string(self.__data)
 
         return base
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 2  # Remove 16-bit address
 
     @property
     def x16bit_source_addr(self):

--- a/digi/xbee/packets/wifi.py
+++ b/digi/xbee/packets/wifi.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021, Digi International Inc.
+# Copyright 2017-2022, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -174,6 +174,16 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
             base[DictKeys.RF_DATA] = utils.hex_to_string(self.__data)
 
         return base
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 8  # Remove 64-bit address
 
     @property
     def source_address(self):
@@ -446,6 +456,16 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
                 DictKeys.PARAMETER:        list(self.__param) if self.__param is not None else None}
 
     @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 8  # Destination address
+
+    @property
     def dest_address(self):
         """
         Returns the IPv4 address of the destination device.
@@ -671,6 +691,16 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
                 DictKeys.COMMAND:       self.__cmd,
                 DictKeys.AT_CMD_STATUS: self.__resp_status,
                 DictKeys.RF_DATA:       list(self.__comm_val) if self.__comm_val is not None else None}
+
+    @property
+    def effective_len(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.effective_len`
+        """
+        return len(self) - 8  # Remove source address
 
     @property
     def source_address(self):

--- a/digi/xbee/sender.py
+++ b/digi/xbee/sender.py
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, Digi International Inc.
+# Copyright 2020-2022, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -82,6 +82,9 @@ class PacketSender:
 
         comm_iface = self.__xbee.comm_iface
         op_mode = self.__xbee.operating_mode
+
+        if self.__xbee._serial_port:
+            self.__xbee._update_tx_stats(packet)
 
         out = packet.output(escaped=op_mode == OperatingMode.ESCAPED_API_MODE)
         comm_iface.write_frame(out)

--- a/doc/api/digi.xbee.models.statistics.rst
+++ b/doc/api/digi.xbee.models.statistics.rst
@@ -1,0 +1,7 @@
+digi\.xbee\.models\.statistics module
+=====================================
+
+.. automodule:: digi.xbee.models.statistics
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -25,6 +25,7 @@ Examples are split by categories:
 * :ref:`samplesFirmware`
 * :ref:`samplesFilesystem`
 * :ref:`samplesProfile`
+* :ref:`samplesStatistics`
 
 
 .. _samplesConfiguration:
@@ -163,6 +164,7 @@ You can locate the example in the following path:
 .. note::
    For more information about how to listen to network modifications, see
    :ref:`listenToNetworkCacheModifications`.
+
 
 .. _samplesCommunication:
 
@@ -803,3 +805,23 @@ file and prints all the accessible settings and properties.
 
 You can locate the example in the following path:
 **examples/profile/ReadXBeeProfileSample**
+
+
+.. _samplesStatistics:
+
+Statistics samples
+------------------
+
+Get XBee statistics sample
+``````````````````````````
+This sample application demonstrates how to get XBee statistics.
+
+The application sets and gets some local parameters. After that, it retrieves
+the XBee statistics.
+
+You can locate the example in the following path:
+**examples/statistics/GetXBeeStatisticsSample**
+
+.. note::
+   For more information about how to use the XBee statistics, see
+   :ref:`getXBeeStatistics`.

--- a/doc/user_doc/communicating_with_xbee_devices.rst
+++ b/doc/user_doc/communicating_with_xbee_devices.rst
@@ -2074,3 +2074,68 @@ the sequence ``bind()``, ``listen()``, ``accept()``.
 |                                                                                                                                                                                                                           |
 | **examples/communication/socket/SocketUDPServerClientSample**                                                                                                                                                             |
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. _getXBeeStatistics:
+
+Get XBee statistics
+-------------------
+
+XBee statistics are collected automatically when it receives or transmits data.
+These statistics are only available for the local XBee device, they are not
+available for remote nodes.
+
+You can access the statistics information of a local XBee using its ``stats``
+attribute, which returns a ``Statistics`` object:
+
++--------------+---------------------------------------------------------+
+| Attribute    | Description                                             |
++==============+=========================================================+
+| **stats**    | Attribute with XBee statistic, a ``Statistics`` object. |
++--------------+---------------------------------------------------------+
+
+Available statistics are attributes of the ``Statistics`` object:
+
++--------------------------------+--------------------+--------------------------------------------------+
+| Statistics                     | Attribute          | Description                                      |
++============+===================+====================+==================================================+
+| Transmit   | TX packets        | **tx_packets**     | Number of transmitted packets via serial         |
+|            +-------------------+--------------------+--------------------------------------------------+
+|            | TX bytes          | **tx_bytes**       | Number of effective transmitted bytes via serial |
++------------+-------------------+--------------------+--------------------------------------------------+
+| Receive    | RX packets        | **rx_packets**     | Number of received packets via serial            |
+|            +-------------------+--------------------+--------------------------------------------------+
+|            | RX bytes          | **rx_bytes**       | Number of effective received bytes via serial    |
++------------+-------------------+--------------------+--------------------------------------------------+
+| Errors     | Remote cmd errors | **rmt_cmd_errors** | Number of failed remote AT commands              |
+|            +-------------------+--------------------+--------------------------------------------------+
+|            | TX errors         | **tx_errors**      | Number of transmission errors                    |
++------------+-------------------+--------------------+--------------------------------------------------+
+
+**Get XBee statistics**
+
+.. code:: python
+
+  [...]
+
+  # Instantiate a local XBee object.
+  xbee = XBeeDevice("COM1", 9600)
+  xbee.open()
+
+  # Perform any action.
+  [...]
+
+  # Get and print XBee stats
+  print(xbee.stats.tx_packets)
+  print(xbee.stats.tx_bytes)
+  print(xbee.stats.rx_packets)
+  print(xbee.stats.rx_bytes)
+  print(xbee.stats.rmt_cmd_errors)
+  print(xbee.stats.tx_errors)
+
++--------------------------------------------------------------------------------------------------------------------------------------------+
+| Example: Get XBee statistics                                                                                                               |
++============================================================================================================================================+
+| The XBee Python Library includes a sample application that shows how to get XBee statistics. The example is located in the following path: |
+|                                                                                                                                            |
+| **examples/statistics/GetXBeeStatisticsSample**                                                                                            |
++--------------------------------------------------------------------------------------------------------------------------------------------+

--- a/examples/statistics/GetXBeeStatisticsSample/GetXBeeStatisticsSample.py
+++ b/examples/statistics/GetXBeeStatisticsSample/GetXBeeStatisticsSample.py
@@ -1,0 +1,75 @@
+# Copyright 2022, Digi International Inc.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from digi.xbee.devices import XBeeDevice
+from digi.xbee.util import utils
+
+# TODO: Replace with the serial port where your local module is connected to.
+PORT = "COM1"
+# TODO: Replace with the baud rate of your local module.
+BAUD_RATE = 9600
+
+PARAM_NODE_ID = "NI"
+PARAM_PAN_ID = "ID"
+PARAM_DEST_ADDRESS_H = "DH"
+PARAM_DEST_ADDRESS_L = "DL"
+
+PARAM_VALUE_NODE_ID = "Yoda"
+PARAM_VALUE_PAN_ID = utils.hex_string_to_bytes("1234")
+PARAM_VALUE_DEST_ADDRESS_H = utils.hex_string_to_bytes("00")
+PARAM_VALUE_DEST_ADDRESS_L = utils.hex_string_to_bytes("FFFF")
+
+
+def main():
+    print(" +------------------------------------------------+")
+    print(" | XBee Python Library Get XBee Statistics Sample |")
+    print(" +------------------------------------------------+\n")
+
+    device = XBeeDevice(PORT, BAUD_RATE)
+
+    try:
+        device.open()
+
+        # Set parameters.
+        device.set_parameter(PARAM_NODE_ID, bytearray(PARAM_VALUE_NODE_ID, 'utf8'))
+        device.set_parameter(PARAM_PAN_ID, PARAM_VALUE_PAN_ID)
+        device.set_parameter(PARAM_DEST_ADDRESS_H, PARAM_VALUE_DEST_ADDRESS_H)
+        device.set_parameter(PARAM_DEST_ADDRESS_L, PARAM_VALUE_DEST_ADDRESS_L)
+
+        # Get parameters.
+        print("Node ID:                     %s" % device.get_parameter(PARAM_NODE_ID).decode())
+        print("PAN ID:                      %s" % utils.hex_to_string(device.get_parameter(PARAM_PAN_ID)))
+        print("Destination address high:    %s" % utils.hex_to_string(device.get_parameter(PARAM_DEST_ADDRESS_H)))
+        print("Destination address low:     %s" % utils.hex_to_string(device.get_parameter(PARAM_DEST_ADDRESS_L)))
+
+        print("")
+        print("All parameters were set correctly!")
+
+        print("Showing XBee statistics")
+        print("    RX: packets=%d, bytes=%d" % (device.stats.rx_packets,
+                                                device.stats.rx_bytes))
+        print("    TX: packets=%d, bytes=%d" % (device.stats.tx_packets,
+                                                device.stats.tx_bytes))
+        print("Showing network errors")
+        print("    Remote AT commands errors=%d" % device.stats.rmt_cmd_errors)
+        print("    TX errors=%d" % device.stats.tx_errors)
+        print("All XBee statistics displayed!")
+
+    finally:
+        if device is not None and device.is_open():
+            device.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/statistics/GetXBeeStatisticsSample/readme.txt
+++ b/examples/statistics/GetXBeeStatisticsSample/readme.txt
@@ -1,0 +1,66 @@
+  Introduction
+  ------------
+  This sample Python application shows how to get XBee statistics using
+  the XBee Python Library.
+
+  The application sets the value of four parameters with different value types:
+  string, byte array and integer. Then it reads them from the device to verify
+  that the read values are the same as the values that were set. After that, it
+  gets the current XBee statistics.
+
+  NOTE: This example uses the generic XBee device (XBeeDevice) class,
+        but it can be applied to any other local XBee device class.
+
+  Requirements
+  ------------
+  To run this example you will need:
+
+    * One XBee radio in API mode and its corresponding carrier board (XBIB
+      or XBee Development Board).
+    * The XCTU application (available at www.digi.com/xctu).
+
+
+  Compatible protocols
+  --------------------
+    * 802.15.4
+    * DigiMesh
+    * Point-to-Multipoint
+    * Zigbee
+
+
+  Example setup
+  -------------
+    1) Plug the XBee radio into the XBee adapter and connect it to your
+       computer's USB or serial port.
+
+    2) Ensure that the module is in API mode.
+       For further information on how to perform this task, read the
+       'Configuring Your XBee Modules' topic of the Getting Started guide.
+
+    3) Set the port and baud rate of the XBee radio in the sample file class.
+       If you configured the module in the previous step with the XCTU, you
+       will see the port number and baud rate in the 'Port' label of the device
+       on the left view.
+
+
+  Running the example
+  -------------------
+  First, build and launch the application. To test the functionality, check
+  that the output console displays the parameters set and then states the
+  following message:
+
+    "All parameters were set correctly!"
+
+  That message indicates that all the parameters could be set and their read
+  values are the same as the values that were set.
+  Next, the XBee statistics are read and the next message appers:
+
+      "All XBee Statistics displayed!"
+
+  That message indicates that all XBee statistics were displayed. The statistics
+  shown are:
+      * RX info: Number of receive packets and bytes.
+      * TX info: Number of transmitted packets and bytes.
+      * Remote AT command errors: Number of packets of remote AT commands
+        that failed.
+      * TX numbers: Number of packets which transmission failed.


### PR DESCRIPTION
Initial support to report basic XBee statistics:
 * TX/RX packets
 * TX/RX Bytes
 * Remote AT command errors
 * TX errors

This commit also updates the documentation and adds a basic example.

Signed-off-by: Isaac Hermida <isaac.hermida@digi.com>