### PR TITLE
zigbee: source route: reverse hops order for a 'Create Source Route' packet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Changelog
 =========
 
 v1.4.2 - XX/XX/202X
+-------------------
 
 * Support for new hardware variants:
 
@@ -10,7 +11,9 @@ v1.4.2 - XX/XX/202X
 * Support to retrieve XBee statistics.
 * Send/receive explicit data in 802.15.4.
   (XBee 3 modules support this feature)
+* Bug fixing:
 
+  * Fix order of nodes when creating a Zigbee source route (#278)
 
 v1.4.1 - 12/22/2021
 -------------------

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -5901,6 +5901,9 @@ class ZigBeeDevice(XBeeDevice):
                         dest_node, dest_node.get_local_xbee_device(),
                         " >>> " if hops else "", " >>> ".join(map(str, hops)),
                         dest_node, len(hops) + 1)
+        # Reverse addresses to create the packet:
+        # from closest to destination to closest to source
+        addresses.reverse()
         self.send_packet(
             CreateSourceRoutePacket(0x00, x64, x16, route_options=0, hops=addresses), sync=False)
 


### PR DESCRIPTION
'Create Source Route' packet (0x21) must include the hops to a destination node
from closest node to destination to closest neighbor to source. See:

https://www.digi.com/resources/documentation/digidocs/90001539/#reference/r_frame_0x21.htm

https://github.com/digidotcom/xbee-python/issues/278