### PR TITLE
hardware: add new versions to the supported hardware list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ v1.4.2 - XX/XX/202X
 
   * XBee 3 Cellular Global LTE Cat 1
   * XBee 3 Cellular North America LTE Cat 1
+  * XBee 3 Cellular LTE-M/NB-IoT Low Power
+  * XBee RR TH Pro/Non-Pro
 * Support to retrieve XBee statistics.
 * Send/receive explicit data in 802.15.4.
   (XBee 3 modules support this feature)

--- a/digi/xbee/filesystem.py
+++ b/digi/xbee/filesystem.py
@@ -86,7 +86,8 @@ REMOTE_SUPPORTED_HW_VERSIONS = (HardwareVersion.XBEE3.code,
                                 HardwareVersion.XBEE3_SMT.code,
                                 HardwareVersion.XBEE3_TH.code)
 LOCAL_SUPPORTED_HW_VERSIONS = REMOTE_SUPPORTED_HW_VERSIONS \
-                              + (HardwareVersion.XBEE3_RR.code,)
+                              + (HardwareVersion.XBEE3_RR.code,
+                                 HardwareVersion.XBEE3_RR_TH.code)
 
 # Update this value when File System API frames are supported
 XB3_MIN_FW_VERSION_FS_API_SUPPORT = {

--- a/digi/xbee/firmware.py
+++ b/digi/xbee/firmware.py
@@ -80,11 +80,13 @@ _PATTERN_GECKO_BOOTLOADER_VERSION = \
     "^.*Gecko Bootloader v([0-9a-fA-F]{1,}\\.[0-9a-fA-F]{1,}\\.[0-9a-fA-F]{1,}).*$"
 
 _XBEE3_BL_DEF_PREFIX = "xb3-boot-rf_"
+_XBEE3_RR_BL_DEF_PREFIX = "xb3-boot-rr_"
 _XBEE3_BOOTLOADER_FILE_PREFIX = {
     HardwareVersion.XBEE3.code: _XBEE3_BL_DEF_PREFIX,
     HardwareVersion.XBEE3_SMT.code: _XBEE3_BL_DEF_PREFIX,
     HardwareVersion.XBEE3_TH.code: _XBEE3_BL_DEF_PREFIX,
-    HardwareVersion.XBEE3_RR.code: "xb3-boot-rr_"
+    HardwareVersion.XBEE3_RR.code: _XBEE3_RR_BL_DEF_PREFIX,
+    HardwareVersion.XBEE3_RR_TH.code: _XBEE3_RR_BL_DEF_PREFIX
 }
 
 _GEN3_BOOTLOADER_ERROR_CHECKSUM = 0x12
@@ -296,7 +298,8 @@ SX_HW_VERSIONS = (HardwareVersion.SX.code,
 XBEE3_HW_VERSIONS = (HardwareVersion.XBEE3.code,
                      HardwareVersion.XBEE3_SMT.code,
                      HardwareVersion.XBEE3_TH.code,
-                     HardwareVersion.XBEE3_RR.code)
+                     HardwareVersion.XBEE3_RR.code,
+                     HardwareVersion.XBEE3_RR_TH.code)
 
 LOCAL_SUPPORTED_HW_VERSIONS = SX_HW_VERSIONS + XBEE3_HW_VERSIONS
 REMOTE_SUPPORTED_HW_VERSIONS = SX_HW_VERSIONS + XBEE3_HW_VERSIONS + S2C_HW_VERSIONS

--- a/digi/xbee/models/hw.py
+++ b/digi/xbee/models/hw.py
@@ -96,10 +96,12 @@ class HardwareVersion(Enum):
     CELLULAR_3_LTE_M_TELIT = (0x4E, "XBee 3 Cellular LTE-M/NB-IoT (Telit)")
     XBEE3_DM_LR = (0x50, "XB3-DMLR")
     XBEE3_DM_LR_868 = (0x51, "XB3-DMLR868")
-    XBEE3_RR = (0x52, "XBee 3 Reduced RAM")
+    XBEE3_RR = (0x52, "XBee RR SMT/MMT, Pro/Non-Pro")
     S2C_P5 = (0x53, "S2C P5")
     CELLULAR_3_GLOBAL_LTE_CAT1 = (0x54, "XBee 3 Cellular Global LTE Cat 1")
     CELLULAR_3_NA_LTE_CAT1 = (0x55, "XBee 3 Cellular North America LTE Cat 1")
+    CELLULAR_3_LTE_M_LOW_POWER = (0x56, "XBee 3 Cellular LTE-M/NB-IoT Low Power")
+    XBEE3_RR_TH = (0x57, "XBee RR TH Pro/Non-Pro")
 
     def __init__(self, code, description):
         self.__code = code

--- a/digi/xbee/models/protocol.py
+++ b/digi/xbee/models/protocol.py
@@ -259,7 +259,8 @@ class XBeeProtocol(Enum):
                           HardwareVersion.CELLULAR_3_CAT1_LTE_VERIZON.code,
                           HardwareVersion.CELLULAR_3_LTE_M_TELIT.code,
                           HardwareVersion.CELLULAR_3_GLOBAL_LTE_CAT1.code,
-                          HardwareVersion.CELLULAR_3_NA_LTE_CAT1.code):
+                          HardwareVersion.CELLULAR_3_NA_LTE_CAT1.code,
+                          HardwareVersion.CELLULAR_3_LTE_M_LOW_POWER.code):
             return XBeeProtocol.CELLULAR
 
         if hw_version == HardwareVersion.CELLULAR_NBIOT_EUROPE.code:
@@ -268,7 +269,8 @@ class XBeeProtocol(Enum):
         if hw_version in (HardwareVersion.XBEE3.code,
                           HardwareVersion.XBEE3_SMT.code,
                           HardwareVersion.XBEE3_TH.code,
-                          HardwareVersion.XBEE3_RR.code):
+                          HardwareVersion.XBEE3_RR.code,
+                          HardwareVersion.XBEE3_RR_TH.code):
             if fw_version.startswith("2"):
                 return XBeeProtocol.RAW_802_15_4
             if fw_version.startswith("3"):

--- a/digi/xbee/recovery.py
+++ b/digi/xbee/recovery.py
@@ -31,7 +31,8 @@ from digi.xbee.util import utils
 SUPPORTED_HARDWARE_VERSIONS = (HardwareVersion.XBEE3.code,
                                HardwareVersion.XBEE3_SMT.code,
                                HardwareVersion.XBEE3_TH.code,
-                               HardwareVersion.XBEE3_RR.code)
+                               HardwareVersion.XBEE3_RR.code,
+                               HardwareVersion.XBEE3_RR_TH.code)
 
 _BAUDRATE_KEY = "baudrate"
 _PARITY_KEY = "parity"


### PR DESCRIPTION
- 0x56: XBee 3 Cellular LTE-M/NB-IoT Low Power
- 0x57: XBee RR TH Pro/Non-Pro

https://onedigi.atlassian.net/browse/XBPL-384
https://onedigi.atlassian.net/browse/XBPL-385

Signed-off-by: Ruben Moral <ruben.moral@digi.com>