### PR TITLE
hardware: add new versions to the supported hardware list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ v1.4.2 - XX/XX/202X
   * XBee 3 Cellular North America LTE Cat 1
   * XBee 3 Cellular LTE-M/NB-IoT Low Power
   * XBee RR TH Pro/Non-Pro
+  * XBee 3 Cellular Global Cat 4
+  * XBee 3 Cellular North America Cat 4
+  * XBee XR 900 TH
+  * XBee XR 868 TH
 * Support to retrieve XBee statistics.
 * Send/receive explicit data in 802.15.4.
   (XBee 3 modules support this feature)

--- a/digi/xbee/firmware.py
+++ b/digi/xbee/firmware.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021, Digi International Inc.
+# Copyright 2019-2023, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -299,7 +299,11 @@ XBEE3_HW_VERSIONS = (HardwareVersion.XBEE3.code,
                      HardwareVersion.XBEE3_SMT.code,
                      HardwareVersion.XBEE3_TH.code,
                      HardwareVersion.XBEE3_RR.code,
-                     HardwareVersion.XBEE3_RR_TH.code)
+                     HardwareVersion.XBEE3_RR_TH.code,
+                     HardwareVersion.XBEE3_DM_LR.code,
+                     HardwareVersion.XBEE3_DM_LR_868.code,
+                     HardwareVersion.XBEE_XR_900_TH.code,
+                     HardwareVersion.XBEE_XR_868_TH.code)
 
 LOCAL_SUPPORTED_HW_VERSIONS = SX_HW_VERSIONS + XBEE3_HW_VERSIONS
 REMOTE_SUPPORTED_HW_VERSIONS = SX_HW_VERSIONS + XBEE3_HW_VERSIONS + S2C_HW_VERSIONS

--- a/digi/xbee/models/hw.py
+++ b/digi/xbee/models/hw.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022, Digi International Inc.
+# Copyright 2017-2023, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -94,14 +94,18 @@ class HardwareVersion(Enum):
     CELLULAR_3_LTE_M_ATT = (0x4B, "XBee Cellular 3 LTE-M AT&T")
     CELLULAR_3_CAT1_LTE_VERIZON = (0x4D, "XBee Cellular 3 Cat 1 LTE Verizon")
     CELLULAR_3_LTE_M_TELIT = (0x4E, "XBee 3 Cellular LTE-M/NB-IoT (Telit)")
-    XBEE3_DM_LR = (0x50, "XB3-DMLR")
-    XBEE3_DM_LR_868 = (0x51, "XB3-DMLR868")
+    XBEE3_DM_LR = (0x50, "XBee XR 900")
+    XBEE3_DM_LR_868 = (0x51, "XBee XR 868")
     XBEE3_RR = (0x52, "XBee RR SMT/MMT, Pro/Non-Pro")
     S2C_P5 = (0x53, "S2C P5")
     CELLULAR_3_GLOBAL_LTE_CAT1 = (0x54, "XBee 3 Cellular Global LTE Cat 1")
     CELLULAR_3_NA_LTE_CAT1 = (0x55, "XBee 3 Cellular North America LTE Cat 1")
     CELLULAR_3_LTE_M_LOW_POWER = (0x56, "XBee 3 Cellular LTE-M/NB-IoT Low Power")
     XBEE3_RR_TH = (0x57, "XBee RR TH Pro/Non-Pro")
+    CELLULAR_3_GLOBAL_CAT4 = (0x58, "XBee 3 Cellular Global Cat 4")
+    CELLULAR_3_NA_CAT4 = (0x59, "XBee 3 Cellular North America Cat 4")
+    XBEE_XR_900_TH = (0x5A, "XBee XR 900 TH")
+    XBEE_XR_868_TH = (0x5B, "XBee XR 868 TH")
 
     def __init__(self, code, description):
         self.__code = code

--- a/digi/xbee/models/protocol.py
+++ b/digi/xbee/models/protocol.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022, Digi International Inc.
+# Copyright 2017-2023, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -260,7 +260,9 @@ class XBeeProtocol(Enum):
                           HardwareVersion.CELLULAR_3_LTE_M_TELIT.code,
                           HardwareVersion.CELLULAR_3_GLOBAL_LTE_CAT1.code,
                           HardwareVersion.CELLULAR_3_NA_LTE_CAT1.code,
-                          HardwareVersion.CELLULAR_3_LTE_M_LOW_POWER.code):
+                          HardwareVersion.CELLULAR_3_LTE_M_LOW_POWER.code,
+                          HardwareVersion.CELLULAR_3_GLOBAL_CAT4.code,
+                          HardwareVersion.CELLULAR_3_NA_CAT4.code):
             return XBeeProtocol.CELLULAR
 
         if hw_version == HardwareVersion.CELLULAR_NBIOT_EUROPE.code:
@@ -282,7 +284,9 @@ class XBeeProtocol(Enum):
                     if br_value != 0 else XBeeProtocol.DIGI_POINT)
 
         if hw_version in (HardwareVersion.XBEE3_DM_LR.code,
-                          HardwareVersion.XBEE3_DM_LR_868.code):
+                          HardwareVersion.XBEE3_DM_LR_868.code,
+                          HardwareVersion.XBEE_XR_900_TH.code,
+                          HardwareVersion.XBEE_XR_868_TH.code):
             return XBeeProtocol.DIGI_MESH
 
         if hw_version == HardwareVersion.S2C_P5.code:

--- a/digi/xbee/recovery.py
+++ b/digi/xbee/recovery.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021, Digi International Inc.
+# Copyright 2019-2023, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -32,7 +32,11 @@ SUPPORTED_HARDWARE_VERSIONS = (HardwareVersion.XBEE3.code,
                                HardwareVersion.XBEE3_SMT.code,
                                HardwareVersion.XBEE3_TH.code,
                                HardwareVersion.XBEE3_RR.code,
-                               HardwareVersion.XBEE3_RR_TH.code)
+                               HardwareVersion.XBEE3_RR_TH.code,
+                               HardwareVersion.XBEE3_DM_LR.code,
+                               HardwareVersion.XBEE3_DM_LR_868.code,
+                               HardwareVersion.XBEE_XR_900_TH.code,
+                               HardwareVersion.XBEE_XR_868_TH.code)
 
 _BAUDRATE_KEY = "baudrate"
 _PARITY_KEY = "parity"


### PR DESCRIPTION
- 0x58: XBee 3 Cellular Global Cat 4
- 0x59: XBee 3 Cellular North America Cat 4
- 0x5A: XBee XR 900 TH
- 0x5B: XBee XR 868 TH

https://onedigi.atlassian.net/browse/XBPL-386