### PR TITLE
Add support for the new XBee BLU device/product.

### DIFF
--- a/digi/xbee/ble.py
+++ b/digi/xbee/ble.py
@@ -1,0 +1,216 @@
+# Copyright 2024, Digi International Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from digi.xbee.packets.bluetooth import BluetoothGAPScanRequestPacket
+from digi.xbee.models.status import BLEGAPScanStatus
+
+
+class BLEManager:
+    """
+    Helper class used to manage the BLE Interface on the XBee.
+
+    NOTE: For more information about Shortened and Local Names
+    when running a GAP scan, see:
+    `<https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Assigned_Numbers/out/en/Assigned_Numbers.pdf?v=1707939725200`_.
+    """
+
+    GAP_SCAN_DURATION_INDEFINITELY = BluetoothGAPScanRequestPacket.INDEFINITE_SCAN_DURATION
+    """
+    Value to have the GAP scan run indefinitely
+    """
+
+    def __init__(self, xbee):
+        """
+        Class constructor. Instantiates a new :class:`.BLEManager` with
+        the given parameters.
+
+        Args:
+            xbee (:class:`.AbstractXBeeDevice`): XBee to manage its
+                                                 BLE interface.
+        """
+        from digi.xbee.devices import AbstractXBeeDevice
+        if not isinstance(xbee, AbstractXBeeDevice):
+            raise ValueError("XBee must be an XBee class")
+
+        self.__xbee = xbee
+        self.__listening_for_status_events = False
+        self.__gap_scan_status = None
+
+    def __str__(self):
+        return "BLE (%s)" % self.__xbee
+
+    def __status_callback(self, data):
+        """
+        Internal BLE GAP scan status Callback
+
+        This function will get called whenever the GAP scanning status
+        has changed.
+        """
+        self.__gap_scan_status = data.status
+
+    def open(self):
+        """
+        Opens the communication with the BLE Manager.
+
+        This method guarantees that all callbacks are started.
+        """
+        if not self.__listening_for_status_events:
+            self.__xbee._packet_listener.add_ble_gap_scan_status_received_callback(
+                                         self.__status_callback)
+            self.__listening_for_status_events = True
+
+    def close(self):
+        """
+        Closes the communication with the BLE Manager.
+
+        This method guarantees that all callbacks are stopped/deleted.
+        """
+        if self.__status_callback in self.__xbee._packet_listener.get_ble_gap_scan_status_received_callbacks():
+            self.__xbee._packet_listener.del_ble_gap_scan_status_received_callback(self.__status_callback)
+            self.__listening_for_status_events = False
+
+    @property
+    def xbee(self):
+        """
+        Returns the XBee of this BLE manager.
+
+        Returns:
+            :class:`.AbstractXBeeDevice`: XBee to manage its BLE interface.
+        """
+        return self.__xbee
+
+    def start_ble_gap_scan(self, duration, window, interval, enable_filter,
+                           custom_filter):
+        """
+        Starts a Bluetooth BLE GAP Scan request
+
+        Args:
+            duration (Integer): Scan Duration
+                                The Scan Duration parameter defines how long
+                                the scan should run.
+                                Scan duration should be between
+                                0 - 65535 (x 1s) (18.20 hr.)
+                                If the scan is set to 0 the scan will run
+                                indefinitely.
+
+            window (Integer): Scan Window
+                              The Scan Window parameter defines how long to
+                              scan at each interval.
+                              The range is from 2500 – 40959375 (x 1 us)
+                              (41 seconds)
+                              The window cannot be bigger than the
+                              scan interval.
+
+            interval (Integer): Scan Interval
+                              The Scan Interval parameter is the duration of
+                              time between two consecutive times that the
+                              scanner wakes up to receive the advertising messages.
+                              The range is from 2500 – 40959375 (x 1 us)
+                              (41 seconds)
+                              The Interval cannot be smaller than the
+                              scan window
+
+            enable_filter (Bool): Filter Type
+                                Supported Filter Types:
+                                False = Filter Disabled
+                                True = Filter advertisements containing the
+                                Shortened or Complete Local Name.
+
+            custom_filter (bytes): Filter (optional)
+                                   When the 'enable_filter' option is enabled,
+                                   the scan will filter the results returned
+                                   by matching the filter against the Shortened
+                                   or Complete Local Name.
+                                   Only items that match will be returned.
+                                   The range for the Filter is from 0-22 bytes
+                                   In other words, it can only accept up to
+                                   22 characters.
+
+        Returns:
+            :class:`.XBeePacket`: Received response packet.
+
+        Raises:
+            InvalidOperatingModeException: If the XBee's operating mode is not
+                API or ESCAPED API. This method only checks the cached value of
+                the operating mode.
+            TimeoutException: If response is not received in the configured
+                timeout.
+            XBeeException: If the XBee's communication interface is closed.
+
+        .. seealso::
+           | :class:`.XBeePacket`
+        """
+        # Ensure we are always listening for status events
+        if not self.__listening_for_status_events:
+            self.open()
+
+        packet = BluetoothGAPScanRequestPacket(BluetoothGAPScanRequestPacket.START_SCAN,
+                                               duration, window, interval,
+                                               enable_filter, custom_filter)
+        return self.__xbee.send_packet_sync_and_get_response(packet)
+
+    def stop_ble_gap_scan(self):
+        """
+        Stops a Bluetooth BLE GAP Scan request
+
+        Returns:
+            :class:`.XBeePacket`: Received response packet.
+
+        Raises:
+            InvalidOperatingModeException: If the XBee's operating mode is not
+                API or ESCAPED API. This method only checks the cached value of
+                the operating mode.
+            TimeoutException: If response is not received in the configured
+                timeout.
+            XBeeException: If the XBee's communication interface is closed.
+        """
+        packet = BluetoothGAPScanRequestPacket(BluetoothGAPScanRequestPacket.STOP_SCAN,
+                                               BluetoothGAPScanRequestPacket.INDEFINITE_SCAN_DURATION,
+                                               0x9C4, 0x9C4,
+                                               0x00, "")
+        return self.__xbee.send_packet_sync_and_get_response(packet)
+
+    def add_ble_gap_advertisement_received_callback(self, callback):
+        """
+        Adds a callback for the event :class:`.BLEGAPScanReceived`.
+
+        Args:
+            callback (Function): The callback. Receives one argument.
+
+                * The data received as a
+                      :class:`.BLEGAPScanLegacyAdvertisementMessage` or
+                      :class:`.BLEGAPScanExtendedAdvertisementMessage`
+        """
+        self.__xbee._packet_listener.add_ble_gap_advertisement_received_callback(callback)
+
+    def del_ble_gap_advertisement_received_callback(self, callback):
+        """
+        Deletes a callback for the callback list of
+        :class:`.BLEGAPScanReceived` event.
+
+        Args:
+            callback (Function): The callback to delete.
+        """
+        if callback in self.__xbee._packet_listener.get_ble_gap_scan_received_callbacks():
+            self.__xbee._packet_listener.del_ble_gap_advertisement_received_callback(callback)
+
+    def is_scan_running(self):
+        """
+        Returns whether a Bluetooth BLE GAP scan is currently running
+
+        Returns:
+            Boolean: `True` if scan is running, `False` otherwise.
+        """
+        return True if self.__gap_scan_status in (BLEGAPScanStatus.STARTED,
+                                                  BLEGAPScanStatus.RUNNING) else False

--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -32,9 +32,11 @@ from digi.xbee.models.hw import HardwareVersion
 from digi.xbee.models.mode import OperatingMode, APIOutputMode, \
     IPAddressingMode, NeighborDiscoveryMode, APIOutputModeBit
 from digi.xbee.models.address import XBee64BitAddress, XBee16BitAddress, \
-    XBeeIMEIAddress
+    XBeeIMEIAddress, XBeeBLEAddress
 from digi.xbee.models.info import SocketInfo
-from digi.xbee.models.message import XBeeMessage, ExplicitXBeeMessage, IPMessage
+from digi.xbee.models.message import XBeeMessage, ExplicitXBeeMessage, IPMessage, \
+    BLEGAPScanLegacyAdvertisementMessage, BLEGAPScanExtendedAdvertisementMessage, \
+    BLEGAPScanStatusMessage
 from digi.xbee.models.options import TransmitOptions, RemoteATCmdOptions, \
     DiscoveryOptions, XBeeLocalInterface, RegisterKeyOptions
 from digi.xbee.models.protocol import XBeeProtocol, IPProtocol, Role
@@ -51,6 +53,8 @@ from digi.xbee.packets.raw import TX64Packet, TX16Packet
 from digi.xbee.packets.relay import UserDataRelayPacket
 from digi.xbee.packets.zigbee import RegisterJoiningDevicePacket, \
     RegisterDeviceStatusPacket, CreateSourceRoutePacket
+from digi.xbee.packets.bluetooth import BluetoothGAPScanRequestPacket
+
 from digi.xbee.sender import PacketSender, SyncRequestSender
 from digi.xbee.util import utils
 from digi.xbee.exception import XBeeException, TimeoutException, \
@@ -1734,12 +1738,12 @@ class AbstractXBeeDevice:
     def get_bluetooth_mac_addr(self):
         """
         Reads and returns the EUI-48 Bluetooth MAC address of this XBee
-        following the format `00112233AABB`.
+        as a :class:`.XBeeBLEAddress`
 
         Note that your device must include Bluetooth Low Energy support.
 
         Returns:
-            String: The Bluetooth MAC address.
+            :class:`.XBeeBLEAddress`: The Bluetooth MAC address.
 
         Raises:
             TimeoutException: If response is not received before the read
@@ -3653,6 +3657,10 @@ class XBeeDevice(AbstractXBeeDevice):
             if self._packet_listener else None
         fs_frame_cbs = self._packet_listener.get_fs_frame_received_callbacks() \
             if self._packet_listener else None
+        ble_gap_scan_cbs = self._packet_listener.get_ble_gap_scan_received_callbacks() \
+            if self._packet_listener else None
+        ble_gap_scan_status_cbs = self._packet_listener.get_ble_gap_scan_status_received_callbacks() \
+            if self._packet_listener else None
 
         # Initialize the packet listener
         self._packet_listener = None
@@ -3679,6 +3687,8 @@ class XBeeDevice(AbstractXBeeDevice):
         self._packet_listener.add_route_record_received_callback(route_record_cbs)
         self._packet_listener.add_route_info_received_callback(route_info_cbs)
         self._packet_listener.add_fs_frame_received_callback(fs_frame_cbs)
+        self._packet_listener.add_ble_gap_advertisement_received_callback(ble_gap_scan_cbs)
+        self._packet_listener.add_ble_gap_scan_status_received_callback(ble_gap_scan_status_cbs)
 
         self._packet_listener.start()
         self._packet_listener.wait_until_started()
@@ -5904,6 +5914,353 @@ class ZigBeeDevice(XBeeDevice):
         addresses.reverse()
         self.send_packet(
             CreateSourceRoutePacket(0x00, x64, x16, route_options=0, hops=addresses), sync=False)
+
+
+class BluDevice(XBeeDevice):
+    """
+    This class represents a local Blu device.
+    """
+
+    __OPERATION_EXCEPTION = "Operation not supported in this module."
+
+    def __init__(self, port=None, baud_rate=None, data_bits=serial.EIGHTBITS,
+                 stop_bits=serial.STOPBITS_ONE, parity=serial.PARITY_NONE,
+                 flow_control=FlowControl.NONE,
+                 _sync_ops_timeout=AbstractXBeeDevice._DEFAULT_TIMEOUT_SYNC_OPERATIONS,
+                 comm_iface=None):
+        """
+        Class constructor. Instantiates a new :class:`.BluDevice` with the
+        provided parameters.
+
+        Args:
+            port (String): Serial port identifier. Depends on operating system.
+                e.g. '/dev/ttyUSB0' on 'GNU/Linux' or 'COM3' on Windows.
+            baud_rate (Integer): Serial port baud rate.
+            data_bits (Integer, default: :attr:`.serial.EIGHTBITS`): Port bitsize.
+            stop_bits (Integer, default: :attr:`.serial.STOPBITS_ONE`): Port stop bits.
+            parity (Character, default: :attr:`.serial.PARITY_NONE`): Port parity.
+            flow_control (Integer, default: :attr:`.FlowControl.NONE`): Port flow control.
+            _sync_ops_timeout (Integer, default: 3): Read timeout (in seconds).
+            comm_iface (:class:`.XBeeCommunicationInterface`): Communication interface.
+
+        Raises:
+            All exceptions raised by :meth:`.XBeeDevice.__init__` constructor.
+
+        .. seealso::
+           | :class:`.XBeeDevice`
+           | :meth:`.XBeeDevice.__init__`
+        """
+        super().__init__(port, baud_rate, data_bits=data_bits, stop_bits=stop_bits,
+                         parity=parity, flow_control=flow_control,
+                         _sync_ops_timeout=_sync_ops_timeout, comm_iface=comm_iface)
+
+        from digi.xbee.ble import BLEManager
+        self._ble_manager = BLEManager(self)
+
+    def open(self, force_settings=False):
+        """
+        Override.
+
+        .. seealso::
+           | :meth:`.XBeeDevice.open`
+        """
+        super().open(force_settings=force_settings)
+        if self._protocol not in (XBeeProtocol.BLE,):
+            self.close()
+            raise XBeeException(_ERROR_INCOMPATIBLE_PROTOCOL
+                                % (self.get_protocol(), XBeeProtocol.BLE))
+        self._ble_manager.open()
+
+    def close(self):
+        """
+        Override.
+
+        .. seealso::
+           | :meth:`.XBeeDevice.close`
+        """
+        self._ble_manager.close()
+        super().close()
+
+    def get_ble_manager(self):
+        """
+        Returns the BLE manager for the XBee.
+
+        Returns:
+             :class:`.BLEManager`: The BLE manager.
+
+        Raises:
+            FileSystemNotSupportedException: If the XBee does not support
+                filesystem.
+        """
+        if not self._ble_manager:
+            self._ble_manager = BLEManager(self)
+
+        return self._ble_manager
+
+    def get_protocol(self):
+        """
+        Override.
+
+        .. seealso::
+           | :meth:`.XBeeDevice.get_protocol`
+        """
+        if not self._protocol or self._protocol == XBeeProtocol.UNKNOWN:
+            return XBeeProtocol.BLE
+
+        return self._protocol
+
+    def get_network(self):
+        """
+        Deprecated.
+
+        This protocol does not support the network functionality.
+        """
+        return None
+
+    def _init_network(self):
+        """
+        Override.
+
+        .. seealso::
+           | :meth:`.XBeeDevice._init_network`
+        """
+        return None
+
+    def get_16bit_addr(self):
+        """
+        Deprecated.
+
+        This protocol does not have an associated 16-bit address.
+        """
+        return None
+
+    def get_dest_address(self):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol.
+        This method raises an :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def set_dest_address(self, addr):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol.
+        This method raises an :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def get_pan_id(self):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def set_pan_id(self, value):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def add_data_received_callback(self, callback):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def del_data_received_callback(self, callback):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def add_expl_data_received_callback(self, callback):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def del_expl_data_received_callback(self, callback):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def read_data(self, timeout=None):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def read_data_from(self, remote_xbee, timeout=None):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def send_data_broadcast(self, data, transmit_options=TransmitOptions.NONE.value):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def send_data(self, remote_xbee, data, transmit_options=TransmitOptions.NONE.value):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def send_data_async(self, remote_xbee, data, transmit_options=TransmitOptions.NONE.value):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def read_expl_data(self, timeout=None):
+        """
+        Override.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def read_expl_data_from(self, remote_xbee, timeout=None):
+        """
+        Override.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def send_expl_data(self, remote_xbee, data, src_endpoint, dest_endpoint,
+                       cluster_id, profile_id, transmit_options=TransmitOptions.NONE.value):
+        """
+        Override.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def send_expl_data_broadcast(self, data, src_endpoint, dest_endpoint, cluster_id,
+                                 profile_id, transmit_options=TransmitOptions.NONE.value):
+        """
+        Override.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def send_expl_data_async(self, remote_xbee, data, src_endpoint, dest_endpoint,
+                             cluster_id, profile_id, transmit_options=TransmitOptions.NONE.value):
+        """
+        Override.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def add_io_sample_received_callback(self, callback):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def del_io_sample_received_callback(self, callback):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def set_dio_change_detection(self, io_lines_set):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def get_io_sampling_rate(self):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def set_io_sampling_rate(self, rate):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def get_power_level(self):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
+
+    def set_power_level(self, power_level):
+        """
+        Deprecated.
+
+        Operation not supported in this protocol. This method raises an
+        :class:`.AttributeError`.
+        """
+        raise AttributeError(self.__OPERATION_EXCEPTION)
 
 
 class IPDevice(XBeeDevice):

--- a/digi/xbee/filesystem.py
+++ b/digi/xbee/filesystem.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023, Digi International Inc.
+# Copyright 2019-2024, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -87,7 +87,9 @@ REMOTE_SUPPORTED_HW_VERSIONS = (HardwareVersion.XBEE3.code,
                                 HardwareVersion.XBEE3_TH.code)
 LOCAL_SUPPORTED_HW_VERSIONS = REMOTE_SUPPORTED_HW_VERSIONS \
                               + (HardwareVersion.XBEE3_RR.code,
-                                 HardwareVersion.XBEE3_RR_TH.code)
+                                 HardwareVersion.XBEE3_RR_TH.code,
+                                 HardwareVersion.XBEE_BLU.code,
+                                 HardwareVersion.XBEE_BLU_TH.code)
 
 # Update this value when File System API frames are supported
 XB3_MIN_FW_VERSION_FS_API_SUPPORT = {

--- a/digi/xbee/firmware.py
+++ b/digi/xbee/firmware.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023, Digi International Inc.
+# Copyright 2019-2024, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -92,6 +92,8 @@ _XBEE3_BOOTLOADER_FILE_PREFIX = {
     HardwareVersion.XBEE3_DM_LR_868.code: _XBEE3_XR_BL_DEF_PREFIX,
     HardwareVersion.XBEE_XR_900_TH.code: _XBEE3_XR_BL_DEF_PREFIX,
     HardwareVersion.XBEE_XR_868_TH.code: _XBEE3_XR_BL_DEF_PREFIX,
+    HardwareVersion.XBEE_BLU.code: _XBEE3_RR_BL_DEF_PREFIX,
+    HardwareVersion.XBEE_BLU_TH.code: _XBEE3_RR_BL_DEF_PREFIX
 }
 
 _GEN3_BOOTLOADER_ERROR_CHECKSUM = 0x12
@@ -302,7 +304,9 @@ XBEE3_HW_VERSIONS = (HardwareVersion.XBEE3.code,
                      HardwareVersion.XBEE3_SMT.code,
                      HardwareVersion.XBEE3_TH.code,
                      HardwareVersion.XBEE3_RR.code,
-                     HardwareVersion.XBEE3_RR_TH.code)
+                     HardwareVersion.XBEE3_RR_TH.code,
+                     HardwareVersion.XBEE_BLU.code,
+                     HardwareVersion.XBEE_BLU_TH.code)
 
 XR_HW_VERSIONS = (HardwareVersion.XBEE3_DM_LR.code,
                   HardwareVersion.XBEE3_DM_LR_868.code,

--- a/digi/xbee/models/hw.py
+++ b/digi/xbee/models/hw.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023, Digi International Inc.
+# Copyright 2017-2024, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -106,6 +106,8 @@ class HardwareVersion(Enum):
     CELLULAR_3_NA_CAT4 = (0x59, "XBee 3 Cellular North America Cat 4")
     XBEE_XR_900_TH = (0x5A, "XBee XR 900 TH")
     XBEE_XR_868_TH = (0x5B, "XBee XR 868 TH")
+    XBEE_BLU = (0x5C, "XBee BLU")
+    XBEE_BLU_TH = (0x5D, "XBee BLU TH")
 
     def __init__(self, code, description):
         self.__code = code

--- a/digi/xbee/models/protocol.py
+++ b/digi/xbee/models/protocol.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023, Digi International Inc.
+# Copyright 2017-2024, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -45,6 +45,7 @@ class XBeeProtocol(Enum):
     XLR_MODULE = (14, "XLR Module")
     CELLULAR = (15, "Cellular")
     CELLULAR_NBIOT = (16, "Cellular NB-IoT")
+    BLE = (17, "BLE")
     UNKNOWN = (99, "Unknown")
 
     def __init__(self, code, description):
@@ -295,6 +296,10 @@ class XBeeProtocol(Enum):
             if fw_version.startswith("B"):
                 return XBeeProtocol.DIGI_MESH
             return XBeeProtocol.ZIGBEE
+
+        if hw_version in (HardwareVersion.XBEE_BLU.code,
+                          HardwareVersion.XBEE_BLU_TH.code):
+            return XBeeProtocol.BLE
 
         return XBeeProtocol.ZIGBEE
 

--- a/digi/xbee/models/status.py
+++ b/digi/xbee/models/status.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021, Digi International Inc.
+# Copyright 2017-2024, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -1351,3 +1351,123 @@ class UpdateProgressStatus:
                 `False` otherwise.
         """
         return self.__finished
+
+
+@unique
+class BLEMACAddressType(Enum):
+    """
+    This class lists all the possible types of BLE Mac Addresses.
+
+    | Inherited properties:
+    |     **name** (String): The name of the BLEMACAddressType.
+    |     **value** (Integer): The ID of the BLEMACAddressType.
+    """
+    PUBLIC = (0x00, "Public")
+    STATIC = (0x01, "Static")
+    RANDOM_RESOLVABLE = (0x02, "Random Resolvable")
+    RANDOM_NONRESOLVABLE = (0x03, "Random Nonresolvable")
+    UNKNOWN = (0xFF, "Unknown")
+
+    def __init__(self, code, description):
+        self.__code = code
+        self.__desc = description
+
+    @property
+    def code(self):
+        """
+        Returns the code of the BLEMACAddressType element.
+
+        Returns:
+            Integer: the code of the BLEMACAddressType element.
+        """
+        return self.__code
+
+    @property
+    def description(self):
+        """
+        Returns the description of the BLEMACAddressType element.
+
+        Returns:
+            String: The description of the BLEMACAddressType element.
+
+        """
+        return self.__desc
+
+    @classmethod
+    def get(cls, code):
+        """
+        Returns the address type for the given code.
+
+        Args:
+            code (Integer): the code of the address type to get.
+
+        Returns:
+            :class:`.BLEMACAddressType`: the address type with the given code.
+        """
+        for addr_type in cls:
+            if code == addr_type.code:
+                return addr_type
+        return BLEMACAddressType.UNKNOWN
+
+
+BLEMACAddressType.__doc__ += utils.doc_enum(BLEMACAddressType)
+
+
+@unique
+class BLEGAPScanStatus(Enum):
+    """
+    This class lists all the possible statuses of a BLE GAP scan
+
+    | Inherited properties:
+    |     **name** (String): The name of the BLEGAPScanStatus.
+    |     **value** (Integer): The ID of the BLEGAPScanStatus.
+    """
+    STARTED = (0x00, "Scanner has started")
+    RUNNING = (0x01, "Scanner is running")
+    STOPPED = (0x02, "Scanner has stopped")
+    ERROR = (0x03, "Scanner was unable to start or stop")
+    INVALID_PARAM = (0x04, "Invalid Parameters")
+
+    def __init__(self, code, description):
+        self.__code = code
+        self.__desc = description
+
+    @property
+    def code(self):
+        """
+        Returns the code of the BLEGAPScanStatus element.
+
+        Returns:
+            Integer: the code of the BLEGAPScanStatus element.
+        """
+        return self.__code
+
+    @property
+    def description(self):
+        """
+        Returns the description of the BLEGAPScanStatus element.
+
+        Returns:
+            String: The description of the BLEGAPScanStatus element.
+
+        """
+        return self.__desc
+
+    @classmethod
+    def get(cls, code):
+        """
+        Returns the address type for the given code.
+
+        Args:
+            code (Integer): the code of the gap scan status.
+
+        Returns:
+            :class:`.BLEGAPScanStatus`: the status type with the given code.
+        """
+        for status in cls:
+            if code == status.code:
+                return status
+        return BLEGAPScanStatus.ERROR
+
+
+BLEGAPScanStatus.__doc__ += utils.doc_enum(BLEGAPScanStatus)

--- a/digi/xbee/packets/aft.py
+++ b/digi/xbee/packets/aft.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020, Digi International Inc.
+# Copyright 2017-2024, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -43,6 +43,7 @@ class ApiFrameType(Enum):
     SEND_DATA_REQUEST = (0x28, "Send Data Request")
     DEVICE_RESPONSE = (0x2A, "Device Response")
     USER_DATA_RELAY_REQUEST = (0x2D, "User Data Relay Request")
+    BLUETOOTH_GAP_SCAN_REQUEST = (0x34, "Bluetooth GAP Scan Request")
     FILE_SYSTEM_REQUEST = (0x3B, "File System Request")
     REMOTE_FILE_SYSTEM_REQUEST = (0x3C, "Remote File System Request")
     SOCKET_CREATE = (0x40, "Socket Create")
@@ -75,6 +76,11 @@ class ApiFrameType(Enum):
     REGISTER_JOINING_DEVICE_STATUS = (0xA4, "Register Joining Device Status")
     USER_DATA_RELAY_OUTPUT = (0xAD, "User Data Relay Output")
     RX_IPV4 = (0xB0, "RX IPv4")
+    BLUETOOTH_GAP_SCAN_LEGACY_ADVERTISEMENT_RESPONSE = (
+        0xB4, "Bluetooth GAP Scan Legacy Advertisement Response")
+    BLUETOOTH_GAP_SCAN_EXTENDED_ADVERTISEMENT_RESPONSE = (
+        0xB7, "Bluetooth GAP Scan Extended Advertisement Response")
+    BLUETOOTH_GAP_SCAN_STATUS = (0xB5, "Bluetooth GAP Scan Status")
     SEND_DATA_RESPONSE = (0xB8, "Send Data Response")
     DEVICE_REQUEST = (0xB9, "Device Request")
     DEVICE_RESPONSE_STATUS = (0xBA, "Device Response Status")

--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022, Digi International Inc.
+# Copyright 2017-2024, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -35,6 +35,13 @@ class DictKeys(Enum):
     API_DATA = "api_spec_data"
     AT_CMD_STATUS = "at_command_status"
     BROADCAST_RADIUS = "broadcast_radius"
+    BLE_ADDRESS = "ble_address"
+    BLE_ADDRESS_TYPE = "ble_address_type"
+    BLE_ADVERTISEMENT_FLAGS = "advertisement_flags"
+    BLE_SCAN_FILTER_TYPE = "scan_filter_type"
+    BLE_SCAN_INTERVAL = "scan_interval"
+    BLE_SCAN_START = "scan_start"
+    BLE_SCAN_WINDOW = "scan_window"
     BLOCK_NUMBER = "block_number"
     BOOTLOADER_MSG_TYPE = "bootloader_msg_type"
     BYTES_USED = "bytes_used"

--- a/digi/xbee/packets/bluetooth.py
+++ b/digi/xbee/packets/bluetooth.py
@@ -1,0 +1,1220 @@
+# Copyright 2024, Digi International Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from digi.xbee.packets.base import XBeeAPIPacket, DictKeys
+from digi.xbee.exception import InvalidOperatingModeException, \
+                                InvalidPacketException
+from digi.xbee.packets.aft import ApiFrameType
+from digi.xbee.models.mode import OperatingMode
+from digi.xbee.util import utils
+from digi.xbee.models.address import XBeeBLEAddress
+
+
+class BluetoothGAPScanRequestPacket(XBeeAPIPacket):
+    """
+    This class represents a Bluetooth GAP scan request packet. Packet is built
+    using the parameters of the constructor or providing a valid byte array.
+
+    .. seealso::
+       | :class:`.BluetoothGAPScanRequestPacket`
+       | :class:`.XBeeAPIPacket`
+    """
+
+    # Various defines, max/mins
+    STOP_SCAN = 0x00
+    """
+    Constant value used to stop the scan
+    """
+    START_SCAN = 0x01
+    """
+    Constant value used to start the scan
+    """
+    INDEFINITE_SCAN_DURATION = 0x00
+    """
+    Constant value for an indefinite scan
+    """
+
+    # Internal only
+    __SCAN_DURATION_MINIMUM = 0x1
+    __SCAN_DURATION_MAXIMUM = 0xFFFF
+    __SCAN_WINDOW_MINIMUM = 0x9C4
+    __SCAN_WINDOW_MAXIMUM = 0x270FD8F
+    __SCAN_INTERVAL_MINIMUM = 0x9C4
+    __SCAN_INTERVAL_MAXIMUM = 0x270FD8F
+    __SCAN_FILTER_DISABLED = 0x00
+    __SCAN_FILTER_ENABLED = 0x01
+    __SCAN_CUSTOM_FILTER_MAXIMUM_LENGTH = 22
+
+    __MIN_PACKET_LENGTH = 17
+
+    def __init__(self, start_command, scan_duration, scan_window,
+                 scan_interval, filter_type, filter_data,
+                 op_mode=OperatingMode.API_MODE):
+        """
+        Class constructor. Instantiates a new :class:`.BluetoothGAPScanRequestPacket`
+        object with the provided parameters.
+
+        Args:
+            start_command (Integer): To start scan set to 1.
+                                     To stop scan set to 0.
+            scan_duration (Integer): Scan duration in seconds.
+                                     Value must be between 0 and 0xFFFF.
+            A value of 0 indicates the scan will run indefinitely.
+            scan_window (Integer): Scan window in microseconds.
+            Value must be between 0x9C4 and 0x270FD8F and
+            value can't be larger than the scan_interval.
+            scan_interval (Integer): Scan interval in microseconds.
+                                     Value must be between 0x9C4 and
+                                     0x270FD8F and
+                                     value can't be smaller than the
+                                     scan_window.
+            filter_type (Integer): Value of 0 disables filter.
+                                   Value of 1 enables filter looking for
+                                   Complete Local Name (0x09) and
+                                   Short Local Name (0x08) types.
+            filter_data (String or bytearray): The size of the filter_data is
+                                               from 0-22 bytes.
+            op_mode (:class:`.OperatingMode`, optional, default=`OperatingMode.API_MODE`):
+                     The mode in which the frame was captured.
+
+
+        Raises:
+            ValueError: if `start_command` is not 0 nor 1.
+            ValueError: if `scan_duration` is not between 0 and 0xFFFF.
+            ValueError: if `scan_window` is not between 0x9C4 and 0x270FD8F
+                        or larger than the scan_interval.
+            ValueError: if `scan_interval` is not between 0x9C4 and 0x270FD8F
+                        or smaller than the scan_window.
+            ValueError: if `filter_type` is not 0 nor 1.
+
+        .. seealso::
+           | :class:`.XBeeAPIPacket`
+        """
+        if start_command not in (self.START_SCAN, self.STOP_SCAN):
+            raise ValueError(f"Command must be {self.START_SCAN} or {self.STOP_SCAN}")
+
+        if scan_duration is None:
+            raise ValueError("The scan duration cannot be None")
+
+        if not (self.INDEFINITE_SCAN_DURATION <= scan_duration <= self.__SCAN_DURATION_MAXIMUM):
+            raise ValueError(f"scan_duration must be between {self.__SCAN_DURATION_INDEFINITELY} and {self.__SCAN_DURATION_MAXIMUM}")
+
+        if scan_window is None:
+            raise ValueError("The scan window cannot be None")
+
+        if not (self.__SCAN_WINDOW_MINIMUM <= scan_window <= self.__SCAN_WINDOW_MAXIMUM):
+            raise ValueError(f"scan_window must be between {self.__SCAN_WINDOW_MINIMUM} and {self.__SCAN_WINDOW_MAXIMUM}")
+
+        if scan_interval is None:
+            raise ValueError("The scan interval cannot be None")
+
+        if not (self.__SCAN_INTERVAL_MINIMUM <= scan_interval <= self.__SCAN_INTERVAL_MAXIMUM):
+            raise ValueError(f"scan_interval must be between {self.__SCAN_INTERVAL_MINIMUM} and {self.__SCAN_INTERVAL_MAXIMUM}")
+
+        if scan_interval < scan_window:
+            raise ValueError("scan_interval can't be smaller than the scan_window")
+
+        if filter_type not in (self.__SCAN_FILTER_DISABLED, self.__SCAN_FILTER_DISABLED):
+            raise ValueError(f"filter_type must be {self.__SCAN_FILTER_DISABLED} or {self.__SCAN_FILTER_DISABLED}")
+
+        if filter_data and len(filter_data) > self.__SCAN_CUSTOM_FILTER_MAXIMUM_LENGTH:
+            raise ValueError(f"The length of the custom filter must be from 0-{self.__SCAN_CUSTOM_FILTER_MAXIMUM_LENGTH}")
+
+        super().__init__(ApiFrameType.BLUETOOTH_GAP_SCAN_REQUEST,
+                         op_mode=op_mode)
+
+        self.__start_command = start_command
+        self.__scan_duration = scan_duration
+        self.__scan_window = scan_window
+        self.__scan_interval = scan_interval
+        self.__filter_type = filter_type
+
+        if isinstance(filter_data, str):
+            self.__filter_data = filter_data.encode('utf8', errors='ignore')
+        else:
+            self.__filter_data = filter_data
+
+    @staticmethod
+    def create_packet(raw, operating_mode):
+        """
+        Override method.
+
+        Returns:
+            :class:`.BluetoothGAPScanRequestPacket`
+
+        Raises:
+            InvalidPacketException: if the bytearray length is less than 17.
+                (start delim, length (2 bytes), frame type,
+                start_command, scan_duration (2 bytes), scan_window (4 bytes),
+                scan_interval (4 bytes), filter_type, checksum = 17 bytes)
+            InvalidPacketException: if the length field of `raw` is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of `raw` is not the
+                header byte. See :class:`.SPECIAL_BYTE`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :py:attr:`.ApiFrameType.BLUETOOTH_GAP_SCAN_REQUEST`.
+            InvalidOperatingModeException: if `operating_mode`
+                                           is not supported.
+
+        .. seealso::
+           | :meth:`.XBeePacket.create_packet`
+        """
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
+            raise InvalidOperatingModeException(op_mode=operating_mode)
+
+        XBeeAPIPacket._check_api_packet(raw, min_length=BluetoothGAPScanRequestPacket.__MIN_PACKET_LENGTH)
+
+        if raw[3] != ApiFrameType.BLUETOOTH_GAP_SCAN_REQUEST.code:
+            raise InvalidPacketException(message="This packet is not a BluetoothGAPScanRequestPacket packet")
+
+        filter_data = None
+        if len(raw) > BluetoothGAPScanRequestPacket.__MIN_PACKET_LENGTH:
+            filter_data = raw[17:-1]
+        return BluetoothGAPScanRequestPacket(
+            raw[4], utils.bytes_to_int(raw[5:7]),
+            utils.bytes_to_int(raw[7:11]),
+            utils.bytes_to_int(raw[11:15]), raw[15],
+            filter_data, op_mode=operating_mode)
+
+    def needs_id(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.needs_id`
+        """
+        return False
+
+    def _get_api_packet_spec_data(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_api_packet_spec_data`
+        """
+        ret = bytearray()
+        ret.append(self.__start_command)
+        ret += utils.int_to_bytes(self.__scan_duration, num_bytes=2)
+        ret += utils.int_to_bytes(self.__scan_window, num_bytes=4)
+        ret += utils.int_to_bytes(self.__scan_interval, num_bytes=4)
+        ret.append(self.__filter_type)
+        if self.__filter_data is not None:
+            ret += self.__filter_data
+        return ret
+
+    def _get_api_packet_spec_data_dict(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_api_packet_spec_data_dict`
+        """
+        return {DictKeys.BLE_SCAN_START: self.__start_command,
+                DictKeys.BLE_SCAN_DURATION.value: "%02X" %
+                                                  self.__scan_duration,
+                DictKeys.BLE_SCAN_WINDOW.value: "%04X" % self.__scan_window,
+                DictKeys.BLE_SCAN_INTERVAL.value: "%04X" %
+                                                  self.__scan_interval,
+                DictKeys.BLE_SCAN_FILTER_TYPE: self.__scan_interval,
+                DictKeys.PAYLOAD.value: utils.hex_to_string(self.__filter_data,
+                                                            True) if self.__filter_data is not None else None}
+
+    @property
+    def start_command(self):
+        """
+        Returns the start_command.
+
+        Returns:
+            Integer: the start_command.
+        """
+        return self.__start_command
+
+    @start_command.setter
+    def start_command(self, start_command):
+        """
+        Sets the start_command.
+
+        Args:
+             start_command (Integer): To start scan set to 1.
+                                      To stop scan set to 0.
+
+        Raises:
+            ValueError: if `start_command` is less than 0 or greater than 1.
+        """
+        if start_command < 0 or start_command > 1:
+            raise ValueError("start_command must be between 0 and 1.")
+        self.__start_command = start_command
+
+    @property
+    def scan_duration(self):
+        """
+        Returns the scan duration.
+
+        Returns:
+            Integer: the scan duration.
+        """
+        return self.__scan_duration
+
+    @scan_duration.setter
+    def scan_duration(self, scan_duration):
+        """
+        Sets the scan duration.
+
+        Args:
+             scan_duration (Integer): Scan duration in seconds.
+                                      Value must be between 0 and 0xFFFF.
+
+        Raises:
+            ValueError: if `scan_duration` is less than 0 or greater
+                        than 0xFFFF.
+        """
+        if scan_duration < 0 or scan_duration > 0xFFFF:
+            raise ValueError("scan_duration must be between 0 and 0xFFFF.")
+        self.__scan_duration = scan_duration
+
+    @property
+    def scan_window(self):
+        """
+        Returns the scan window.
+
+        Returns:
+            Integer: the scan window.
+        """
+        return self.__scan_window
+
+    @scan_window.setter
+    def scan_window(self, scan_window):
+        """
+        Sets the scan window.
+
+        Args:
+             scan_window (Integer): Scan window in microseconds.
+             Scan window in microseconds.
+             Value must be between 0x9C4 and 0x270FD8F.
+
+        Raises:
+            ValueError: if `scan_window` is less than 0x9C4 or greater
+                        than 0x270FD8F.
+        """
+        if scan_window < 0x9C4 or scan_window > 0x270FD8F:
+            raise ValueError(f"scan_window must be between {self.__SCAN_WINDOW_MINIMUM} and {self.__SCAN_WINDOW_MAXIMUM}.")
+        self.__scan_window = scan_window
+
+    @property
+    def scan_interval(self):
+        """
+        Returns the scan interval.
+
+        Returns:
+            Integer: the scan interval.
+        """
+        return self.__scan_interval
+
+    @scan_interval.setter
+    def scan_interval(self, scan_interval):
+        """
+        Sets the scan interval.
+
+        Args:
+             scan_interval (Integer): Scan window in microseconds.
+             Scan window in microseconds.
+             Value must be between 0x9C4 and 0x270FD8F.
+
+        Raises:
+            ValueError: if `scan_interval` is less than 0x9C4 or greater
+                        than 0x270FD8F.
+        """
+        if scan_interval < 0x9C4 or scan_interval > 0x270FD8F:
+            raise ValueError(f"scan_interval must be between {self.__SCAN_INTERVAL_MINIMUM} and {self.__SCAN_INTERVAL_MAXIMUM}.")
+        self.__scan_interval = scan_interval
+
+    @property
+    def filter_type(self):
+        """
+        Returns the filter_type.
+
+        Returns:
+            Integer: the filter_type.
+        """
+        return self.__filter_type
+
+    @filter_type.setter
+    def filter_type(self, filter_type):
+        """
+        Sets the filter_type.
+        Args:
+             filter_type (Integer): Value of 0 disables filter.
+                                    Value of 1 enables filter looking for
+            Complete Local Name (0x09) and Short Local Name (0x08) types.
+
+        Raises:
+            ValueError: if `filter_type` is less than 0 or greater than 1.
+        """
+        if filter_type < 0 or filter_type > 1:
+            raise ValueError("filter_type must be between 0 and 1.")
+        self.__filter_type = filter_type
+
+    @property
+    def filter_data(self):
+        """
+        Returns the filter data.
+
+        Returns:
+            Bytearray: packet's filter data.
+        """
+        return self.__filter_data
+
+    @filter_data.setter
+    def filter_data(self, filter_data):
+        """
+        Sets the filter data.
+
+        Args:
+            filter_data (String or Bytearray): the new filter data.
+        """
+        if isinstance(filter_data, str):
+            self.__filter_data = filter_data.encode('utf8', errors='ignore')
+        else:
+            self.__filter_data = filter_data
+
+
+class BluetoothGAPScanLegacyAdvertisementResponsePacket(XBeeAPIPacket):
+    """
+    This class represents a Bluetooth GAP scan legacy advertisement
+    response packet.
+    Packet is built using the parameters of the constructor or providing a
+    valid byte array.
+
+    .. seealso::
+       | :class:`.BluetoothGAPScanLegacyAdvertisementResponsePacket`
+       | :class:`.XBeeAPIPacket`
+    """
+
+    __MIN_PACKET_LENGTH = 16
+
+    def __init__(self, address, address_type, advertisement_flags, rssi,
+                 payload, op_mode=OperatingMode.API_MODE):
+        """
+        Class constructor. Instantiates a new :class:`.BluetoothGAPScanLegacyAdvertisementResponsePacket`
+        object with the provided parameters.
+
+        Args:
+            address (:class:`.XBeeBLEAddress`): The Bluetooth MAC address of
+                                                the received advertisement
+            address_type (Integer): Indicates whether the Bluetooth address
+                                    is a public address or a randomly
+                                    generated address.
+            advertisement_flags (Integer): bitfield structure where bit0
+                                           indicates whether the advertisement
+                                           is connectable.
+                                           Other bits are reserved.
+            rssi (Integer): The received signal strength of the advertisement,
+                            in dBm.
+            payload (bytearray): The actual data payload of the advertisement
+                                 which can contain various information elements,
+                                 manufacturer-specific data, or other relevant
+                                 details about the advertising device.
+            op_mode (:class:`.OperatingMode`, optional, default=`OperatingMode.API_MODE`):
+                     The mode in which the frame was captured.
+
+        Raises:
+            ValueError: if length of `payload` is less than 16 or greater
+                        than 255.
+
+        .. seealso::
+            | :class:`.XBeeBLEAddress`
+        """
+        if len(payload) > 255:
+            raise ValueError("Response payload length must be less than 256 bytes")
+
+        super().__init__(ApiFrameType.BLUETOOTH_GAP_SCAN_LEGACY_ADVERTISEMENT_RESPONSE,
+                         op_mode=op_mode)
+
+        self.__address = address
+        self.__address_type = address_type
+        self.__advertisement_flags = advertisement_flags
+        self.__rssi = rssi
+        self.__payload = payload
+
+    @staticmethod
+    def create_packet(raw, operating_mode):
+        """
+        Override method.
+
+        Returns:
+            :class:`.BluetoothGAPScanLegacyAdvertisementResponsePacket`
+
+        Raises:
+            InvalidPacketException: if the bytearray length is less than 32.
+                (start delim + length (2 bytes) + frame type
+                + address (6 bytes) + address_type + advertisement_flags
+                + rssi + reserved + payload_length + checksum = 16 bytes)
+            InvalidPacketException: if the length field of `raw` is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of `raw` is not the
+                header byte. See :class:`.SPECIAL_BYTE`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :py:attr:`.ApiFrameType.BluetoothGAPScanLegacyAdvertisementResponsePacket`.
+            InvalidPacketException: if the payload_length field does not match
+                                    the actual
+                length of the payload.
+            InvalidOperatingModeException: if `operating_mode` is not
+                                           supported.
+
+        .. seealso::
+           | :meth:`.XBeePacket.create_packet`
+        """
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
+            raise InvalidOperatingModeException(op_mode=operating_mode)
+
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=BluetoothGAPScanLegacyAdvertisementResponsePacket.__MIN_PACKET_LENGTH)
+
+        if raw[3] != ApiFrameType.BLUETOOTH_GAP_SCAN_LEGACY_ADVERTISEMENT_RESPONSE.code:
+            raise InvalidPacketException(message="This packet is not an BLUETOOTH_GAP_SCAN_LEGACY_ADVERTISEMENT_RESPONSE")
+
+        payload = None
+        if len(raw) > BluetoothGAPScanLegacyAdvertisementResponsePacket.__MIN_PACKET_LENGTH:
+            payload = raw[15:-1]
+
+        payload_length = raw[14]
+        if len(payload) != payload_length:
+            raise InvalidPacketException(
+                message="BluetoothGAPScanLegacyAdvertisementResponsePacket payload length field is %u and does not match actual length of payload that is %u".format(
+                    payload_length, len(payload)
+                ))
+
+        return BluetoothGAPScanLegacyAdvertisementResponsePacket(
+            XBeeBLEAddress(raw[4:10]), raw[10], raw[11], raw[12], payload,
+            op_mode=operating_mode)
+
+    def needs_id(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.needs_id`
+        """
+        return False
+
+    def _get_api_packet_spec_data(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_API_packet_spec_data`
+        """
+        ret = bytearray()
+        ret.append(len(self.__address.address))
+        ret.append(self.__address_type)
+        ret.append(self.__advertisement_flags)
+        ret.append(self.__rssi)
+        ret.append(0)
+        if self.__payload is not None:
+            ret.append(len(self.__payload))
+            ret += self.__payload
+        else:
+            ret.append(0)
+        return ret
+
+    def _get_api_packet_spec_data_dict(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_API_packet_spec_data_dict`
+        """
+        return {DictKeys.BLE_ADDRESS: "%s (%s)" % (self.__address.packed,
+                                                   self.__address.exploded),
+                DictKeys.BLE_ADDRESS_TYPE: self.__address_type,
+                DictKeys.BLE_ADVERTISEMENT_FLAGS: self.__advertisement_flags,
+                DictKeys.RSSI: self.__rssi,
+                DictKeys.RESERVED: 0,
+                DictKeys.PAYLOAD.value: utils.hex_to_string(self.__payload,
+                                                            True) if self.__payload is not None else None}
+
+    @property
+    def address(self):
+        """
+        Returns the Bluetooth MAC address of the received advertisement.
+
+        Returns:
+            address (:class:`.XBeeBLEAddress`): returns the Bluetooth
+                                                MAC address.
+        """
+        return self.__address
+
+    @address.setter
+    def address(self, address):
+        """
+        Sets the BLE MAC address of the received advertisement
+
+        Args:
+            address (:class:`.XBeeBLEAddress`): the 48 bit BLE MAC address.
+        """
+        if address is not None:
+            self.__address = address
+
+    @property
+    def address_type(self):
+        """
+        Returns the address type of the received advertisement.
+
+        Returns:
+            Integer: the address type.
+        """
+        return self.__address_type
+
+    @address_type.setter
+    def address_type(self, address_type):
+        """
+        Sets the address type indicating whether the Bluetooth address is a
+            public or randomly generated address.
+
+        Args:
+             address_type (Integer): address type
+        """
+        self.__address_type = address_type
+
+    @property
+    def advertisement_flags(self):
+        """
+        Returns the advertisement flags.
+
+        Returns:
+            Integer: the advertisement flags.
+        """
+        return self.__advertisement_flags
+
+    @advertisement_flags.setter
+    def advertisement_flags(self, advertisement_flags):
+        """
+        Sets the Advertisement flags type.
+        Bit 0 indicates whether the advertisement is connectable.
+
+        Args:
+             advertisement_flags (Integer): advertisement flag
+        """
+        self.__advertisement_flags = advertisement_flags
+
+    @property
+    def rssi(self):
+        """
+        Returns the RSSI of the advertisement.
+
+        Returns:
+            Integer: the RSSI.
+        """
+        return self.__rssi
+
+    @rssi.setter
+    def rssi(self, rssi):
+        """
+        Sets the RSSI of the advertisement in dBm.
+
+        Args:
+             rssi (Integer): the RSSI
+        """
+        self.__rssi = rssi
+
+    @property
+    def payload(self):
+        """
+        Returns the payload that was received.
+
+        Returns:
+            Bytearray: the payload that was received.
+        """
+        if self.__payload is None:
+            return None
+        return self.__payload.copy()
+
+    @payload.setter
+    def payload(self, payload):
+        """
+        Sets the payload that was received.
+
+        Args:
+            payload (Bytearray): the new payload that was received.
+        """
+        if payload is None:
+            self.__payload = None
+        else:
+            self.__payload = payload.copy()
+
+
+class BluetoothGAPScanExtendedAdvertisementResponsePacket(XBeeAPIPacket):
+    """
+    This class represents a Bluetooth GAP scan extended advertisement response
+    packet. Packet is built using the parameters of the constructor or
+    providing a valid byte array.
+
+    .. seealso::
+       | :class:`.BluetoothGAPScanExtendedAdvertisementResponsePacket`
+       | :class:`.XBeeAPIPacket`
+    """
+
+    __MIN_PACKET_LENGTH = 23
+
+    def __init__(self, address, address_type, advertisement_flags, rssi,
+                 advertisement_set_id, primary_phy, secondary_phy, tx_power,
+                 periodic_interval, data_completeness, payload,
+                 op_mode=OperatingMode.API_MODE):
+        """
+        Class constructor. Instantiates a new
+        :class:`.BluetoothGAPScanExtendedAdvertisementResponsePacket` object
+        with the provided parameters.
+
+        Args:
+            address (:class:`.XBeeBLEAddress`): The Bluetooth MAC address of
+                                                the received advertisement
+            address_type (Integer): Indicates whether the Bluetooth address is
+                                    a public address or a randomly
+                                    generated address.
+            advertisement_flags (Integer): bitfield structure where bit0
+                indicates whether the advertisement is connectable.
+                Other bits are reserved.
+            rssi (Integer) The received signal strength of the advertisement,
+                           in dBm.
+            advertisement_set_id (Integer): A device can broadcast multiple
+                                            advertisements at a time.
+                                            The set identifier will help
+                                            identify which advertisement
+                                            you received.
+            primary_phy (Integer): This is the preferred PHY for connecting
+                                   with this device.  Values are:
+                                   0x1 : 1M PHY
+                                   0x2 : 2M PHY
+                                   0x4 : LE Coded PHY 125k
+                                   0x8 : LE Coded PHY 500k
+                                   0xFF : Any PHY supported
+            secondary_phy (Integer): This is the secondary PHY for connecting
+                                     with this device.
+                                     This has the same values as primary_phy.
+            tx_power (Integer): Transmission power of received advertisement.
+                                This is a signed value.
+            periodic_interval (Integer): Interval for periodic advertising.
+                                         0 indicates no periodic advertising.
+                                         Interval value is in increments of 1.25 ms.
+            data_completeness (Integer): Values are
+                                         0x0 indicates all data of the advertisement has been reported.
+                                         0x1 : Data is incomplete, but more data will follow.
+                                         0x2 : Data is incomplete, but no more data is following.
+                                         Data has be truncated.
+            payload (bytearray): The actual data payload of the advertisement
+                                 which can contain various information elements,
+                                 manufacturer-specific data, or other relevant details
+                                 about the advertising device.
+            op_mode (:class:`.OperatingMode`, optional, default=`OperatingMode.API_MODE`):
+                     The mode in which the frame was captured.
+
+        Raises:
+            ValueError: if length of `payload` is less than 22 or
+                        greater than 255.
+        """
+
+        if len(payload) > 255:
+            raise ValueError("Response payload length must be less than 256 bytes")
+
+        super().__init__(ApiFrameType.BLUETOOTH_GAP_SCAN_EXTENDED_ADVERTISEMENT_RESPONSE,
+                         op_mode=op_mode)
+
+        self.__address = address
+        self.__address_type = address_type
+        self.__advertisement_flags = advertisement_flags
+        self.__rssi = rssi
+        self.__advertisement_set_id = advertisement_set_id
+        self.__primary_phy = primary_phy
+        self.__secondary_phy = secondary_phy
+        self.__tx_power = tx_power
+        self.__periodic_interval = periodic_interval
+        self.__data_completeness = data_completeness
+        self.__payload = payload
+
+    @staticmethod
+    def create_packet(raw, operating_mode):
+        """
+        Override method.
+
+        Returns:
+            :class:`.BluetoothGAPScanExtendedAdvertisementResponsePacket`
+
+        Raises:
+            InvalidPacketException: if the bytearray length is less than 45.
+                (start delim + length (2 bytes) + frame type
+                + address (6 bytes) + address_type + advertisement_flags
+                + rssi + reserved + advertisement_set_id + primary_phy
+                + secondary_phy + tx_power + periodic_interval (2 bytes)
+                + data_completeness + payload_length + checksum = 23 bytes)
+            InvalidPacketException: if the length field of `raw` is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of `raw` is not the
+                header byte. See :class:`.SPECIAL_BYTE`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :py:attr:`.ApiFrameType.BluetoothGAPScanExtendedAdvertisementResponsePacket`.
+            InvalidOperatingModeException: if `operating_mode` is not
+                                           supported.
+
+        .. seealso::
+           | :meth:`.XBeePacket.create_packet`
+        """
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
+            raise InvalidOperatingModeException(op_mode=operating_mode)
+
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=BluetoothGAPScanExtendedAdvertisementResponsePacket.__MIN_PACKET_LENGTH)
+
+        if raw[3] != ApiFrameType.BLUETOOTH_GAP_SCAN_EXTENDED_ADVERTISEMENT_RESPONSE.code:
+            raise InvalidPacketException(message="This packet is not an BLUETOOTH_GAP_SCAN_EXTENDED_ADVERTISEMENT_RESPONSE")
+
+        payload = None
+        if len(raw) > BluetoothGAPScanExtendedAdvertisementResponsePacket.__MIN_PACKET_LENGTH:
+            payload = raw[22:-1]
+
+        payload_length = raw[21]
+        if len(payload) != payload_length:
+            raise InvalidPacketException(
+                message="BluetoothGAPScanExtendedAdvertisementResponsePacket payload length field is %u and does not match actual length of payload that is %u".format(
+                    payload_length, len(payload)
+                ))
+
+        return BluetoothGAPScanExtendedAdvertisementResponsePacket(
+            XBeeBLEAddress(raw[4:10]), raw[10], raw[11], raw[12], raw[14],
+            raw[15], raw[16], raw[17], raw[18:19], raw[20],
+            payload, op_mode=operating_mode)
+
+    def needs_id(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.needs_id`
+        """
+        return False
+
+    def _get_api_packet_spec_data(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_API_packet_spec_data`
+        """
+        ret = bytearray()
+        ret.append(len(self.__address.address))
+        ret.append(self.__address_type)
+        ret.append(self.__advertisement_flags)
+        ret.append(self.__rssi)
+        ret.append(self.__advertisement_set_id)
+        ret.append(self.__primary_phy)
+        ret.append(self.__secondary_phy)
+        ret.append(self.__tx_power)
+        ret += self.__periodic_interval
+        ret.append(self.__data_completeness)
+        ret.append(0)
+        if self.__payload is not None:
+            ret.append(len(self.__payload))
+            ret += self.__payload
+        else:
+            ret.append(0)
+        return ret
+
+    def _get_api_packet_spec_data_dict(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_API_packet_spec_data_dict`
+
+        """
+        return {DictKeys.BLE_ADDRESS: "%s (%s)" % (self.__address.packed,
+                                                   self.__address.exploded),
+                DictKeys.BLE_ADDRESS_TYPE: self.__address_type,
+                DictKeys.BLE_ADVERTISEMENT_FLAGS: self.__advertisement_flags,
+                DictKeys.RSSI: self.__rssi,
+                DictKeys.RESERVED: 0,
+                DictKeys.ADVERTISEMENT_SET_ID: self.__advertisement_set_id,
+                DictKeys.PRIMARY_PHY: self.__primary_phy,
+                DictKeys.SECONDARY_PHY: self.__secondary_phy,
+                DictKeys.TX_POWER: self.__tx_power,
+                DictKeys.PERIODIC_INTERVAL: self.__periodic_interval,
+                DictKeys.DATA_COMPLETENESS: self.__data_completeness,
+                DictKeys.PAYLOAD.value: utils.hex_to_string(self.__payload,
+                                                            True) if self.__payload is not None else None}
+
+    @property
+    def address(self):
+        """
+        Returns the Bluetooth MAC address of the received advertisement.
+
+        Returns:
+            address (:class:`.XBeeBLEAddress`): returns the Bluetooth
+                                                MAC address.
+        """
+        return self.__address
+
+    @address.setter
+    def address(self, address):
+        """
+        Sets the BLE MAC address of the received advertisement
+
+        Args:
+            address (byt:class:`.XBeeBLEAddress`): the 48 bit BLE MAC address.
+        """
+        self.__address = address
+
+    @property
+    def address_type(self):
+        """
+        Returns the address type
+
+        Returns:
+            Integer: the address type.
+        """
+        return self.__address_type
+
+    @address_type.setter
+    def address_type(self, address_type):
+        """
+        Sets the address type indicating whether the Bluetooth address is a
+        public or randomly generated address.
+
+        Args:
+             address_type (Integer): address type
+        """
+        self.__address_type = address_type
+
+    @property
+    def advertisement_flags(self):
+        """
+        Returns the Advertisement flags
+
+        Returns:
+            Integer: the advertisement flags.
+        """
+        return self.__advertisement_flags
+
+    @advertisement_flags.setter
+    def advertisement_flags(self, advertisement_flags):
+        """
+        Sets the Advertisement flags type.
+        Bit 0 indicates whether the advertisement is connectable.
+
+        Args:
+             advertisement_flags (Integer): advertisement flag
+        """
+        self.__advertisement_flags = advertisement_flags
+
+    @property
+    def rssi(self):
+        """
+        Returns the RSSI of the advertisement.
+
+        Returns:
+            Integer: the RSSI.
+        """
+        return self.__rssi
+
+    @rssi.setter
+    def rssi(self, rssi):
+        """
+        Sets the RSSI of the advertisement in dBm.
+
+        Args:
+             rssi (Integer): the RSSI
+        """
+        self.__rssi = rssi
+
+    @property
+    def advertisement_set_id(self):
+        """
+        Returns the advertisement set identifier used to help identify which
+        advertisement you received.
+
+        Returns:
+            Integer: the advertisement set identifier.
+        """
+        return self.__advertisement_set_id
+
+    @advertisement_set_id.setter
+    def advertisement_set_id(self, advertisement_set_id):
+        """
+        Sets the advertisement set identifier.
+
+        Args:
+             advertisement_set_id (Integer):
+        """
+        self.__advertisement_set_id = advertisement_set_id
+
+    @property
+    def primary_phy(self):
+        """
+        Returns the preferred PHY for connecting this device.
+
+        Returns:
+            Integer: the primary PHY
+        """
+        return self.__primary_phy
+
+    @primary_phy.setter
+    def primary_phy(self, primary_phy):
+        """
+        Sets the preferred PHY for connecting this device.
+
+        Args:
+             primary_phy (Integer): primary PHY
+        """
+        self.__primary_phy = primary_phy
+
+    @property
+    def secondary_phy(self):
+        """
+        Returns the secondary PHY for connecting this device.
+
+        Returns:
+            Integer: the secondary PHY.
+        """
+        return self.__secondary_phy
+
+    @secondary_phy.setter
+    def secondary_phy(self, secondary_phy):
+        """
+        Sets the secondary PHY for connecting this device.
+
+        Args:
+             secondary_phy (Integer): secondary PHY
+        """
+        self.__secondary_phy = secondary_phy
+
+    @property
+    def tx_power(self):
+        """
+        Returns the transmission power of received advertisement.
+        This is a signed value.
+
+        Returns:
+            Integer: transmission power.
+        """
+        return self.__tx_power
+
+    @tx_power.setter
+    def tx_power(self, tx_power):
+        """
+        Sets the transmission power of received advertisement.
+
+        Args:
+             tx_power (Integer): transmission power.
+        """
+        self.__tx_power = tx_power
+
+    @property
+    def periodic_interval(self):
+        """
+        Returns the interval for periodic advertising.
+        0 indicates no periodic advertising.
+
+        Returns:
+            Integer: periodic interval.
+        """
+        return int.from_bytes(self.__periodic_interval, "big")
+
+    @periodic_interval.setter
+    def periodic_interval(self, periodic_interval):
+        """
+        Sets the Interval for periodic advertising.
+
+        Args:
+             periodic_interval (Integer): periodic interval.
+        """
+        self.__periodic_interval = periodic_interval
+
+    @property
+    def data_completeness(self):
+        """
+        Returns the data completeness field.
+
+        Returns:
+            Integer: data completeness field.
+        """
+        return self.__data_completeness
+
+    @data_completeness.setter
+    def data_completeness(self, data_completeness):
+        """
+        Sets the data completeness field.
+
+        Args:
+             data_completeness (Integer): data completeness.
+        """
+        self.__data_completeness = data_completeness
+
+    @property
+    def payload(self):
+        """
+        Returns the payload that was received.
+
+        Returns:
+            Bytearray: the payload that was received.
+        """
+        if self.__payload is None:
+            return None
+        return self.__payload.copy()
+
+    @payload.setter
+    def payload(self, payload):
+        """
+        Sets the payload that was received.
+
+        Args:
+            payload (Bytearray): the new payload that was received.
+        """
+        if payload is None:
+            self.__payload = None
+        else:
+            self.__payload = payload.copy()
+
+
+class BluetoothGAPScanStatusPacket(XBeeAPIPacket):
+    """
+    This class represents a Bluetooth GAP scan status packet. Packet is built
+    using the parameters of the constructor or providing a valid byte array.
+
+    .. seealso::
+       | :class:`.BluetoothGAPScanStatusPacket`
+       | :class:`.XBeeAPIPacket`
+    """
+
+    __MIN_PACKET_LENGTH = 6
+
+    def __init__(self, scan_status, op_mode=OperatingMode.API_MODE):
+        """
+        Class constructor. Instantiates a new
+        :class:`.BluetoothGAPScanStatusPacket` object with the provided parameters.
+
+        Args:
+            scan_status (Integer): Reflects the status of the
+                        Bluetooth scanner.  Values are:
+                        0x00: Scanner has successfully started.
+                        0x01: Scanner is currently running.
+                        0x02: Scanner has successfully stopped.
+                        0x03: Scanner was unable to start or stop.
+                        0x04: Invalid parameters.
+
+           op_mode (:class:`.OperatingMode`, optional, default=`OperatingMode.API_MODE`):
+                The mode in which the frame was captured.
+        """
+
+        super().__init__(ApiFrameType.BLUETOOTH_GAP_SCAN_STATUS,
+                         op_mode=op_mode)
+
+        self.__scan_status = scan_status
+
+    @staticmethod
+    def create_packet(raw, operating_mode):
+        """
+        Override method.
+
+        Returns:
+            :class:`.BluetoothGAPScanStatusPacket`
+
+        Raises:
+            InvalidPacketException: if the bytearray length is not 6.
+                (start delim + length (2 bytes) + frame type
+                + scan_status + checksum = 6 bytes)
+            InvalidPacketException: if the length field of `raw` is different
+                from its real length. (length field: bytes 2 and 3)
+            InvalidPacketException: if the first byte of `raw` is not the
+                header byte. See :class:`.SPECIAL_BYTE`.
+            InvalidPacketException: if the calculated checksum is different
+                from the checksum field value (last byte).
+            InvalidPacketException: if the frame type is different from
+                :py:attr:`.ApiFrameType.BluetoothGAPScanLegacyAdvertisementResponsePacket`.
+            InvalidOperatingModeException: if `operating_mode`
+                                           is not supported.
+
+        .. seealso::
+           | :meth:`.XBeePacket.create_packet`
+        """
+        if operating_mode not in (OperatingMode.ESCAPED_API_MODE,
+                                  OperatingMode.API_MODE):
+            raise InvalidOperatingModeException(op_mode=operating_mode)
+
+        XBeeAPIPacket._check_api_packet(
+            raw, min_length=BluetoothGAPScanStatusPacket.__MIN_PACKET_LENGTH)
+
+        if raw[3] != ApiFrameType.BLUETOOTH_GAP_SCAN_STATUS.code:
+            raise InvalidPacketException(
+                      message="This packet is not an BLUETOOTH_GAP_SCAN_STATUS"
+                      )
+
+        return BluetoothGAPScanStatusPacket(
+            raw[4], op_mode=operating_mode)
+
+    def needs_id(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket.needs_id`
+        """
+        return False
+
+    def _get_api_packet_spec_data(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_API_packet_spec_data`
+        """
+        ret = bytearray()
+        ret.append(self.__scan_status)
+        ret.append(0)
+        return ret
+
+    def _get_api_packet_spec_data_dict(self):
+        """
+        Override method.
+
+        .. seealso::
+           | :meth:`.XBeeAPIPacket._get_API_packet_spec_data_dict`
+        """
+        return {DictKeys.SCAN_STATUS: self.__scan_status}
+
+    @property
+    def scan_status(self):
+        """
+        Returns the scan status of the Bluetooth scanner.
+
+        Returns:
+            Integer: scan status
+        """
+        return self.__scan_status
+
+    @scan_status.setter
+    def scan_status(self, scan_status):
+        """
+        Sets the scan status.
+
+        Args:
+            scan_status: (Integer) scan status
+        """
+        self.__scan_status = scan_status

--- a/digi/xbee/packets/factory.py
+++ b/digi/xbee/packets/factory.py
@@ -123,6 +123,8 @@ from digi.xbee.packets.wifi import RemoteATCommandWifiPacket, \
     RemoteATCommandResponseWifiPacket, IODataSampleRxIndicatorWifiPacket
 from digi.xbee.packets.zigbee import RegisterJoiningDevicePacket,\
     RegisterDeviceStatusPacket, RouteRecordIndicatorPacket, OTAFirmwareUpdateStatusPacket
+from digi.xbee.packets.bluetooth import BluetoothGAPScanLegacyAdvertisementResponsePacket, \
+    BluetoothGAPScanExtendedAdvertisementResponsePacket, BluetoothGAPScanStatusPacket
 
 
 def build_frame(packet_bytearray, operating_mode=OperatingMode.API_MODE):
@@ -318,5 +320,17 @@ def build_frame(packet_bytearray, operating_mode=OperatingMode.API_MODE):
 
     if frame_type == ApiFrameType.OTA_FIRMWARE_UPDATE_STATUS:
         return OTAFirmwareUpdateStatusPacket.create_packet(packet_bytearray, operating_mode)
+
+    if frame_type == ApiFrameType.BLUETOOTH_GAP_SCAN_LEGACY_ADVERTISEMENT_RESPONSE:
+        return BluetoothGAPScanLegacyAdvertisementResponsePacket.create_packet(
+                   packet_bytearray, operating_mode)
+
+    if frame_type == ApiFrameType.BLUETOOTH_GAP_SCAN_EXTENDED_ADVERTISEMENT_RESPONSE:
+        return BluetoothGAPScanExtendedAdvertisementResponsePacket.create_packet(
+                   packet_bytearray, operating_mode)
+
+    if frame_type == ApiFrameType.BLUETOOTH_GAP_SCAN_STATUS:
+        return BluetoothGAPScanStatusPacket.create_packet(packet_bytearray,
+                                                          operating_mode)
 
     return UnknownXBeePacket.create_packet(packet_bytearray, operating_mode=operating_mode)

--- a/digi/xbee/recovery.py
+++ b/digi/xbee/recovery.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023, Digi International Inc.
+# Copyright 2019-2024, Digi International Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -33,6 +33,8 @@ SUPPORTED_HARDWARE_VERSIONS = (HardwareVersion.XBEE3.code,
                                HardwareVersion.XBEE3_TH.code,
                                HardwareVersion.XBEE3_RR.code,
                                HardwareVersion.XBEE3_RR_TH.code,
+                               HardwareVersion.XBEE_BLU.code,
+                               HardwareVersion.XBEE_BLU_TH.code,
                                HardwareVersion.XBEE3_DM_LR.code,
                                HardwareVersion.XBEE3_DM_LR_868.code,
                                HardwareVersion.XBEE_XR_900_TH.code,

--- a/doc/api/digi.xbee.packets.bluetooth.rst
+++ b/doc/api/digi.xbee.packets.bluetooth.rst
@@ -1,0 +1,7 @@
+digi\.xbee\.packets\.bluetooth module
+=====================================
+
+.. automodule:: digi.xbee.packets.bluetooth
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/doc/api/digi.xbee.packets.rst
+++ b/doc/api/digi.xbee.packets.rst
@@ -13,6 +13,7 @@ Submodules
 
    digi.xbee.packets.aft
    digi.xbee.packets.base
+   digi.xbee.packets.bluetooth
    digi.xbee.packets.cellular
    digi.xbee.packets.common
    digi.xbee.packets.devicecloud

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -332,6 +332,19 @@ You can find the example at the following path:
    :ref:`communicateSendBluetoothData`.
 
 
+Generic Access Profile (GAP) Scan (BLU Devices)
+```````````````````````````````````````````````
+
+The 2 sample applications show how to issue a BLE GAP scan request,
+and display its results.
+
+You can find the first example at the following path:
+**examples/communication/bluetooth/GapScanExample**
+
+You can find the second example at the following path:
+**examples/communication/bluetooth/GapScanCursesDemo**
+
+
 Send MicroPython Data
 `````````````````````
 

--- a/doc/getting_started_with_xbee_python_library.rst
+++ b/doc/getting_started_with_xbee_python_library.rst
@@ -136,6 +136,13 @@ operate in the same network.
    started guide differs from other protocols. The cellular protocol sends and
    reads data from an echo server.
 
+.. note::
+   If you are getting started with the BLU, you only need to configure one
+   device. For the BLE protocol, the XBee application demonstrated in the
+   getting started guide differs from other protocols, and will show
+   how to receive Generic Access Profile (GAP) broadcasts from other
+   BLE devices.
+
 Use XCTU to configure the devices. Plug the devices into the XBee adapters and
 connect them to your computer’s USB or serial ports.
 
@@ -155,6 +162,7 @@ Repeat these steps to configure your XBee devices using XCTU.
 * :ref:`gsgConfigDPdevices`
 * :ref:`gsgConfigCellulardevices`
 * :ref:`gsgConfigWiFidevices`
+* :ref:`gsgConfigBludevices`
 
 
 .. _gsgConfig802devices:
@@ -324,6 +332,20 @@ Wi-Fi devices
    verifying it has a value different than **0.0.0.0**.
 
 
+.. _gsgConfigBludevices:
+
+BLU devices
+`````````````````
+
+#. Click **Load default firmware settings** in the **Radio Configuration**
+   toolbar to load the default values for the device firmware.
+#. Ensure the API mode (API1 or API2) is enabled. To do so, the **AP**
+   parameter value must be **1** (API mode without escapes) or **2** (API mode
+   with escapes).
+#. Click **Write radio settings** in the **Radio Configuration** toolbar to
+   apply the new values to the module.
+
+
 .. _gsgRunApp:
 
 Run your first XBee Python application
@@ -341,6 +363,7 @@ the corresponding steps depending on the protocol of your XBee devices.
 * :ref:`gsgAppZBDMDP802`
 * :ref:`gsgAppWiFi`
 * :ref:`gsgAppCellular`
+* :ref:`gsgAppBlu`
 
 
 .. _gsgAppZBDMDP802:
@@ -562,4 +585,69 @@ execute it:
 
       .. code::
 
+        > device.close()
+
+
+.. _gsgAppBlu:
+
+BLU devices
+````````````````
+
+BLU devices are stand alone devices, so there is no network
+of remote devices to communicate with them. For the BLE
+protocol, the application demonstrated in this guide differs from other
+protocols.
+
+The application will issue a GAP Scan request, and display the return:
+
+#. Open the Python interpreter and write the application commands.
+
+   #. Import the ``BluDevice`` class by executing the following command:
+
+      .. code::
+
+        > from digi.xbee.devices import BluDevice
+
+   #. Instantiate a Blu XBee device:
+
+      .. code::
+
+        > device = BluDevice("COM1", 9600)
+
+      .. note::
+         Remember to replace the COM port with the one your *sender* XBee device
+         is connected to. In UNIX-based systems, the port usually starts with
+         ``/dev/tty``.
+
+   #. Open the connection with the device:
+
+      .. code::
+
+        > ble_manager = device.get_ble_manager()
+        > device.open()
+
+   #. Create a callback function for live GAP scan results
+
+      .. code::
+
+        > def scan_callback(data):
+        >     print(data.to_dict())
+
+   #. Tell the BLE manager to send the live GAP scan results to that callback
+
+      .. code::
+
+        > ble_manager.add_ble_gap_advertisement_received_callback(scan_callback)
+
+   #. Tell the BLE manager to start scanning for 30 seconds
+
+      .. code::
+
+        > ble_manager.start_ble_gap_scan(30, 10000, 10000, False, "")
+
+   #. Remove the callback, and close the connection with the device:
+
+      .. code::
+
+        > ble_manager.del_ble_gap_advertisement_received_callback(scan_callback)
         > device.close()

--- a/doc/user_doc/working_with_xbee_classes.rst
+++ b/doc/user_doc/working_with_xbee_classes.rst
@@ -4,7 +4,7 @@ Work with XBee classes
 When working with the XBee Python Library, start with an XBee object that
 represents a physical module. A physical XBee is the combination of hardware and
 firmware. Depending on that combination, the device runs a specific wireless
-communication protocol such as Zigbee, 802.15.4, DigiMesh, Wi-Fi, or Cellular.
+communication protocol such as Zigbee, 802.15.4, DigiMesh, BLE, Wi-Fi, or Cellular.
 An ``XBeeDevice`` class represents the XBee module in the API.
 
 These protocols share some features and settings, but there are some differences
@@ -20,6 +20,7 @@ The XBee Python Library supports one XBee class per protocol, as follows:
 * XBee 802.15.4 (``Raw802Device``)
 * XBee DigiMesh (``DigiMeshDevice``)
 * XBee Point-to-multipoint (``DigiPointDevice``)
+* XBee BLU (``BluDevice``)
 * XBee IP devices (This is a non-instantiable class)
 
   * XBee Cellular (``CellularDevice``)
@@ -70,6 +71,8 @@ local device are listed in the following table:
 | DigiMeshDevice  | DigiMesh protocol                    |
 +-----------------+--------------------------------------+
 | DigiPointDevice | Point-to-multipoint protocol         |
++-----------------+--------------------------------------+
+| BluDevice       | BLE protocol                         |
 +-----------------+--------------------------------------+
 | CellularDevice  | Cellular protocol                    |
 +-----------------+--------------------------------------+
@@ -132,7 +135,7 @@ table lists the remote XBee classes:
 
 
 .. note::
-  XBee Cellular and Wi-Fi protocols do not support remote devices.
+  XBee Cellular, Wi-Fi and BLE protocols do not support remote devices.
 
 To instantiate a remote XBee object, provide the following parameters:
 

--- a/examples/communication/bluetooth/GapScanCursesDemo/GapScanCursesDemo.py
+++ b/examples/communication/bluetooth/GapScanCursesDemo/GapScanCursesDemo.py
@@ -1,0 +1,183 @@
+# Copyright 2024, Digi International Inc.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import copy
+import curses
+from digi.xbee.devices import BluDevice
+from digi.xbee.models.message import (
+    BLEGAPScanLegacyAdvertisementMessage,
+    BLEGAPScanExtendedAdvertisementMessage
+)
+
+# TODO: Replace with the serial port where your local module is connected to.
+PORT = "COM1"
+# TODO: Replace with the baud rate of your local module.
+BAUD_RATE = 9600
+
+
+class GapScanCursesDemo:
+    """
+    BLE GAP Scan Demo using the python curses module
+    """
+
+    # Various screen offsets to draw on the screen
+    _HEADER_ROW_OFFSET = 0
+    _DATA_ROW_OFFSET = 2
+    _NAME_COL_OFFSET = 0
+    _MAC_COL_OFFSET = 26
+    _RSSI_COL_OFFSET = 48
+    _CONNECTABLE_COL_OFFSET = 58
+    _SEEN_COL_OFFSET = 74
+
+    def __init__(self, ble_manager=None):
+        """
+        Class constructor for the GapScanCursesDemo
+        """
+        self._ble_manager = ble_manager
+        self._list = []
+        self._stdscr = None
+
+    def run(self):
+        """
+        Runs the BLE GAP scan demo
+        """
+        curses.wrapper(self._main_loop)
+
+    def _add_advertisement_to_list(self, new_item):
+        # Attempt to find the device in current list, if it exists
+        found = next((item for item in self._list if item['Address'] == new_item['Address']), None)
+        if found:
+            # Found it.  Update data and increase counter
+            found['Name'] = new_item['Name']
+            found['RSSI'] = new_item['RSSI']
+            found['Connectable'] = new_item['Connectable']
+            found['Count'] += 1
+        else:
+            # New device.  Add it to our current list
+            new_item["Count"] = 1
+            self._list.append(new_item)
+
+    def _scan_callback(self, data):
+        """
+        BLE GAP Scan Callback
+        """
+        if isinstance(
+            data,
+            (BLEGAPScanLegacyAdvertisementMessage, BLEGAPScanExtendedAdvertisementMessage)
+        ):
+            new_item = copy.deepcopy(data.to_dict())
+            self._add_advertisement_to_list(new_item)
+
+            count = 0
+            for item in self._list:
+                name = item['Name'] if item['Name'] else "N/A"
+                # Clear name area, and then write the name
+                self._stdscr.addstr(self._DATA_ROW_OFFSET + count,
+                                    self._NAME_COL_OFFSET, ' ' * 22)
+                self._stdscr.addstr(self._DATA_ROW_OFFSET + count,
+                                    self._NAME_COL_OFFSET, name)
+                # Add rest of the data points
+                addr = ':'.join(item['Address'][i:i+2] for i in range(0, 12, 2))
+                self._stdscr.addstr(self._DATA_ROW_OFFSET + count,
+                                    self._MAC_COL_OFFSET, addr)
+                self._stdscr.addstr(self._DATA_ROW_OFFSET + count,
+                                    self._RSSI_COL_OFFSET - 1,
+                                    str(int(item['RSSI'])) + ' dBm')
+                self._stdscr.addstr(self._DATA_ROW_OFFSET + count,
+                                    self._CONNECTABLE_COL_OFFSET,
+                                    str(item['Connectable']))
+                self._stdscr.addstr(self._DATA_ROW_OFFSET + count,
+                                    self._SEEN_COL_OFFSET, str(item['Count']))
+                count += 1
+
+            # Finally, refresh the screen
+            self._stdscr.refresh()
+
+    def _setup_screen(self):
+        """
+        Set up the initial screen
+        """
+
+        # Start colors in curses
+        curses.use_default_colors()
+        curses.start_color()
+        curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_BLACK)
+
+        # Clear and set the bacoground screen for a blank canvas
+        self._stdscr.clear()
+        self._stdscr.bkgd(' ', curses.color_pair(1))
+
+        # Hide the cursor
+        curses.curs_set(0)
+
+        # Set up our titles at the top of the screen
+        self._stdscr.addstr(self._HEADER_ROW_OFFSET,
+                            self._NAME_COL_OFFSET, "Name")
+        self._stdscr.addstr(self._HEADER_ROW_OFFSET,
+                            self._MAC_COL_OFFSET, "MAC Address")
+        self._stdscr.addstr(self._HEADER_ROW_OFFSET,
+                            self._RSSI_COL_OFFSET, "RSSI")
+        self._stdscr.addstr(self._HEADER_ROW_OFFSET,
+                            self._CONNECTABLE_COL_OFFSET, "Connectable")
+        self._stdscr.addstr(self._HEADER_ROW_OFFSET,
+                            self._SEEN_COL_OFFSET, "Seen")
+
+        # Refresh once more
+        self._stdscr.refresh()
+
+    def _main_loop(self, stdscr):
+        """
+        The GapScanCursesDemo's main loop
+        """
+        self._stdscr = stdscr
+
+        # Set up the basic screen
+        self._setup_screen()
+
+        # Set up callback for any results that come in
+        self._ble_manager.add_ble_gap_advertisement_received_callback(self._scan_callback)
+
+        # Start the GAP scan request
+        self._ble_manager.start_ble_gap_scan(0, 10000, 10000, False, '')
+
+        # Loop where k is the last character pressed
+        k = 0
+        while (k != ord('q')):
+            k = self._stdscr.getch()
+
+        # Out of loop, stop scan
+        self._ble_manager.stop_ble_gap_scan()
+        self._ble_manager.del_ble_gap_advertisement_received_callback(self._scan_callback)
+
+
+def main():
+    ble_manager = None
+    device = BluDevice(PORT, BAUD_RATE)
+    try:
+        device.open()
+        ble_manager = device.get_ble_manager()
+        ret = GapScanCursesDemo(ble_manager)
+        ret.run()
+    except Exception as e:
+        print(str(e))
+        exit(1)
+    finally:
+        if device.is_open():
+            if ble_manager:
+                ble_manager.close()
+            device.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/communication/bluetooth/GapScanCursesDemo/readme.txt
+++ b/examples/communication/bluetooth/GapScanCursesDemo/readme.txt
@@ -1,0 +1,80 @@
+  Introduction
+  ------------
+  This demo Python application shows how to set up a BLE GAP scan, start it,
+  receive and process the scan results coming from the scan on the XBee device.
+
+  The application registers a callback to be notified when new GAP scan data
+  coming from Bluetooth BLE is received and displays it on the screen.
+
+  NOTE: This demo is currently only supported on the XBee BLU device
+        which uses 'XBeeBLU' device class.
+
+
+  Requirements
+  ------------
+  To run this demo you will need:
+
+    * One XBee BLU module in API mode and its corresponding carrier board
+      (XBIB or equivalent).
+    * The XCTU application (available at www.digi.com/xctu).
+    * The Python 'curses' library installed.
+
+
+  Compatible protocols
+  --------------------
+    * Bluetooth/BLE
+
+
+  Demo setup
+  -------------
+    1) Plug the XBee BLU radio into the XBee adapter and connect it to your
+       computer's USB or serial port.
+
+    2) Ensure that the module is in API mode.
+       For further information on how to perform this task, read the
+       'Configuring Your XBee Modules' topic of the Getting Started guide.
+
+    3) Enable the Bluetooth interface of the XBee BLU device using XCTU.
+       For further information on how to perform this task, refer to the
+       XCTU user manual.
+
+    4) Set the port and baud rate of the XBee BLU radio in the demo file.
+       If you configured the module in the previous step with XCTU, you will
+       see the port number and baud rate in the 'Port' label of the device
+       on the left view.
+
+    5) Install the Python 'curses' library in your Python enviroment.
+       - For Linux based installations, this typically has already been done
+         for you by your Linux distribution.
+         If not, use 'pip' to install the 'curses' package.
+
+       - For Windows based installations, you will need to install the
+         'windows-curses' library using PIP.
+         For example, the following steps should work, assuming the
+         Python enviroment has been properly set up:
+
+             python.exe -m ensurepip --upgrade
+             python.exe -m pip install --upgrade pip setuptools wheel
+             python.exe -m pip install windows-curses
+
+
+  Running the demo
+  -------------------
+  Launch the application by running it:
+      python3 GapScanCursesDemo.py
+
+  The window/display will be cleared, and then a BLE GAP scan
+  will be started.
+
+  As devices are discovered by the scan, they will be displayed
+  in the window/display.
+
+  Each device will be displayed by:
+      - Short name, if the device provides it, otherwise "N/A".
+      - BLE MAC address.
+      - Current RSSI value.
+      - Whether the device is Connectable or not.
+      - Number of times they have been seen.
+        (Number of times we have seen them send a BLE packet over the air)
+         
+  To quit the application, press 'q'.

--- a/examples/communication/bluetooth/GapScanExample/GapScanExample.py
+++ b/examples/communication/bluetooth/GapScanExample/GapScanExample.py
@@ -1,0 +1,74 @@
+# Copyright 2024, Digi International Inc.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import time
+from digi.xbee.devices import BluDevice
+from digi.xbee.models.message import (
+    BLEGAPScanLegacyAdvertisementMessage,
+    BLEGAPScanExtendedAdvertisementMessage,
+)
+
+
+# TODO: Replace with the serial port where your local module is connected to.
+PORT = "COM1"
+# TODO: Replace with the baud rate of your local module.
+BAUD_RATE = 9600
+
+# Time for the BLE GAP scan to run for
+TIME_TO_SCAN = 10
+
+
+def main():
+    print(" +---------------------------------------------------+")
+    print(" | XBee Python Library Receive Bluetooth Data Sample |")
+    print(" +---------------------------------------------------+\n")
+
+    device = BluDevice(PORT, BAUD_RATE)
+
+    try:
+        ble_manager = device.get_ble_manager()
+        device.open()
+
+        def scan_callback(data):
+            """
+            BLE GAP scan Callback
+
+            This function will get called whenever
+            a new GAP scan entry has been received.
+            """
+            if isinstance(
+                data,
+                (BLEGAPScanLegacyAdvertisementMessage, BLEGAPScanExtendedAdvertisementMessage)
+            ):
+                print(data.to_dict())
+
+        ble_manager.add_ble_gap_advertisement_received_callback(scan_callback)
+
+        print("Starting BLE GAP scan...\n")
+        ble_manager.start_ble_gap_scan(TIME_TO_SCAN, 10000, 10000, False, "")
+
+        # Wait until the scan finishes.
+        while True:
+            time.sleep(1)
+            if not ble_manager.is_scan_running():
+                break
+
+    finally:
+        if device is not None and device.is_open():
+            ble_manager.del_ble_gap_advertisement_received_callback(scan_callback)
+            device.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/communication/bluetooth/GapScanExample/readme.txt
+++ b/examples/communication/bluetooth/GapScanExample/readme.txt
@@ -1,0 +1,55 @@
+  Introduction
+  ------------
+  This Python example shows how to set up a BLE GAP scan, start it,
+  receive and process the scan results and scan status coming from
+  the scan on the XBee device.
+
+  The application registers a callback to be notified when new GAP scan data
+  coming from Bluetooth BLE is received and displays it on the screen,
+  and also registers a callback to be notified when the GAP scan status
+  changes.
+
+  NOTE: This example is currently only supported on the XBee BLU device
+        which uses 'XBeeBLU' device class.
+
+
+  Requirements
+  ------------
+  To run this example you will need:
+
+    * One XBee BLU module in API mode and its corresponding carrier board
+      (XBIB or equivalent).
+    * The XCTU application (available at www.digi.com/xctu).
+
+
+  Compatible protocols
+  --------------------
+    * Bluetooth/BLE
+
+
+  Example setup
+  -------------
+    1) Plug the XBee BLU radio into the XBee adapter and connect it to your
+       computer's USB or serial port.
+
+    2) Ensure that the module is in API mode.
+       For further information on how to perform this task, read the
+       'Configuring Your XBee Modules' topic of the Getting Started guide.
+
+    3) Enable the Bluetooth interface of the XBee BLU device using XCTU.
+       For further information on how to perform this task, refer to the
+       XCTU user manual.
+
+    4) Set the port and baud rate of the XBee BLU radio in the example file.
+       If you configured the module in the previous step with XCTU, you will
+       see the port number and baud rate in the 'Port' label of the device
+       on the left view.
+
+
+  Running the example
+  -------------------
+  Launch the application by running it:
+      python3 GapScanExample.py
+
+  As devices are discovered by the scan, the scan data
+  will be displayed.

--- a/functional_tests/Bluetooth/device_info.py
+++ b/functional_tests/Bluetooth/device_info.py
@@ -1,0 +1,57 @@
+# Copyright 2024, Digi International Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from digi.xbee.devices import BluDevice
+
+# Configure your test device port and baud rate
+PORT_LOCAL = "COM1"
+BAUD_RATE_LOCAL = 9600
+
+
+def main():
+    print(" +---------------------------+")
+    print(" | XBee BLU device info test |")
+    print(" +---------------------------+\n")
+
+    local = BluDevice(PORT_LOCAL, BAUD_RATE_LOCAL)
+
+    try:
+        local.open()
+        local.read_device_info()
+
+        print("Firmware Version:", local.get_firmware_version().hex())
+
+        hv = local.get_hardware_version()
+        print("Hardware Version: %s (0x%02X)" % (hv, hv.code))
+
+        print("Bluetooth MAC:", local.ble_addr())
+        print(
+            "Bluetooth Identifier:",
+            ascii(
+                local.get_parameter("BI").decode(
+                    "ascii", errors="backslashreplace"
+                )
+            )
+        )
+
+        print("Serial Number:", local.get_64bit_addr())
+        print("Node ID:", ascii(local.get_node_id()))
+
+    finally:
+        if local.is_open():
+            local.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/functional_tests/Bluetooth/test_gap_scan.py
+++ b/functional_tests/Bluetooth/test_gap_scan.py
@@ -1,0 +1,416 @@
+# Copyright 2024, Digi International Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import time
+from typing import cast
+from digi.xbee.devices import BluDevice
+from digi.xbee.models.message import BLEGAPScanLegacyAdvertisementMessage, BLEGAPScanExtendedAdvertisementMessage
+from digi.xbee.models.status import BLEMACAddressType
+from digi.xbee.exception import TimeoutException
+from digi.xbee.models.status import BLEGAPScanStatus
+
+
+# Configure your test device port and baud rate
+PORT_LOCAL = "/dev/ttyUSB0"
+BAUD_RATE_LOCAL = "9600"
+# Configure a FILTER for testing that you only receive messages from this device
+FILTER_TEST = None
+# FILTER_TEST = 'ResMed'
+# FILTER_TEST = 'ResMed 289272'
+
+# Set to True to check and verify that legacy advertisements are properly received
+TEST_LEGACY_ADVERTISEMENTS = True
+
+# Set to True to check and verify that extended advertisements are properly received
+TEST_EXTENDED_ADVERTISEMENTS = False
+
+
+def flush_advertisements(ble_manager):
+    # Make sure scanning is off
+    ble_manager.stop_ble_gap_scan()
+    time.sleep(1)
+    print("Flushed advertisements")
+
+
+def flush_gap_status_messages(ble_manager):
+    # Make sure scanning is off
+    ble_manager.stop_ble_gap_scan()
+    time.sleep(1)
+    print("Flushed gap status messages")
+
+
+def test_gap_scan_request(ble_manager):
+    rx_msg = None
+
+    def gap_scan_callback(msg):
+        nonlocal rx_msg
+        print(f"{msg.to_dict()}")
+        rx_msg = msg
+
+    flush_advertisements(ble_manager)
+
+    print("\n\nTest GAP scan request")
+
+    print("Test scan with infinite duration")
+    ble_manager.add_ble_gap_advertisement_received_callback(gap_scan_callback)
+    print("Start scanning")
+    ble_manager.start_ble_gap_scan(0, 0x1111111, 0x1111111, False, "")
+    max_time = 60.0
+    print("Wait {} seconds for messages".format(max_time))
+    start_time = time.time()
+    while True:
+        time.sleep(0.1)
+        if ((time.time() - start_time > max_time) or (rx_msg is not None)):
+            break
+    print("Stop scanning")
+    ble_manager.stop_ble_gap_scan()
+    # Verify we got at least 1 message
+    if rx_msg is None:
+        raise RuntimeError("Failed to receive any Bluetooth advertisements")
+
+    # Test GAP scan for short duration
+    duration = 2
+    print("Test GAP scan of {} seconds".format(duration))
+    ble_manager.start_ble_gap_scan(duration, 0x2222222, 0x2222222, False, "")
+    print("Wait for messages for {} seconds".format(duration + 1))
+    time.sleep(duration + 1)
+    print("Clear messages, we don't expect to get any more")
+    rx_msg = None
+    time.sleep(2)
+    if rx_msg is not None:
+        raise RuntimeError("Got message past the duration time")
+    print("Stop scanning")
+    ble_manager.stop_ble_gap_scan()
+    ble_manager.del_ble_gap_advertisement_received_callback(gap_scan_callback)
+
+    print("Success")
+
+
+def test_gap_scan_parameters(ble_manager):
+    flush_advertisements(ble_manager)
+
+    print("\n\nTest different parameter ranges for start_ble_gap_scan")
+    duration = 0xFFFF
+    print("Test maximum duration {}".format(duration))
+    ble_manager.start_ble_gap_scan(duration, 0x1111111, 0x1111111, False, "")
+    ble_manager.stop_ble_gap_scan()
+
+    duration += 1
+    print("Test maximum duration plus 1 ({}) fails".format(duration))
+    try:
+        ble_manager.start_ble_gap_scan(duration, 0x1111111, 0x1111111, False, "")
+    except Exception:
+        pass
+    else:
+        raise RuntimeError("Failed to see exception passing in duration value of {}".format(duration))
+
+    scan_window = 0x9C4
+    print("Test scan window minimum value")
+    ble_manager.start_ble_gap_scan(0, scan_window, 0x1111111, False, "")
+    ble_manager.stop_ble_gap_scan()
+
+    scan_window -= 1
+    print("Test scan window minimum value minus 1 ({}) fails".format(scan_window))
+    try:
+        ble_manager.start_ble_gap_scan(0, scan_window, 0x1111111, False, "")
+    except Exception:
+        pass
+    else:
+        raise RuntimeError("Failed to see exception passing in scan window value of {}".format(scan_window))
+
+    scan_window = 0x270FD8F
+    scan_interval = scan_window  # Must be greater or equal to scan window
+    print("Test scan window max value of ({})".format(scan_window))
+    ble_manager.start_ble_gap_scan(0, scan_window, scan_interval, False, "")
+    ble_manager.stop_ble_gap_scan()
+
+    scan_window += 1
+    print("Test scan window max value plus 1 ({}) fails".format(scan_window))
+    try:
+        ble_manager.start_ble_gap_scan(0, scan_window, scan_interval, False, "")
+    except Exception:
+        pass
+    else:
+        raise RuntimeError("Failed to see exception passing in scan window value of {}".format(scan_window))
+
+    scan_interval = 0x9C4
+    scan_window = scan_interval
+    print("Test scan interval minimum value")
+    ble_manager.start_ble_gap_scan(0, scan_window, scan_interval, False, "")
+    ble_manager.stop_ble_gap_scan()
+
+    scan_interval -= 1
+    print("Test scan interval minimum value minus 1 ({}) fails".format(scan_interval))
+    try:
+        ble_manager.start_ble_gap_scan(0, scan_window, scan_interval, False, "")
+    except Exception:
+        pass
+    else:
+        raise RuntimeError("Failed to see exception passing in scan interval value of {}".format(scan_interval))
+
+    scan_interval = 0x270FD8F
+    scan_window = 0x1111111
+    print("Test scan interval max value of ({})".format(scan_interval))
+    ble_manager.start_ble_gap_scan(0, scan_window, scan_interval, False, "")
+    ble_manager.stop_ble_gap_scan()
+
+    scan_interval += 1
+    print("Test scan interval max value plus 1 ({}) fails".format(scan_interval))
+    try:
+        ble_manager.start_ble_gap_scan(0, scan_window, scan_interval, False, "")
+    except Exception:
+        pass
+    else:
+        raise RuntimeError("Failed to see exception passing in scan interval value of {}".format(scan_interval))
+
+    print("Test scan window greater than scan interval fails")
+    scan_interval = 0x1111111
+    scan_window = scan_interval + 1
+    try:
+        ble_manager.start_ble_gap_scan(0, scan_window, scan_interval, False, "")
+    except Exception:
+        pass
+    else:
+        raise RuntimeError("Failed to see exception passing in scan window value of {} and scan interval value of {}".format(
+            scan_window, scan_interval))
+
+    print("Success")
+
+
+def test_gap_scan_filter(ble_manager):
+    global FILTER_TEST
+    rx_msg = None
+    failed = False
+
+    def gap_scan_callback(msg):
+        global FILTER_TEST
+        nonlocal rx_msg
+        nonlocal failed
+        print(f"{msg.to_dict()}")
+        name = msg.name
+        if name is None or FILTER_TEST not in name:
+            failed = True
+            raise RuntimeError("For filter test expected to get: {} but got {}".format(FILTER_TEST, name))
+        rx_msg = msg
+
+    flush_advertisements(ble_manager)
+
+    print("\n\nTest scan with filtering")
+    ble_manager.add_ble_gap_advertisement_received_callback(gap_scan_callback)
+    print("Start scanning")
+    ble_manager.start_ble_gap_scan(0, 0x1111111, 0x1111111, True, FILTER_TEST)
+    min_time = 5.0  # Test should run for at least this time
+    max_time = 60.0
+    print("Wait {} seconds for messages".format(max_time))
+    start_time = time.time()
+    while True:
+        time.sleep(0.1)
+        current_time = time.time()
+        if ((current_time - start_time > max_time) or failed):
+            break
+        if ((current_time - start_time > min_time) and (rx_msg is not None)):
+            break
+
+    print("Stop scanning")
+    ble_manager.stop_ble_gap_scan()
+    ble_manager.del_ble_gap_advertisement_received_callback(gap_scan_callback)
+    # Verify we got at least 1 message
+    if rx_msg is None:
+        raise RuntimeError("Failed to receive any Bluetooth advertisements")
+    if failed:
+        raise RuntimeError("Failed to properly filter advertisements")
+
+    print("Success")
+
+
+def test_legacy_advertisement(ble_manager):
+    rx_msg = None
+
+    def gap_scan_callback(msg):
+        nonlocal rx_msg
+        print(f"{msg.to_dict()}")
+        if isinstance(msg, BLEGAPScanLegacyAdvertisementMessage):
+            rx_msg = msg
+
+    flush_advertisements(ble_manager)
+
+    print("\n\nTest that we can receive legacy advertisement and that the advertisement message class is correct")
+    ble_manager.add_ble_gap_advertisement_received_callback(gap_scan_callback)
+    print("Start scanning")
+    ble_manager.start_ble_gap_scan(0, 0x1111111, 0x1111111, False, "")
+    max_time = 60.0
+    print("Wait {} seconds for a message".format(max_time))
+    start_time = time.time()
+    while True:
+        time.sleep(0.1)
+        if ((time.time() - start_time > max_time) or (rx_msg is not None)):
+            break
+    print("Stop scanning")
+    ble_manager.stop_ble_gap_scan()
+    ble_manager.del_ble_gap_advertisement_received_callback(gap_scan_callback)
+    # Verify we got a message
+    if rx_msg is None:
+        raise RuntimeError("Failed to receive any Bluetooth legacy advertisements")
+
+    msg = cast(BLEGAPScanLegacyAdvertisementMessage, rx_msg)
+
+    # Verify address
+    address = msg.address
+    if len(address.address) != 6:
+        raise RuntimeError("Invalid address {}".format(address.address))
+
+    # Verify address type
+    address_type = msg.address_type
+    if (address_type not in (
+            BLEMACAddressType.PUBLIC,
+            BLEMACAddressType.STATIC,
+            BLEMACAddressType.RANDOM_RESOLVABLE,
+            BLEMACAddressType.RANDOM_NONRESOLVABLE,
+            BLEMACAddressType.UNKNOWN)):
+        raise RuntimeError("Invalid address_type {}".format(address_type))
+
+    connectable = msg.connectable
+    if not isinstance(connectable, bool):
+        raise RuntimeError("Invalid connectable {}".format(connectable))
+
+    rssi = msg.rssi
+    if not isinstance(rssi, float):
+        raise TypeError("rssi is not a float, but {}".format(type(rssi)))
+    if ((rssi > 0.0) or (rssi < -255.0)):
+        raise ValueError("rssi value {} is out of range".format(rssi))
+
+    name = msg.name
+    if name is not None and not isinstance(name, str):
+        raise TypeError("name is not a string type or None, but {}".format(type(name)))
+
+
+def test_extended_advertisement(ble_manager):
+    rx_msg = None
+
+    def gap_scan_callback(msg):
+        nonlocal rx_msg
+        print(f"{msg.to_dict()}")
+        if isinstance(msg, BLEGAPScanExtendedAdvertisementMessage):
+            rx_msg = msg
+
+    flush_advertisements(ble_manager)
+
+    print("\n\nTest that we can receive extended advertisement and that the advertisement message class is correct")
+    ble_manager.add_ble_gap_advertisement_received_callback(gap_scan_callback)
+    print("Start scanning")
+    ble_manager.start_ble_gap_scan(0, 0x1111111, 0x1111111, False, "")
+    max_time = 60.0
+    print("Wait {} seconds for a message".format(max_time))
+    start_time = time.time()
+    while True:
+        time.sleep(0.1)
+        if ((time.time() - start_time > max_time) or (rx_msg is not None)):
+            break
+    print("Stop scanning")
+    ble_manager.stop_ble_gap_scan()
+    ble_manager.del_ble_gap_advertisement_received_callback(gap_scan_callback)
+    # Verify we got a message
+    if rx_msg is None:
+        raise RuntimeError("Failed to receive any Bluetooth extended advertisements")
+
+    msg = cast(BLEGAPScanExtendedAdvertisementMessage, rx_msg)
+
+    # Verify address
+    address = msg.address
+    if len(address.address) != 6:
+        raise RuntimeError("Invalid address {}".format(address.address))
+
+    # Verify address type
+    address_type = msg.address_type
+    if (address_type not in (
+            BLEMACAddressType.PUBLIC,
+            BLEMACAddressType.STATIC,
+            BLEMACAddressType.RANDOM_RESOLVABLE,
+            BLEMACAddressType.RANDOM_NONRESOLVABLE,
+            BLEMACAddressType.UNKNOWN)):
+        raise RuntimeError("Invalid address_type {}".format(address_type))
+
+    connectable = msg.connectable
+    if not isinstance(connectable, bool):
+        raise RuntimeError("Invalid connectable {}".format(connectable))
+
+    rssi = msg.rssi
+    if not isinstance(rssi, float):
+        raise TypeError("rssi is not a float, but {}".format(type(rssi)))
+    if ((rssi > 0.0) or (rssi < -255.0)):
+        raise ValueError("rssi value {} is out of range".format(rssi))
+
+    name = msg.name
+    if name is not None and not isinstance(name, str):
+        raise TypeError("name is not a string type or None, but {}".format(type(name)))
+
+    advertisement_set_id = msg.advertisement_set_id
+    if not isinstance(advertisement_set_id, int):
+        raise TypeError("advertisement_set_id is not type int, but {}".format(type(advertisement_set_id)))
+
+    primary_phy = msg.primary_phy
+    if not isinstance(primary_phy, int):
+        raise TypeError("primary_phy is not type int, but {}".format(type(primary_phy)))
+
+    secondary_phy = msg.secondary_phy
+    if not isinstance(secondary_phy, int):
+        raise TypeError("secondary_phy is not type int, but {}".format(type(secondary_phy)))
+
+    periodic_interval = msg.periodic_interval
+    if not isinstance(periodic_interval, int):
+        raise TypeError("periodic_interval is not type int, but {}".format(type(periodic_interval)))
+
+    data_completeness = msg.data_completeness
+    if not isinstance(data_completeness, int):
+        raise TypeError("data_completeness is not type int, but {}".format(type(data_completeness)))
+
+
+def test_gap_scan_status_callback(ble_manager):
+    scan_started = 0
+    scan_running = 0
+    scan_stopped = 0
+    scan_error = 0
+    scan_invalid_param = 0
+    scan_unknown = 0
+
+
+def main():
+
+    xbee = BluDevice(PORT_LOCAL, BAUD_RATE_LOCAL)
+    ble_manager = xbee.get_ble_manager()
+
+    try:
+        xbee.open()
+
+        test_gap_scan_request(ble_manager)
+
+        if FILTER_TEST is not None:
+            test_gap_scan_filter(ble_manager)
+
+        test_gap_scan_parameters(ble_manager)
+
+        if TEST_LEGACY_ADVERTISEMENTS:
+            test_legacy_advertisement(ble_manager)
+
+        if TEST_EXTENDED_ADVERTISEMENTS:
+            test_extended_advertisement(ble_manager)
+
+    finally:
+
+        if xbee.is_open():
+            xbee.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This product does not support the XBee protocol, but instead, only supports Bluetooth/BLE.

The XBee BLU currently adds extra support over the existing Bluetooth support, by adding a few new API packet/frames.

These frames are:
Bluetooth GAP Scan Request - 0x34
Bluetooth GAP Scan Legacy Advertisement Response - 0xB4 Bluetooth GAP Scan Extended Advertisement Response - 0xB7 Bluetooth GAP Scan Status - 0xB5

In addition to creating a new device type called BluDevice that supports these new calls, there have also been a couple new functional tests to verify the support, along with a new Demo/Example application that will initate a BLE GAP scan, and display all devices that are broadcasting BLE advertisements.