### PR TITLE
exposed low level serialException on usb disconnect

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2437,6 +2437,14 @@ class XBeeDevice(AbstractXBeeDevice):
         self.__route_received = RouteReceived()
         self.__stats = Statistics()
 
+    def add_error_callback(self, callback):
+        """Public method to handle serial errors (e.g., disconnections)."""
+        self._packet_listener.add_error_callback(callback)
+
+    def remove_error_callback(self, callback):
+        """Remove an error callback."""
+        self._packet_listener.remove_error_callback(callback)
+
     @classmethod
     def create_xbee_device(cls, comm_port_data):
         """

--- a/digi/xbee/serial.py
+++ b/digi/xbee/serial.py
@@ -271,6 +271,10 @@ class XBeeSerialPort(Serial, XBeeCommunicationInterface):
             return xbee_packet
         except TimeoutException:
             return None
+        
+        except SerialException as e:
+
+            raise
 
     def read_existing(self):
         """


### PR DESCRIPTION
While utilizing the library for my application, i noticed there was no way to catch the serial exception once the connected xbee radio is disconnected while my [python application ](https://github.com/n1lby73/xbeeGateway) is still running. After careful inspection to find out the underlying cause, i noticed that the serial exception was caught from the xbee library but was not exposed for user level.

with this modification the serial exception error has been exposed with the use of a callback function called `add_error_callback(callback)` through `XBeeDevice` from `digi.xbee.devices`  
